### PR TITLE
POC: Optimizations to make data generation faster (3-7x faster)

### DIFF
--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.32", features = ["derive"] }
 tpchgen = { path = "../tpchgen" }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -238,8 +238,8 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
     let filename = "orders.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = OrderGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for order in generator.iter() {
+    let mut iter = OrderGenerator::new(cli.scale_factor as f64, cli.part, cli.parts).iter();
+    while let Some(order) = iter.make_next_order() {
         writeln!(
             writer,
             "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}",
@@ -247,7 +247,7 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
             order.o_custkey,
             order.o_orderstatus,
             order.o_totalprice,
-            order.o_orderdate,
+            dates::DateUtils::to_epoch_date(order.o_orderdate),
             order.o_orderpriority,
             order.o_clerk,
             order.o_shippriority,

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -29,8 +29,8 @@ use tpchgen::generators::{
 #[command(about = "TPC-H Data Generator", long_about = None)]
 struct Cli {
     /// Scale factor to address defaults to 1.
-    #[arg(short, long, default_value_t = 1)]
-    scale_factor: i64,
+    #[arg(short, long, default_value_t = 1.0)]
+    scale_factor: f64,
 
     /// Output directory for generated files
     #[arg(short, long)]

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -215,8 +215,8 @@ fn generate_customer(cli: &Cli) -> io::Result<()> {
     let filename = "customer.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = CustomerGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for customer in generator.iter() {
+    let mut iter = CustomerGenerator::new(cli.scale_factor as f64, cli.part, cli.parts).iter();
+    while let Some(customer) = iter.make_next_customer() {
         writeln!(
             writer,
             "{}|{}|{}|{}|{}|{:.2}|{}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -137,8 +137,8 @@ fn generate_region(cli: &Cli) -> io::Result<()> {
     let filename = "region.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = RegionGenerator::new();
-    for region in generator.iter() {
+    let mut iter = RegionGenerator::new().iter();
+    while let Some(region) = iter.make_next_region() {
         writeln!(
             writer,
             "{}|{}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -177,8 +177,8 @@ fn generate_supplier(cli: &Cli) -> io::Result<()> {
     let filename = "supplier.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = SupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for supplier in generator.iter() {
+    let mut iter = SupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts).iter();
+    while let Some(supplier) = iter.make_next_supplier() {
         writeln!(
             writer,
             "{}|{}|{}|{}|{}|{:.2}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -14,32 +14,270 @@
 // The main function is the entry point for the CLI and it uses the `clap` crate
 // to parse the command line arguments and then generate the data.
 
-use clap::{command, Parser};
+// tpchgen-cli/src/main.rs
+use clap::{Parser, ValueEnum};
+use std::fs::{self, File};
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+use tpchgen::generators::{
+    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    PartSupplierGenerator, RegionGenerator, SupplierGenerator,
+};
 
-#[derive(Debug, Parser)]
-#[command(version, about = "TPCH data generation CLI with a dbgen compatible API.", long_about = None)]
-struct Args {
-    #[arg(
-        short,
-        long,
-        help = "Scale factor to use can be one of (0.01, 0.1, 1, 10, 30, 100, 300, 1000, 3000"
-    )]
-    scale: f64,
+#[derive(Parser)]
+#[command(name = "tpchgen")]
+#[command(about = "TPC-H Data Generator", long_about = None)]
+struct Cli {
+    /// Scale factor to address defaults to 1.
+    #[arg(short, long, default_value_t = 1)]
+    scale_factor: i64,
 
-    #[arg(
-        short,
-        help = "Generate data for only the specified tables (defaults to all)."
-    )]
-    tables: Vec<String>,
+    /// Output directory for generated files
+    #[arg(short, long)]
+    output_dir: PathBuf,
 
-    #[arg(short, long, help = "Output format for the data (CSV or Parquet)")]
-    format: String,
+    /// Which tables to generate (default: all)
+    #[arg(short, long)]
+    tables: Option<Vec<Table>>,
 
-    #[arg(short, long, help = "Output directory for the generated data")]
-    output: String,
+    /// Number of parts to generate (for parallel generation)
+    #[arg(short, long, default_value_t = 1)]
+    parts: i32,
+
+    /// Which part to generate (1-based, only relevant if parts > 1)
+    #[arg(long, default_value_t = 1)]
+    part: i32,
 }
 
-fn main() {
-    let args = Args::parse();
-    println!("Hello, world!");
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum Table {
+    Nation,
+    Region,
+    Part,
+    Supplier,
+    PartSupp,
+    Customer,
+    Orders,
+    LineItem,
+}
+
+fn main() -> io::Result<()> {
+    // Parse command line arguments
+    let cli = Cli::parse();
+
+    // Create output directory if it doesn't exist
+    fs::create_dir_all(&cli.output_dir)?;
+
+    // Determine which tables to generate
+    let tables: Vec<Table> = if let Some(tables) = cli.tables.as_ref() {
+        tables.clone()
+    } else {
+        vec![
+            Table::Nation,
+            Table::Region,
+            Table::Part,
+            Table::Supplier,
+            Table::PartSupp,
+            Table::Customer,
+            Table::Orders,
+            Table::LineItem,
+        ]
+    };
+
+    // Generate each table
+    for table in tables {
+        println!("Generating table: {:?}", table);
+        match table {
+            Table::Nation => generate_nation(&cli)?,
+            Table::Region => generate_region(&cli)?,
+            Table::Part => generate_part(&cli)?,
+            Table::Supplier => generate_supplier(&cli)?,
+            Table::PartSupp => generate_partsupp(&cli)?,
+            Table::Customer => generate_customer(&cli)?,
+            Table::Orders => generate_orders(&cli)?,
+            Table::LineItem => generate_lineitem(&cli)?,
+        }
+    }
+
+    println!("Generation complete!");
+    Ok(())
+}
+
+fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<Box<dyn Write>> {
+    let path = cli.output_dir.join(filename);
+    let file = File::create(path)?;
+
+    Ok(Box::new(BufWriter::new(file)))
+}
+
+fn generate_nation(cli: &Cli) -> io::Result<()> {
+    let filename = "nation.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = NationGenerator::new();
+    for nation in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{}",
+            nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_region(cli: &Cli) -> io::Result<()> {
+    let filename = "region.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = RegionGenerator::new();
+    for region in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}",
+            region.r_regionkey, region.r_name, region.r_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_part(cli: &Cli) -> io::Result<()> {
+    let filename = "part.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = PartGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for part in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}",
+            part.p_partkey,
+            part.p_name,
+            part.p_mfgr,
+            part.p_brand,
+            part.p_type,
+            part.p_size,
+            part.p_container,
+            part.p_retailprice,
+            part.p_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_supplier(cli: &Cli) -> io::Result<()> {
+    let filename = "supplier.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = SupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for supplier in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{}|{}|{:.2}|{}",
+            supplier.s_suppkey,
+            supplier.s_name,
+            supplier.s_address,
+            supplier.s_nationkey,
+            supplier.s_phone,
+            supplier.s_acctbal,
+            supplier.s_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_partsupp(cli: &Cli) -> io::Result<()> {
+    let filename = "partsupp.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = PartSupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for ps in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{:.2}|{}",
+            ps.ps_partkey, ps.ps_suppkey, ps.ps_availqty, ps.ps_supplycost, ps.ps_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_customer(cli: &Cli) -> io::Result<()> {
+    let filename = "customer.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = CustomerGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for customer in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{}|{}|{:.2}|{}|{}",
+            customer.c_custkey,
+            customer.c_name,
+            customer.c_address,
+            customer.c_nationkey,
+            customer.c_phone,
+            customer.c_acctbal,
+            customer.c_mktsegment,
+            customer.c_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_orders(cli: &Cli) -> io::Result<()> {
+    let filename = "orders.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = OrderGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for order in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}",
+            order.o_orderkey,
+            order.o_custkey,
+            order.o_orderstatus,
+            order.o_totalprice,
+            order.o_orderdate,
+            order.o_orderpriority,
+            order.o_clerk,
+            order.o_shippriority,
+            order.o_comment
+        )?;
+    }
+
+    Ok(())
+}
+
+fn generate_lineitem(cli: &Cli) -> io::Result<()> {
+    let filename = "lineitem.tbl";
+    let mut writer = new_table_writer(cli, filename)?;
+
+    let generator = LineItemGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    for item in generator.iter() {
+        writeln!(
+            writer,
+            "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}",
+            item.l_orderkey,
+            item.l_partkey,
+            item.l_suppkey,
+            item.l_linenumber,
+            item.l_quantity,
+            item.l_extendedprice,
+            item.l_discount,
+            item.l_tax,
+            item.l_returnflag,
+            item.l_linestatus,
+            item.l_shipdate,
+            item.l_commitdate,
+            item.l_receiptdate,
+            item.l_shipinstruct,
+            item.l_shipmode,
+            item.l_comment
+        )?;
+    }
+
+    Ok(())
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -121,8 +121,8 @@ fn generate_nation(cli: &Cli) -> io::Result<()> {
     let filename = "nation.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = NationGenerator::new();
-    for nation in generator.iter() {
+    let mut iter = NationGenerator::new().iter();
+    while let Some(nation) = iter.make_next_nation() {
         writeln!(
             writer,
             "{}|{}|{}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -1,3 +1,45 @@
+//! TPCH data generation CLI with a dbgen compatible API.
+//!
+//! This crate provides a CLI for generating TPCH data and tries to remain close
+//! API wise to the original dbgen tool, as in we use the same command line flags
+//! and arguments.
+//!
+//! -h, --help       Prints help information
+//! -V, --version    Prints version information
+//! -s, --scale      Scale factor for the data generation
+//! -T, --tables     Tables to generate data for
+//! -F, --format     Output format for the data (CSV or Parquet)
+//! -O, --output     Output directory for the generated data
+//
+// The main function is the entry point for the CLI and it uses the `clap` crate
+// to parse the command line arguments and then generate the data.
+
+use clap::{command, Parser};
+
+#[derive(Debug, Parser)]
+#[command(version, about = "TPCH data generation CLI with a dbgen compatible API.", long_about = None)]
+struct Args {
+    #[arg(
+        short,
+        long,
+        help = "Scale factor to use can be one of (0.01, 0.1, 1, 10, 30, 100, 300, 1000, 3000"
+    )]
+    scale: f64,
+
+    #[arg(
+        short,
+        help = "Generate data for only the specified tables (defaults to all)."
+    )]
+    tables: Vec<String>,
+
+    #[arg(short, long, help = "Output format for the data (CSV or Parquet)")]
+    format: String,
+
+    #[arg(short, long, help = "Output directory for the generated data")]
+    output: String,
+}
+
 fn main() {
+    let args = Args::parse();
     println!("Hello, world!");
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -153,8 +153,8 @@ fn generate_part(cli: &Cli) -> io::Result<()> {
     let filename = "part.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = PartGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for part in generator.iter() {
+    let mut iter = PartGenerator::new(cli.scale_factor as f64, cli.part, cli.parts).iter();
+    while let Some(part) = iter.make_next_part() {
         writeln!(
             writer,
             "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -23,6 +23,7 @@ use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
+use tpchgen::text::TextPool;
 
 #[derive(Parser)]
 #[command(name = "tpchgen")]
@@ -83,6 +84,11 @@ fn main() -> io::Result<()> {
             Table::LineItem,
         ]
     };
+
+    // Prepare the global text pool so it is available for all generators
+    // explicitly so it does not appear to be part of the first table
+    println!("Generating text pool");
+    TextPool::default();
 
     // Generate each table
     for table in tables {

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -199,8 +199,8 @@ fn generate_partsupp(cli: &Cli) -> io::Result<()> {
     let filename = "partsupp.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = PartSupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for ps in generator.iter() {
+    let mut iter = PartSupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts).iter();
+    while let Some(ps) = iter.make_next_part_supplier() {
         writeln!(
             writer,
             "{}|{}|{}|{:.2}|{}",

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -19,6 +19,7 @@ use clap::{Parser, ValueEnum};
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use tpchgen::dates;
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
@@ -262,7 +263,8 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
     let mut writer = new_table_writer(cli, filename)?;
 
     let generator = LineItemGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
-    for item in generator.iter() {
+    let mut iter = generator.iter();
+    while let Some(item) = iter.make_next_lineitem() {
         writeln!(
             writer,
             "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}",
@@ -276,9 +278,9 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
             item.l_tax,
             item.l_returnflag,
             item.l_linestatus,
-            item.l_shipdate,
-            item.l_commitdate,
-            item.l_receiptdate,
+            dates::DateUtils::to_epoch_date(item.l_shipdate),
+            dates::DateUtils::to_epoch_date(item.l_commitdate),
+            dates::DateUtils::to_epoch_date(item.l_receiptdate),
             item.l_shipinstruct,
             item.l_shipmode,
             item.l_comment

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -97,15 +97,6 @@ impl DateUtils {
     fn is_leap_year(year: i32) -> bool {
         year % 4 == 0 && year % 100 != 0
     }
-
-    /// Calculate leap year adjustment
-    fn leap_year_adjustment(year: i32, month: i32) -> i32 {
-        if Self::is_leap_year(year) && month >= 2 {
-            1
-        } else {
-            0
-        }
-    }
 }
 
 /// Creates the date index used for lookups
@@ -133,7 +124,7 @@ fn make_date(index: i32) -> NaiveDate {
         d - MONTH_YEAR_DAY_START[(m - 1) as usize] - if is_leap_year(y) && m > 2 { 1 } else { 0 };
 
     // Create date from year, month, day
-    
+
     NaiveDate::from_ymd_opt(1900 + y, m as u32, dy as u32).unwrap()
 }
 

--- a/tpchgen/src/distribution.rs
+++ b/tpchgen/src/distribution.rs
@@ -45,7 +45,7 @@ impl Distribution {
             let mut dist = vec![String::new(); max as usize];
 
             let mut index = 0;
-            for (value_index, value) in values.iter().enumerate() {
+            for (_, value) in values.iter().enumerate() {
                 let count = distribution.get(value).unwrap();
 
                 for _ in 0..*count {
@@ -66,6 +66,11 @@ impl Distribution {
             distribution: distribution_array,
             max_weight,
         }
+    }
+
+    /// Returns the distribution name.
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Gets a value at the specified index.
@@ -163,7 +168,7 @@ impl DistributionLoader {
     {
         let regex_separator = Regex::new(r"\|").unwrap();
         let mut members = IndexMap::new();
-        let mut count = -1;
+        let mut _count = -1;
 
         for line in lines.by_ref() {
             if Self::is_end(&line) {
@@ -193,7 +198,7 @@ impl DistributionLoader {
             };
 
             if value.eq_ignore_ascii_case("count") {
-                count = weight;
+                _count = weight;
             } else {
                 members.insert(value, weight);
             }

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -16,7 +16,7 @@ use crate::random::{RandomBoundedInt, RandomString, RandomStringSequence, Random
 /// Generator for Nation table data
 pub struct NationGenerator {
     distributions: Distributions,
-    text_pool: TextPool,
+    text_pool: Arc<TextPool>,
 }
 
 impl Default for NationGenerator {
@@ -34,7 +34,7 @@ impl NationGenerator {
     /// Creates a NationGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
         distributions: Distributions,
-        text_pool: TextPool,
+        text_pool: Arc<TextPool>,
     ) -> Self {
         NationGenerator {
             distributions,
@@ -166,7 +166,7 @@ impl Region {
 /// Generator for Region table data
 pub struct RegionGenerator {
     distributions: Distributions,
-    text_pool: TextPool,
+    text_pool: Arc<TextPool>,
 }
 
 impl Default for RegionGenerator {
@@ -184,7 +184,7 @@ impl RegionGenerator {
     /// Creates a RegionGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
         distributions: Distributions,
-        text_pool: TextPool,
+        text_pool: Arc<TextPool>,
     ) -> Self {
         RegionGenerator {
             distributions,
@@ -321,7 +321,7 @@ impl PartGenerator {
             part,
             part_count,
             Distributions::default(),
-            Arc::new(TextPool::default()),
+            TextPool::default(),
         )
     }
 
@@ -565,7 +565,7 @@ impl SupplierGenerator {
             part,
             part_count,
             Distributions::default(),
-            Arc::new(TextPool::default()),
+            TextPool::default(),
         )
     }
 
@@ -836,7 +836,7 @@ impl CustomerGenerator {
             part,
             part_count,
             Distributions::default(),
-            Arc::new(TextPool::default()),
+            TextPool::default(),
         )
     }
 
@@ -1032,12 +1032,7 @@ impl PartSupplierGenerator {
 
     /// Creates a new PartSupplierGenerator with the given scale factor
     pub fn new(scale_factor: f64, part: i32, part_count: i32) -> Self {
-        Self::new_with_text_pool(
-            scale_factor,
-            part,
-            part_count,
-            Arc::new(TextPool::default()),
-        )
+        Self::new_with_text_pool(scale_factor, part, part_count, TextPool::default())
     }
 
     /// Creates a PartSupplierGenerator with specified text pool
@@ -1271,7 +1266,7 @@ impl OrderGenerator {
             part,
             part_count,
             Distributions::default(),
-            Arc::new(TextPool::default()),
+            TextPool::default(),
         )
     }
 
@@ -1625,7 +1620,7 @@ impl LineItemGenerator {
             part,
             part_count,
             Distributions::default(),
-            Arc::new(TextPool::default()),
+            TextPool::default(),
         )
     }
 

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -695,7 +695,7 @@ impl SupplierGeneratorIterator {
         // Add supplier complaints or commendation to the comment
         let bbb_comment_random_value = self.bbb_comment_random.next_value();
         if bbb_comment_random_value <= SupplierGenerator::BBB_COMMENTS_PER_SCALE_BASE {
-            let buffer = comment.clone();
+            let _buffer = comment.clone();
 
             // select random place for BBB comment
             let noise = self.bbb_junk_random.next_int(

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -49,29 +49,20 @@ impl NationGenerator {
     }
 }
 
-impl IntoIterator for NationGenerator {
-    type Item = Nation;
-    type IntoIter = NationGeneratorIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
 /// The NATION table
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Nation {
+pub struct Nation<'a> {
     /// Primary key (0-24)
     pub n_nationkey: i64,
     /// Nation name
-    pub n_name: String,
+    pub n_name: &'a str,
     /// Foreign key to REGION
     pub n_regionkey: i64,
     /// Variable length comment
-    pub n_comment: String,
+    pub n_comment: &'a str,
 }
 
-impl fmt::Display for Nation {
+impl<'a> fmt::Display for Nation<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -81,14 +72,14 @@ impl fmt::Display for Nation {
     }
 }
 
-impl Nation {
+impl<'a> Nation<'a> {
     /// Create a new `nation` record with the specified values.
-    pub fn new(n_nationkey: i64, n_name: &str, n_regionkey: i64, n_comment: &str) -> Self {
+    pub fn new(n_nationkey: i64, n_name: &'a str, n_regionkey: i64, n_comment: &'a str) -> Self {
         Nation {
             n_nationkey,
-            n_name: n_name.to_string(),
+            n_name,
             n_regionkey,
-            n_comment: n_comment.to_string(),
+            n_comment,
         }
     }
 }
@@ -98,6 +89,8 @@ pub struct NationGeneratorIterator {
     nations: Distribution,
     comment_random: RandomText,
     index: usize,
+
+    row_finished: bool,
 }
 
 impl NationGeneratorIterator {
@@ -112,14 +105,17 @@ impl NationGeneratorIterator {
                 Self::COMMENT_AVERAGE_LENGTH as f64,
             ),
             index: 0,
+            row_finished: false,
         }
     }
-}
 
-impl Iterator for NationGeneratorIterator {
-    type Item = Nation;
+    pub fn make_next_nation(&mut self) -> Option<Nation<'_>> {
+        if self.row_finished {
+            self.comment_random.row_finished();
+            self.index += 1;
+        }
+        self.row_finished = true;
 
-    fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.nations.size() {
             return None;
         }
@@ -128,15 +124,12 @@ impl Iterator for NationGeneratorIterator {
             // n_nationkey
             n_nationkey: self.index as i64,
             // n_name
-            n_name: self.nations.get_value(self.index).to_string(),
+            n_name: self.nations.get_value(self.index),
             // n_regionkey
             n_regionkey: self.nations.get_weight(self.index) as i64,
             // n_comment
-            n_comment: self.comment_random.next_value(),
+            n_comment: self.comment_random.next_str(),
         };
-
-        self.comment_random.row_finished();
-        self.index += 1;
 
         Some(nation)
     }

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -329,9 +329,7 @@ impl RandomAlphaNumeric {
     }
 
     pub fn next_value(&mut self) -> String {
-        let length = self
-            .inner
-            .next_int(self.min_length, self.max_length) as usize;
+        let length = self.inner.next_int(self.min_length, self.max_length) as usize;
         let mut buffer = vec![0u8; length];
 
         let mut char_index = 0;
@@ -475,10 +473,9 @@ impl RandomStringSequence {
         // Randomize first 'count' elements
         for current_position in 0..self.count {
             // Pick a random position to swap with
-            let swap_position = self
-                .inner
-                .next_int(current_position, values.len() as i32 - 1)
-                as usize;
+            let swap_position =
+                self.inner
+                    .next_int(current_position, values.len() as i32 - 1) as usize;
 
             // Swap the elements
             values.swap(current_position as usize, swap_position);

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -330,11 +330,6 @@ impl RandomAlphaNumeric {
         }
     }
 
-    /// to remove in favor of next_str
-    pub fn next_value(&mut self) -> String {
-        self.next_str().to_string()
-    }
-
     pub fn next_str(&mut self) -> &str {
         let length = self.inner.next_int(self.min_length, self.max_length) as usize;
         self.buffer.clear();
@@ -387,11 +382,6 @@ impl RandomPhoneNumber {
         }
     }
 
-    // todo: remove and always return a &str
-    pub fn next_value(&mut self, nation_key: i64) -> String {
-        self.next_str(nation_key).to_string()
-    }
-
     pub fn next_str(&mut self, nation_key: i64) -> &str {
         let country_code = 10 + (nation_key % Self::NATIONS_MAX as i64);
         let local1 = self.inner.next_int(100, 999);
@@ -441,11 +431,6 @@ impl RandomString {
         }
     }
 
-    // TODO remove and always return a &str
-    pub fn next_value(&mut self) -> String {
-        self.distribution.random_value(&mut self.inner).to_string()
-    }
-
     pub fn next_str(&mut self) -> &str {
         self.distribution.random_value(&mut self.inner)
     }
@@ -486,11 +471,6 @@ impl RandomStringSequence {
             distribution: distribution.clone(),
             buffer: String::new(),
         }
-    }
-
-    /// TODO remove and always return a &str
-    pub fn next_value(&mut self) -> String {
-        self.next_str().to_string()
     }
 
     /// return the next value as a &str
@@ -561,15 +541,6 @@ impl RandomText {
             min_length: (average_text_length * Self::LOW_LENGTH_MULTIPLIER) as i32,
             max_length: (average_text_length * Self::HIGH_LENGTH_MULTIPLIER) as i32,
         }
-    }
-
-    pub fn next_value(&mut self) -> String {
-        let offset = self
-            .inner
-            .next_int(0, self.text_pool.size() - self.max_length);
-        let lenght = self.inner.next_int(self.min_length, self.max_length);
-
-        self.text_pool.text(offset, offset + lenght)
     }
 
     pub fn next_str(&mut self) -> &str {

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -422,8 +422,13 @@ impl RandomString {
         }
     }
 
+    // TODO remove and always return a &str
     pub fn next_value(&mut self) -> String {
         self.distribution.random_value(&mut self.inner).to_string()
+    }
+
+    pub fn next_str(&mut self) -> &str {
+        self.distribution.random_value(&mut self.inner)
     }
 
     /// Advance the inner random number generator by the given number of rows.
@@ -533,6 +538,15 @@ impl RandomText {
         let lenght = self.inner.next_int(self.min_length, self.max_length);
 
         self.text_pool.text(offset, offset + lenght)
+    }
+
+    pub fn next_str(&mut self) -> &str {
+        let offset = self
+            .inner
+            .next_int(0, self.text_pool.size() - self.max_length);
+        let lenght = self.inner.next_int(self.min_length, self.max_length);
+
+        self.text_pool.text_as_str(offset, offset + lenght)
     }
 
     pub fn advance_rows(&mut self, row_count: i64) {

--- a/tpchgen/src/text.rs
+++ b/tpchgen/src/text.rs
@@ -80,6 +80,18 @@ impl TextPool {
         String::from_utf8(result).unwrap()
     }
 
+    pub fn text_as_str(&self, begin: i32, end: i32) -> &str {
+        assert!(begin >= 0, "Begin index must be greater than or equal to 0");
+        assert!(
+            end <= self.size,
+            "End index must be less than the pool size"
+        );
+        assert!(begin < end, "Begin index must be less than the end index");
+
+        /* Safety: text contains only ASCII , and bounds were checked above */
+        unsafe { std::str::from_utf8_unchecked(&self.text[begin as usize..end as usize]) }
+    }
+
     fn generate_sentence(
         distributions: &Distributions,
         builder: &mut ByteArrayBuilder,


### PR DESCRIPTION
- Draft as it builds on https://github.com/clflushopt/tpchgen-rs/pull/12
- part of https://github.com/clflushopt/tpchgen-rs/issues/6

## Why

I couldn't help myself  😎  (While testing the `dbgen` command line code I wanted to make it faster)

## What

## Performance Results

On my M3 Mac:

| Scale Factor | Main | This PR | times faster |
|--------|--------|--------|--------|
| 0.001 | 17.6s | 2.5s | 7 |
| 1 | 24.1s | 7.95 | 3 |

Note I only applied the "don't copy strings" technique to lineitem. The same thing can be done to all the other tables to get better performance


```
time cargo run --release -- -s 0.001 --output-dir=/tmp/tpchdbgen-rs
...
real	0m17.596s
```


# Background

Some quick profiling on main shows large amounts of time initializing the TextPool and string manipulaton

![Screenshot 2025-03-14 at 6 50 33 AM](https://github.com/user-attachments/assets/43022ac8-eb5f-466b-88d0-042860d55bc9)

## Changes
1. Initialize TextPool once, rather than for each table, in 15f3002179d8ca1267b9000829e1b0ded870763e
2. Avoid copying strings in LineItem (use `&str` instead), in c529cf5359b0b76a28c077abfc53d0d714b05700

Here is the profiling after these changes:

<img width="1381" alt="Screenshot 2025-03-14 at 8 22 38 AM" src="https://github.com/user-attachments/assets/2a9bc66d-f2a5-4490-89a8-d3f4923ddbbe" />

Note: I think we could reduce more of the time by formatting the date strings directly into the output (rather than into directly into buffers and then output):
