### PR TITLE
feat: optimize single threaded performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@
 members = [ "tpchgen" , "tpchgen-cli"]
 
 resolver = "2"
+
+[profile.release]
+debug = true

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -123,8 +123,7 @@ fn generate_nation(cli: &Cli) -> io::Result<()> {
             nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_region(cli: &Cli) -> io::Result<()> {
@@ -139,8 +138,7 @@ fn generate_region(cli: &Cli) -> io::Result<()> {
             region.r_regionkey, region.r_name, region.r_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_part(cli: &Cli) -> io::Result<()> {
@@ -163,8 +161,7 @@ fn generate_part(cli: &Cli) -> io::Result<()> {
             part.p_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_supplier(cli: &Cli) -> io::Result<()> {
@@ -185,8 +182,7 @@ fn generate_supplier(cli: &Cli) -> io::Result<()> {
             supplier.s_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_partsupp(cli: &Cli) -> io::Result<()> {
@@ -201,8 +197,7 @@ fn generate_partsupp(cli: &Cli) -> io::Result<()> {
             ps.ps_partkey, ps.ps_suppkey, ps.ps_availqty, ps.ps_supplycost, ps.ps_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_customer(cli: &Cli) -> io::Result<()> {
@@ -224,8 +219,7 @@ fn generate_customer(cli: &Cli) -> io::Result<()> {
             customer.c_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_orders(cli: &Cli) -> io::Result<()> {
@@ -248,8 +242,7 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
             order.o_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }
 
 fn generate_lineitem(cli: &Cli) -> io::Result<()> {
@@ -279,6 +272,5 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
             item.l_comment
         )?;
     }
-
-    Ok(())
+    writer.flush()
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -106,8 +106,9 @@ fn main() -> io::Result<()> {
 fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<Box<dyn Write>> {
     let path = cli.output_dir.join(filename);
     let file = File::create(path)?;
+    let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
 
-    Ok(Box::new(BufWriter::new(file)))
+    Ok(Box::new(writer))
 }
 
 fn generate_nation(cli: &Cli) -> io::Result<()> {

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -86,7 +86,6 @@ fn main() -> io::Result<()> {
 
     // Generate each table
     for table in tables {
-        println!("Generating table: {:?}", table);
         match table {
             Table::Nation => generate_nation(&cli)?,
             Table::Region => generate_region(&cli)?,
@@ -106,7 +105,7 @@ fn main() -> io::Result<()> {
 fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<Box<dyn Write>> {
     let path = cli.output_dir.join(filename);
     let file = File::create(path)?;
-    let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
+    let writer = BufWriter::with_capacity(32 * 1024, file);
 
     Ok(Box::new(writer))
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -146,7 +146,7 @@ fn generate_part(cli: &Cli) -> io::Result<()> {
     let filename = "part.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = PartGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = PartGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for part in generator.iter() {
         writeln!(
             writer,
@@ -170,7 +170,7 @@ fn generate_supplier(cli: &Cli) -> io::Result<()> {
     let filename = "supplier.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = SupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = SupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for supplier in generator.iter() {
         writeln!(
             writer,
@@ -192,7 +192,7 @@ fn generate_partsupp(cli: &Cli) -> io::Result<()> {
     let filename = "partsupp.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = PartSupplierGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = PartSupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for ps in generator.iter() {
         writeln!(
             writer,
@@ -208,7 +208,7 @@ fn generate_customer(cli: &Cli) -> io::Result<()> {
     let filename = "customer.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = CustomerGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = CustomerGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for customer in generator.iter() {
         writeln!(
             writer,
@@ -231,7 +231,7 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
     let filename = "orders.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = OrderGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = OrderGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for order in generator.iter() {
         writeln!(
             writer,
@@ -255,7 +255,7 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
     let filename = "lineitem.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = LineItemGenerator::new(cli.scale_factor as f64, cli.part, cli.parts);
+    let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for item in generator.iter() {
         writeln!(
             writer,

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -63,13 +63,18 @@ impl DateUtils {
         DATE_INDEX[idx as usize]
     }
 
+    /// Format money value (convert to decimal)
+    pub fn format_money(value: i64) -> String {
+        format!("{:.2}", value as f64 / 100.0)
+    }
+
     /// Checks if a date is in the past
-    pub fn is_in_past(date: i32) -> bool {
+    pub const fn is_in_past(date: i32) -> bool {
         Self::julian(date) <= CURRENT_DATE
     }
 
     /// Converts to julian date format
-    fn julian(date: i32) -> i32 {
+    const fn julian(date: i32) -> i32 {
         let mut offset = date - MIN_GENERATE_DATE;
         let mut result = MIN_GENERATE_DATE;
 
@@ -88,13 +93,8 @@ impl DateUtils {
         result + offset
     }
 
-    /// Format money value (convert to decimal)
-    pub fn format_money(value: i64) -> String {
-        format!("{:.2}", value as f64 / 100.0)
-    }
-
     /// Check if a year is a leap year
-    fn is_leap_year(year: i32) -> bool {
+    const fn is_leap_year(year: i32) -> bool {
         year % 4 == 0 && year % 100 != 0
     }
 }
@@ -111,7 +111,7 @@ fn make_date_index() -> Vec<NaiveDate> {
 }
 
 /// Create a date from an index
-fn make_date(index: i32) -> NaiveDate {
+const fn make_date(index: i32) -> NaiveDate {
     let y = julian(index + MIN_GENERATE_DATE - 1) / 1000;
     let d = julian(index + MIN_GENERATE_DATE - 1) % 1000;
 
@@ -128,7 +128,7 @@ fn make_date(index: i32) -> NaiveDate {
 }
 
 /// Helpers duplicated to avoid circular references
-fn julian(date: i32) -> i32 {
+const fn julian(date: i32) -> i32 {
     let mut offset = date - MIN_GENERATE_DATE;
     let mut result = MIN_GENERATE_DATE;
 
@@ -147,11 +147,11 @@ fn julian(date: i32) -> i32 {
     result + offset
 }
 
-fn is_leap_year(year: i32) -> bool {
+const fn is_leap_year(year: i32) -> bool {
     year % 4 == 0 && year % 100 != 0
 }
 
-fn leap_year_adjustment(year: i32, month: i32) -> i32 {
+const fn leap_year_adjustment(year: i32, month: i32) -> i32 {
     if is_leap_year(year) && month >= 2 {
         1
     } else {

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -124,7 +124,6 @@ fn make_date(index: i32) -> NaiveDate {
         d - MONTH_YEAR_DAY_START[(m - 1) as usize] - if is_leap_year(y) && m > 2 { 1 } else { 0 };
 
     // Create date from year, month, day
-
     NaiveDate::from_ymd_opt(1900 + y, m as u32, dy as u32).unwrap()
 }
 

--- a/tpchgen/src/distribution.rs
+++ b/tpchgen/src/distribution.rs
@@ -496,6 +496,5 @@ mod tests {
                 name
             );
         }
-        println!("{:#?}", distributions);
     }
 }

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -74,7 +74,7 @@ impl fmt::Display for Nation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {}",
+            "{}|{}|{}|{}|",
             self.n_nationkey, self.n_name, self.n_regionkey, self.n_comment
         )
     }
@@ -150,6 +150,16 @@ pub struct Region {
     pub r_name: String,
     /// Variable length comment
     pub r_comment: String,
+}
+
+impl fmt::Display for Region {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}|{}|{}|",
+            self.r_regionkey, self.r_name, self.r_comment
+        )
+    }
 }
 
 impl Region {
@@ -278,7 +288,7 @@ impl fmt::Display for Part {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {},{}, {}, {}, {:.2}, {}",
+            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}|",
             self.p_partkey,
             self.p_name,
             self.p_mfgr,
@@ -518,7 +528,7 @@ impl fmt::Display for Supplier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {}, {}, {:.2}, {}",
+            "{}|{}|{}|{}|{}|{:.2}|{}|",
             self.s_suppkey,
             self.s_name,
             self.s_address,
@@ -797,7 +807,7 @@ impl fmt::Display for Customer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {}, {}, {:.2}, {}, {}",
+            "{}|{}|{}|{}|{}|{:.2}|{}|{}|",
             self.c_custkey,
             self.c_name,
             self.c_address,
@@ -1005,7 +1015,7 @@ impl fmt::Display for PartSupp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {:.2}, {}",
+            "{}|{}|{}|{:.2}|{}|",
             self.ps_partkey, self.ps_suppkey, self.ps_availqty, self.ps_supplycost, self.ps_comment
         )
     }
@@ -1218,7 +1228,7 @@ impl fmt::Display for Order {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {:.2}, {}, {}, {}, {}, {}",
+            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}|",
             self.o_orderkey,
             self.o_custkey,
             self.o_orderstatus,
@@ -1562,7 +1572,7 @@ impl fmt::Display for LineItem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}, {}, {}, {}, {:.2}, {:.2}, {:.2}, {:.2}, {}, {}, {}, {}, {}, {}, {}, {}",
+            "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
             self.l_orderkey,
             self.l_partkey,
             self.l_suppkey,

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -464,7 +464,7 @@ impl RandomString {
 pub struct RandomStringSequence {
     inner: RowRandomInt,
     count: i32,
-    values: Vec<String>,
+    distribution: Distribution,
 }
 
 impl RandomStringSequence {
@@ -481,11 +481,7 @@ impl RandomStringSequence {
         Self {
             inner: RowRandomInt::new(seed, distribution.size() as i32 * seeds_per_row),
             count,
-            values: distribution
-                .get_values()
-                .iter()
-                .map(|v| v.to_string())
-                .collect(),
+            distribution: distribution.clone(),
         }
     }
 

--- a/tpchgen/tests/integration_tests.rs
+++ b/tpchgen/tests/integration_tests.rs
@@ -33,7 +33,7 @@ fn test_generator<T, G, F>(
     dir.push(reference_path);
 
     // Read reference data.
-    let mut reference_data = read_tbl_gz(dir);
+    let reference_data = read_tbl_gz(dir);
 
     // Generate data using our own generators.
     let generator = generator_fn(scale_factor);


### PR DESCRIPTION
Part of #6 this change introduces several, small optimizations that compound at large scale factors (1+).

- Refactor `RandomStringSequence` to allocate the values vector only once instead of per call to `next_value()` and inline the randomness swapping logic to be on indices to avoid mutating the original vector, below you can see the profile.

**Before**
![Screenshot_20250315_135619](https://github.com/user-attachments/assets/012d9d20-4e5a-4f86-ad8f-28ef98d392ec)

**After**
![Screenshot_20250315_135606](https://github.com/user-attachments/assets/0225c7bc-5f85-4f82-9be5-a4f1f7c7c10a)