### PR TITLE
Change Random* generators to return `&str` or structs rather than `String` (10% faster)

### DIFF
--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -131,7 +131,7 @@ impl Iterator for NationGeneratorIterator {
             // n_regionkey
             n_regionkey: self.nations.get_weight(self.index) as i64,
             // n_comment
-            n_comment: self.comment_random.next_value(),
+            n_comment: self.comment_random.next_value().to_string(),
         };
 
         self.comment_random.row_finished();
@@ -241,7 +241,7 @@ impl Iterator for RegionGeneratorIterator {
         let region = Region {
             r_regionkey: self.index as i64,
             r_name: self.regions.get_value(self.index).to_string(),
-            r_comment: self.comment_random.next_value(),
+            r_comment: self.comment_random.next_value().to_string(),
         };
 
         self.comment_random.row_finished();
@@ -448,14 +448,14 @@ impl PartGeneratorIterator {
 
         Part {
             p_partkey: part_key,
-            p_name: name,
+            p_name: name.to_string(),
             p_mfgr: format!("Manufacturer#{}", manufacturer),
             p_brand: format!("Brand#{}", brand),
-            p_type: self.type_random.next_value(),
+            p_type: self.type_random.next_value().to_string(),
             p_size: self.size_random.next_value(),
-            p_container: self.container_random.next_value(),
+            p_container: self.container_random.next_value().to_string(),
             p_retailprice: Self::calculate_part_price(part_key) as f64 / 100.0,
-            p_comment: self.comment_random.next_value(),
+            p_comment: self.comment_random.next_value().to_string(),
         }
     }
 
@@ -690,7 +690,7 @@ impl SupplierGeneratorIterator {
 
     /// Creates a supplier with the given key
     fn make_supplier(&mut self, supplier_key: i64) -> Supplier {
-        let mut comment = self.comment_random.next_value();
+        let mut comment = self.comment_random.next_value().to_string();
 
         // Add supplier complaints or commendation to the comment
         let bbb_comment_random_value = self.bbb_comment_random.next_value();
@@ -737,9 +737,9 @@ impl SupplierGeneratorIterator {
         Supplier {
             s_suppkey: supplier_key,
             s_name: format!("Supplier#{:09}", supplier_key),
-            s_address: self.address_random.next_value(),
+            s_address: self.address_random.next_value().to_string(),
             s_nationkey: nation_key,
-            s_phone: self.phone_random.next_value(nation_key),
+            s_phone: self.phone_random.next_value(nation_key).to_string(),
             s_acctbal: self.account_balance_random.next_value() as f64 / 100.0,
             s_comment: comment,
         }
@@ -954,12 +954,12 @@ impl CustomerGeneratorIterator {
         Customer {
             c_custkey: customer_key,
             c_name: format!("Customer#{:09}", customer_key),
-            c_address: self.address_random.next_value(),
+            c_address: self.address_random.next_value().to_string(),
             c_nationkey: nation_key,
-            c_phone: self.phone_random.next_value(nation_key),
+            c_phone: self.phone_random.next_value(nation_key).to_string(),
             c_acctbal: self.account_balance_random.next_value() as f64 / 100.0,
-            c_mktsegment: self.market_segment_random.next_value(),
-            c_comment: self.comment_random.next_value(),
+            c_mktsegment: self.market_segment_random.next_value().to_string(),
+            c_comment: self.comment_random.next_value().to_string(),
         }
     }
 }
@@ -1148,7 +1148,7 @@ impl PartSupplierGeneratorIterator {
             ps_suppkey: supplier_key,
             ps_availqty: self.available_quantity_random.next_value(),
             ps_supplycost: self.supply_cost_random.next_value() as f64 / 100.0,
-            ps_comment: self.comment_random.next_value(),
+            ps_comment: self.comment_random.next_value().to_string(),
         }
     }
 
@@ -1484,10 +1484,10 @@ impl OrderGeneratorIterator {
             o_orderstatus: order_status,
             o_totalprice: total_price as f64 / 100.,
             o_orderdate: dates::DateUtils::to_epoch_date(order_date).to_string(),
-            o_orderpriority: self.order_priority_random.next_value(),
+            o_orderpriority: self.order_priority_random.next_value().to_string(),
             o_clerk: format!("Clerk#{:09}", self.clerk_random.next_value()),
             o_shippriority: 0, // Fixed value per TPC-H spec
-            o_comment: self.comment_random.next_value(),
+            o_comment: self.comment_random.next_value().to_string(),
         }
     }
 }
@@ -1897,7 +1897,7 @@ impl LineItemGeneratorIterator {
         receipt_date += ship_date;
 
         let returned_flag = if dates::DateUtils::is_in_past(receipt_date) {
-            self.returned_flag_random.next_value()
+            self.returned_flag_random.next_value().to_string()
         } else {
             "N".to_string()
         };
@@ -1926,9 +1926,9 @@ impl LineItemGeneratorIterator {
             l_shipdate: dates::DateUtils::to_epoch_date(ship_date).to_string(),
             l_commitdate: dates::DateUtils::to_epoch_date(commit_date).to_string(),
             l_receiptdate: dates::DateUtils::to_epoch_date(receipt_date).to_string(),
-            l_shipinstruct: ship_instructions,
-            l_shipmode: ship_mode,
-            l_comment: comment,
+            l_shipinstruct: ship_instructions.to_string(),
+            l_shipmode: ship_mode.to_string(),
+            l_comment: comment.to_string(),
         }
     }
 }

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -1,6 +1,7 @@
 //! Implementation of the core random number generators.
 
 use crate::{distribution::Distribution, text::TextPool};
+use std::fmt::Display;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct RowRandomInt {
@@ -299,6 +300,7 @@ pub struct RandomAlphaNumeric {
     inner: RowRandomInt,
     min_length: i32,
     max_length: i32,
+    buffer: Vec<u8>,
 }
 
 impl RandomAlphaNumeric {
@@ -325,12 +327,13 @@ impl RandomAlphaNumeric {
             inner: RowRandomInt::new(seed, Self::USAGE_PER_ROW * seeds_per_row),
             min_length,
             max_length,
+            buffer: Vec::new(),
         }
     }
 
-    pub fn next_value(&mut self) -> String {
+    pub fn next_value(&mut self) -> &str {
         let length = self.inner.next_int(self.min_length, self.max_length) as usize;
-        let mut buffer = vec![0u8; length];
+        self.buffer.resize(length, 0);
 
         let mut char_index = 0;
         for i in 0..length {
@@ -339,12 +342,12 @@ impl RandomAlphaNumeric {
             }
 
             let char_pos = (char_index & 0x3f) as usize;
-            buffer[i] = Self::ALPHA_NUMERIC[char_pos];
+            self.buffer[i] = Self::ALPHA_NUMERIC[char_pos];
             char_index >>= 6;
         }
 
-        // This is safe because ALPHA_NUMERIC contains only valid ASCII
-        String::from_utf8(buffer).unwrap()
+        // SAFETY: ALPHA_NUMERIC contains only valid ASCII characters
+        unsafe { std::str::from_utf8_unchecked(&self.buffer) }
     }
 
     /// Advance the inner random number generator by the specified number of rows.
@@ -377,16 +380,13 @@ impl RandomPhoneNumber {
         }
     }
 
-    pub fn next_value(&mut self, nation_key: i64) -> String {
-        let country_code = 10 + (nation_key % Self::NATIONS_MAX as i64);
-        let local1 = self.inner.next_int(100, 999);
-        let local2 = self.inner.next_int(100, 999);
-        let local3 = self.inner.next_int(1000, 9999);
-
-        format!(
-            "{:02}-{:03}-{:03}-{:04}",
-            country_code, local1, local2, local3
-        )
+    pub fn next_value(&mut self, nation_key: i64) -> PhoneNumberInstance {
+        PhoneNumberInstance {
+            country_code: 10 + (nation_key % Self::NATIONS_MAX as i64) as i32,
+            local1: self.inner.next_int(100, 999),
+            local2: self.inner.next_int(100, 999),
+            local3: self.inner.next_int(1000, 9999),
+        }
     }
 
     /// Advance the inner random number generator by the specified number of rows.
@@ -396,6 +396,30 @@ impl RandomPhoneNumber {
 
     pub fn row_finished(&mut self) {
         self.inner.row_finished();
+    }
+}
+
+/// A displayable phone number
+///
+/// Example display:
+/// ```text
+/// 27-918-335-1736
+/// ```
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PhoneNumberInstance {
+    country_code: i32,
+    local1: i32,
+    local2: i32,
+    local3: i32,
+}
+
+impl Display for PhoneNumberInstance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:02}-{:03}-{:03}-{:04}",
+            self.country_code, self.local1, self.local2, self.local3
+        )
     }
 }
 
@@ -422,8 +446,8 @@ impl RandomString {
         }
     }
 
-    pub fn next_value(&mut self) -> String {
-        self.distribution.random_value(&mut self.inner).to_string()
+    pub fn next_value(&mut self) -> &str {
+        self.distribution.random_value(&mut self.inner)
     }
 
     /// Advance the inner random number generator by the given number of rows.
@@ -461,13 +485,13 @@ impl RandomStringSequence {
         }
     }
 
-    pub fn next_value(&mut self) -> String {
+    pub fn next_value(&mut self) -> StringSequenceInstance<'_> {
         // Get all values from the distribution
-        let mut values: Vec<String> = self
+        let mut values: Vec<&str> = self
             .distribution
             .get_values()
             .iter()
-            .map(|v| v.to_string())
+            .map(|s| s.as_str())
             .collect();
 
         // Randomize first 'count' elements
@@ -481,8 +505,9 @@ impl RandomStringSequence {
             values.swap(current_position as usize, swap_position);
         }
 
-        // Join the first 'count' values with spaces
-        values[0..self.count as usize].join(" ")
+        // Keep only the first 'count' values, and join them with spaces
+        values.truncate(self.count as usize);
+        StringSequenceInstance { values }
     }
 
     /// Advance the inner random number generator by the given number of rows.
@@ -492,6 +517,32 @@ impl RandomStringSequence {
 
     pub fn row_finished(&mut self) {
         self.inner.row_finished();
+    }
+}
+
+/// Displayable string sequence instance
+///
+/// Prints the sequence of strings as a single string with spaces between them.
+///
+/// Example display:
+/// ```text
+/// "value1 value2 value3"
+/// ```
+#[derive(Default, Debug, Clone)]
+pub struct StringSequenceInstance<'a> {
+    values: Vec<&'a str>,
+}
+
+impl<'a> Display for StringSequenceInstance<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.values.iter();
+        if let Some(first) = iter.next() {
+            write!(f, "{}", first)?;
+        }
+        for value in iter {
+            write!(f, " {}", value)?;
+        }
+        Ok(())
     }
 }
 
@@ -526,13 +577,13 @@ impl RandomText {
         }
     }
 
-    pub fn next_value(&mut self) -> String {
+    pub fn next_value(&mut self) -> &str {
         let offset = self
             .inner
             .next_int(0, self.text_pool.size() - self.max_length);
-        let lenght = self.inner.next_int(self.min_length, self.max_length);
+        let length = self.inner.next_int(self.min_length, self.max_length);
 
-        self.text_pool.text(offset, offset + lenght)
+        self.text_pool.text(offset, offset + length)
     }
 
     pub fn advance_rows(&mut self, row_count: i64) {

--- a/tpchgen/src/text.rs
+++ b/tpchgen/src/text.rs
@@ -62,22 +62,14 @@ impl TextPool {
         self.size
     }
 
-    /// Returns a chunk of text from the pool.
-    pub fn text(&self, begin: i32, end: i32) -> String {
-        assert!(begin >= 0, "Begin index must be greater than or equal to 0");
-        assert!(
-            end <= self.size,
-            "End index must be less than the pool size"
-        );
-        assert!(begin < end, "Begin index must be less than the end index");
-
-        let mut result = Vec::with_capacity((end - begin) as usize);
-        for i in begin..end {
-            result.push(self.text[i as usize]);
-        }
-
-        // This is fine I guess.
-        String::from_utf8(result).unwrap()
+    /// Returns a chunk of text from the pool
+    ///
+    /// Returns the text from the pool between the given begin and end indices.
+    pub fn text(&self, begin: i32, end: i32) -> &str {
+        // get slice of bytes (note this also does bounds checks)
+        let result: &[u8] = &self.text[begin as usize..end as usize];
+        // Safety: text pool contains only ASCII
+        unsafe { std::str::from_utf8_unchecked(result) }
     }
 
     fn generate_sentence(


### PR DESCRIPTION
- Part of https://github.com/clflushopt/tpchgen-rs/issues/6

The overall plan is described [here](https://github.com/clflushopt/tpchgen-rs/issues/6#issuecomment-2728967340). I am trying to make these PRs easy to review by making them in chunks.

## Rationale: 
Several of the data generators currently return `String` which forces a copy. The data generator then copies the data again into the output immediately, so avoiding the intermediate copy makes things faster. 

## Changes:
1. Update the generators as much as possible to avoid creating `String`s . 
2. Avoid UTF-8 validation on known ASCII data 

This PR actually does make things a bit faster (but most of the data is still turned into a String by the iterators), but in future PRs I will change the iterators so they do not use Strings either. 

I will comment more inline

## Performance
Performance (of `target/release/tpchgen-cli -s 1 --output-dir=/tmp/tpchdbgen-rs`)
Main: real	0m11.045s
This PR: real	0m10.015s