### PR TITLE
Change date handling to use TPCHDate type rather than String (10% faster)

### DIFF
--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -1,5 +1,6 @@
 use chrono::NaiveDate;
 use lazy_static::lazy_static;
+use std::fmt::{Display, Formatter};
 
 /// The value of 1970-01-01 in the date generator system
 pub const GENERATED_DATE_EPOCH_OFFSET: i32 = 83966;
@@ -49,16 +50,30 @@ impl GenerateUtils {
     }
 }
 
-pub struct DateUtils;
+/// Represents a date (day/year)
+///
+/// Example display: 1992-01-01
+#[derive(Debug, Clone, PartialEq)]
+pub struct TPCHDate {
+    inner: NaiveDate,
+}
 
-impl DateUtils {
+impl Display for TPCHDate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl TPCHDate {
     /// Converts a generated date to an epoch date
-    pub fn to_epoch_date(generated_date: i32) -> NaiveDate {
-        Self::format_date(generated_date - GENERATED_DATE_EPOCH_OFFSET)
+    pub fn new(generated_date: i32) -> Self {
+        Self {
+            inner: Self::format_date(generated_date - GENERATED_DATE_EPOCH_OFFSET),
+        }
     }
 
     /// Formats a date from epoch date format
-    pub fn format_date(epoch_date: i32) -> NaiveDate {
+    fn format_date(epoch_date: i32) -> NaiveDate {
         let idx = epoch_date - (MIN_GENERATE_DATE - GENERATED_DATE_EPOCH_OFFSET);
         DATE_INDEX[idx as usize]
     }
@@ -88,11 +103,6 @@ impl DateUtils {
         result + offset
     }
 
-    /// Format money value (convert to decimal)
-    pub fn format_money(value: i64) -> String {
-        format!("{:.2}", value as f64 / 100.0)
-    }
-
     /// Check if a year is a leap year
     fn is_leap_year(year: i32) -> bool {
         year % 4 == 0 && year % 100 != 0
@@ -110,7 +120,7 @@ fn make_date_index() -> Vec<NaiveDate> {
     dates
 }
 
-/// Create a date from an index
+/// Create a chrono date from an index
 fn make_date(index: i32) -> NaiveDate {
     let y = julian(index + MIN_GENERATE_DATE - 1) / 1000;
     let d = julian(index + MIN_GENERATE_DATE - 1) % 1000;

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -10,7 +10,7 @@ use crate::random::RowRandomInt;
 use crate::text::TextPool;
 use std::sync::Arc;
 
-use crate::dates::GenerateUtils;
+use crate::dates::{GenerateUtils, TPCHDate};
 use crate::random::{RandomBoundedInt, RandomString, RandomStringSequence, RandomText};
 
 /// Generator for Nation table data
@@ -1203,7 +1203,7 @@ pub struct Order {
     /// Order total price
     pub o_totalprice: f64,
     /// Order date
-    pub o_orderdate: String, // Could use a date type instead
+    pub o_orderdate: TPCHDate,
     /// Order priority
     pub o_orderpriority: String,
     /// Clerk who processed the order
@@ -1465,7 +1465,7 @@ impl OrderGeneratorIterator {
             total_price += ((discounted_price / 100) * (100 + tax as i64)) / 100;
 
             let ship_date = self.line_ship_date_random.next_value() + order_date;
-            if dates::DateUtils::is_in_past(ship_date) {
+            if TPCHDate::is_in_past(ship_date) {
                 shipped_count += 1;
             }
         }
@@ -1483,7 +1483,7 @@ impl OrderGeneratorIterator {
             o_custkey: customer_key,
             o_orderstatus: order_status,
             o_totalprice: total_price as f64 / 100.,
-            o_orderdate: dates::DateUtils::to_epoch_date(order_date).to_string(),
+            o_orderdate: TPCHDate::new(order_date),
             o_orderpriority: self.order_priority_random.next_value(),
             o_clerk: format!("Clerk#{:09}", self.clerk_random.next_value()),
             o_shippriority: 0, // Fixed value per TPC-H spec
@@ -1545,11 +1545,11 @@ pub struct LineItem {
     /// Line status (O=ordered, F=fulfilled)
     pub l_linestatus: String,
     /// Date shipped
-    pub l_shipdate: String, // Could use a date type instead
+    pub l_shipdate: TPCHDate,
     /// Date committed to ship
-    pub l_commitdate: String, // Could use a date type instead
+    pub l_commitdate: TPCHDate,
     /// Date received
-    pub l_receiptdate: String, // Could use a date type instead
+    pub l_receiptdate: TPCHDate,
     /// Shipping instructions
     pub l_shipinstruct: String,
     /// Shipping mode
@@ -1896,13 +1896,13 @@ impl LineItemGeneratorIterator {
         let mut receipt_date = self.receipt_date_random.next_value();
         receipt_date += ship_date;
 
-        let returned_flag = if dates::DateUtils::is_in_past(receipt_date) {
+        let returned_flag = if TPCHDate::is_in_past(receipt_date) {
             self.returned_flag_random.next_value()
         } else {
             "N".to_string()
         };
 
-        let status = if dates::DateUtils::is_in_past(ship_date) {
+        let status = if TPCHDate::is_in_past(ship_date) {
             "F".to_string() // Fulfilled
         } else {
             "O".to_string() // Open
@@ -1923,9 +1923,9 @@ impl LineItemGeneratorIterator {
             l_tax: tax as f64 / 100.0,
             l_returnflag: returned_flag,
             l_linestatus: status,
-            l_shipdate: dates::DateUtils::to_epoch_date(ship_date).to_string(),
-            l_commitdate: dates::DateUtils::to_epoch_date(commit_date).to_string(),
-            l_receiptdate: dates::DateUtils::to_epoch_date(receipt_date).to_string(),
+            l_shipdate: TPCHDate::new(ship_date),
+            l_commitdate: TPCHDate::new(commit_date),
+            l_receiptdate: TPCHDate::new(receipt_date),
             l_shipinstruct: ship_instructions,
             l_shipmode: ship_mode,
             l_comment: comment,


### PR DESCRIPTION
- Similarly to https://github.com/clflushopt/tpchgen-rs/pull/26
- Part of https://github.com/clflushopt/tpchgen-rs/issues/6

The overall plan is described [here](https://github.com/clflushopt/tpchgen-rs/issues/6#issuecomment-2728967340). I am trying to make these PRs easy to review by making them in chunks.

## Rationale: 
Several of the data generators represent Dates using a `String` which forces a copy. The data generator then copies the data again into the output immediately, so avoiding the intermediate copy makes things faster. 

## Changes:
1. Use a TPCHDate type rather than a string to represent dates


## Performance
This PR also improves performance on its own (so when combined with https://github.com/clflushopt/tpchgen-rs/pull/26 we are already significantly better)

Performance (of `target/release/tpchgen-cli -s 1 --output-dir=/tmp/tpchdbgen-rs`)
Main: real	0m11.045s
This PR: real	0m9.819s