### PR TITLE
feat: Add fmt + clippy to the build action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,24 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Run cargo-fmt
+        run: cargo fmt --all -- --check
+      - name: Run cargo-clippy
+        run: cargo clippy -- -D warnings
+      - name: Build
+        run: cargo build --verbose
+      - name: Run Tests
+        run: cargo test --verbose

--- a/tpchgen/src/distribution.rs
+++ b/tpchgen/src/distribution.rs
@@ -25,10 +25,9 @@ impl Distribution {
 
         let mut running_weight = 0;
         let mut is_valid_distribution = true;
-        let mut index = 0;
 
         // Process each value and its weight
-        for (value, weight) in &distribution {
+        for (index, (value, weight)) in distribution.iter().enumerate() {
             values.push(value.clone());
 
             running_weight += weight;
@@ -36,8 +35,6 @@ impl Distribution {
 
             // A valid distribution requires all weights to be positive
             is_valid_distribution &= *weight > 0;
-
-            index += 1;
         }
 
         // Only create the full distribution array for valid distributions
@@ -220,18 +217,20 @@ pub struct Distributions {
     distributions: IndexMap<String, Distribution>,
 }
 
-impl Distributions {
-    /// Creates a new distributions wrapper.
-    pub fn new(distributions: IndexMap<String, Distribution>) -> Self {
-        Distributions { distributions }
-    }
-
+impl Default for Distributions {
     /// Loads the default distributions from `DISTS_SEED`.
-    pub fn default() -> Self {
+    fn default() -> Self {
         let cursor = io::Cursor::new(DISTS_SEED);
         let lines = cursor.lines();
         let distributions = DistributionLoader::load_distributions(lines).unwrap();
         Distributions::new(distributions)
+    }
+}
+
+impl Distributions {
+    /// Creates a new distributions wrapper.
+    pub fn new(distributions: IndexMap<String, Distribution>) -> Self {
+        Distributions { distributions }
     }
 
     /// Returns the `adjectives` distribution.

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -28,7 +28,10 @@ impl Default for NationGenerator {
 impl NationGenerator {
     /// Creates a new NationGenerator with default distributions and text pool
     pub fn new() -> Self {
-        Self::new_with_distributions_and_text_pool(Distributions::default(), TextPool::default())
+        Self::new_with_distributions_and_text_pool(
+            Distributions::default(),
+            TextPool::get_or_init_default(),
+        )
     }
 
     /// Creates a NationGenerator with the specified distributions and text pool
@@ -188,7 +191,10 @@ impl Default for RegionGenerator {
 impl RegionGenerator {
     /// Creates a new RegionGenerator with default distributions and text pool
     pub fn new() -> Self {
-        Self::new_with_distributions_and_text_pool(Distributions::default(), TextPool::default())
+        Self::new_with_distributions_and_text_pool(
+            Distributions::default(),
+            TextPool::get_or_init_default(),
+        )
     }
 
     /// Creates a RegionGenerator with the specified distributions and text pool
@@ -331,7 +337,7 @@ impl PartGenerator {
             part,
             part_count,
             Distributions::default(),
-            TextPool::default(),
+            TextPool::get_or_init_default(),
         )
     }
 
@@ -575,7 +581,7 @@ impl SupplierGenerator {
             part,
             part_count,
             Distributions::default(),
-            TextPool::default(),
+            TextPool::get_or_init_default(),
         )
     }
 
@@ -846,7 +852,7 @@ impl CustomerGenerator {
             part,
             part_count,
             Distributions::default(),
-            TextPool::default(),
+            TextPool::get_or_init_default(),
         )
     }
 
@@ -1042,7 +1048,12 @@ impl PartSupplierGenerator {
 
     /// Creates a new PartSupplierGenerator with the given scale factor
     pub fn new(scale_factor: f64, part: i32, part_count: i32) -> Self {
-        Self::new_with_text_pool(scale_factor, part, part_count, TextPool::default())
+        Self::new_with_text_pool(
+            scale_factor,
+            part,
+            part_count,
+            TextPool::get_or_init_default(),
+        )
     }
 
     /// Creates a PartSupplierGenerator with specified text pool
@@ -1276,7 +1287,7 @@ impl OrderGenerator {
             part,
             part_count,
             Distributions::default(),
-            TextPool::default(),
+            TextPool::get_or_init_default(),
         )
     }
 
@@ -1458,7 +1469,7 @@ impl OrderGeneratorIterator {
             delta *= -1;
         }
 
-        let mut total_price = 0 as i64;
+        let mut total_price = 0;
         let mut shipped_count = 0;
 
         let line_count = self.line_count_random.next_value();
@@ -1630,7 +1641,7 @@ impl LineItemGenerator {
             part,
             part_count,
             Distributions::default(),
-            TextPool::default(),
+            TextPool::get_or_init_default(),
         )
     }
 

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -533,7 +533,7 @@ pub struct StringSequenceInstance<'a> {
     values: Vec<&'a str>,
 }
 
-impl<'a> Display for StringSequenceInstance<'a> {
+impl Display for StringSequenceInstance<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut iter = self.values.iter();
         if let Some(first) = iter.next() {

--- a/tpchgen/src/text.rs
+++ b/tpchgen/src/text.rs
@@ -18,9 +18,8 @@ pub struct TextPool {
     size: i32,
 }
 
-/// A default text pool that is lazily initialized and shared across the
-/// application
-
+/// The default global text pool is lazily initialized once and shared across
+/// all the table generators.
 static DEFAULT_TEXT_POOL: OnceLock<Arc<TextPool>> = OnceLock::new();
 
 impl TextPool {
@@ -29,8 +28,9 @@ impl TextPool {
     /// Maximum length of a sentence in the text.
     const MAX_SENTENCE_LENGTH: i32 = 256;
 
-    /// Returns the default text pool.
-    pub fn default() -> Arc<Self> {
+    /// Returns the default text pool or initializes for the first time if
+    /// that's not already the case.
+    pub fn get_or_init_default() -> Arc<Self> {
         Arc::clone(DEFAULT_TEXT_POOL.get_or_init(|| {
             Arc::new(Self::new(
                 Self::DEFAULT_TEXT_POOL_SIZE,
@@ -327,11 +327,11 @@ impl IndexedDistribution {
         let mut random_table = vec![String::new(); max_weight as usize];
 
         let mut value_index = 0;
-        for i in 0..random_table.len() {
+        for (i, item) in random_table.iter_mut().enumerate() {
             if i >= distribution.get_weight(value_index) as usize {
                 value_index += 1;
             }
-            random_table[i] = distribution.get_value(value_index).to_string();
+            *item = distribution.get_value(value_index).to_string();
         }
 
         IndexedDistribution { random_table }
@@ -372,11 +372,11 @@ impl ParsedDistribution {
         let mut random_table = vec![0; max_weight as usize];
 
         let mut value_index = 0;
-        for i in 0..random_table.len() {
+        for (i, item) in random_table.iter_mut().enumerate() {
             if i >= distribution.get_weight(value_index) as usize {
                 value_index += 1;
             }
-            random_table[i] = value_index;
+            *item = value_index;
         }
 
         ParsedDistribution {


### PR DESCRIPTION
Runs `cargo clippy` and `cargo clippy` as a preamble during the Rust action in CI + I addressed a few linter issues clippy raised.
