### PR TITLE
Alamb/lineitem no copy

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -20,7 +20,7 @@ use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 use tpchgen::generators::{
-    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    CustomerGenerator, LineItemGeneratorBuilder, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
 
@@ -248,7 +248,8 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
     let filename = "lineitem.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
+    let mut generator =
+        LineItemGeneratorBuilder::new(cli.scale_factor, cli.part, cli.parts).build();
     for item in generator.iter() {
         writeln!(
             writer,

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -1545,7 +1545,7 @@ impl Iterator for OrderGeneratorIterator {
 
 /// The LINEITEM table
 #[derive(Debug, Clone, PartialEq)]
-pub struct LineItem {
+pub struct LineItem<'a> {
     /// Foreign key to ORDERS
     pub l_orderkey: i64,
     /// Foreign key to PART
@@ -1563,9 +1563,9 @@ pub struct LineItem {
     /// Tax percentage
     pub l_tax: f64,
     /// Return flag (R=returned, A=accepted, null=pending)
-    pub l_returnflag: String,
+    pub l_returnflag: &'a str,
     /// Line status (O=ordered, F=fulfilled)
-    pub l_linestatus: String,
+    pub l_linestatus: &'a str,
     /// Date shipped
     pub l_shipdate: TPCHDate,
     /// Date committed to ship
@@ -1573,14 +1573,14 @@ pub struct LineItem {
     /// Date received
     pub l_receiptdate: TPCHDate,
     /// Shipping instructions
-    pub l_shipinstruct: String,
+    pub l_shipinstruct: &'a str,
     /// Shipping mode
-    pub l_shipmode: String,
+    pub l_shipmode: &'a str,
     /// Variable length comment
-    pub l_comment: String,
+    pub l_comment: &'a str,
 }
 
-impl fmt::Display for LineItem {
+impl<'a> fmt::Display for LineItem<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -1771,7 +1771,7 @@ pub struct LineItemGenerator {
     line_number: i32,
 }
 
-impl LineItemGenerator {
+impl<'a> LineItemGenerator {
     fn new(
         distributions: &Distributions,
         text_pool: Arc<TextPool>,
@@ -1913,15 +1913,15 @@ impl LineItemGenerator {
         receipt_date += ship_date;
 
         let returned_flag = if TPCHDate::is_in_past(receipt_date) {
-            self.returned_flag_random.next_value().to_string()
+            self.returned_flag_random.next_value()
         } else {
-            "N".to_string()
+            "N"
         };
 
         let status = if TPCHDate::is_in_past(ship_date) {
-            "F".to_string() // Fulfilled
+            "F" // Fulfilled
         } else {
-            "O".to_string() // Open
+            "O" // Open
         };
 
         let ship_instructions = self.ship_instructions_random.next_value();
@@ -1942,9 +1942,9 @@ impl LineItemGenerator {
             l_shipdate: TPCHDate::new(ship_date),
             l_commitdate: TPCHDate::new(commit_date),
             l_receiptdate: TPCHDate::new(receipt_date),
-            l_shipinstruct: ship_instructions.to_string(),
-            l_shipmode: ship_mode.to_string(),
-            l_comment: comment.to_string(),
+            l_shipinstruct: ship_instructions,
+            l_shipmode: ship_mode,
+            l_comment: comment,
         }
     }
 
@@ -1955,7 +1955,7 @@ impl LineItemGenerator {
     /// Arguments:
     /// * `advance`: should internal sate be advanced before returning
     ///   the next `LineItem`?
-    fn next_line_item(&mut self, advance: bool) -> Option<LineItem> {
+    fn next_line_item(&'a mut self, advance: bool) -> Option<LineItem<'a>> {
         if advance {
             self.line_number += 1;
 
@@ -2001,7 +2001,7 @@ impl LineItemGenerator {
     pub fn iter(&mut self) -> LineItemIterator {
         LineItemIterator {
             advance: false,
-            generator: self
+            generator: self,
         }
     }
 }
@@ -2013,9 +2013,9 @@ pub struct LineItemIterator<'a> {
 }
 
 impl<'a> Iterator for LineItemIterator<'a> {
-    type Item = LineItem;
+    type Item = LineItem<'a>;
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn next(&'a mut self) -> Option<Self::Item> {
         let advance = self.advance;
         self.advance = true;
         self.generator.next_line_item(advance)

--- a/tpchgen/tests/integration_tests.rs
+++ b/tpchgen/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use tpchgen::generators::{
-    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    CustomerGenerator, LineItemGeneratorBuilder, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
 
@@ -196,7 +196,7 @@ fn test_orders_sf_0_001() {
 #[test]
 fn test_lineitem_sf_0_001() {
     test_generator(
-        |sf| LineItemGenerator::new(sf, 1, 1).iter(),
+        |sf| LineItemGeneratorBuilder::new(sf, 1, 1).iter(),
         "data/sf-0.001/lineitem.tbl.gz",
         0.001,
         |item| {
@@ -360,7 +360,7 @@ fn test_orders_sf_0_01() {
 #[test]
 fn test_lineitem_sf_0_01() {
     test_generator(
-        |sf| LineItemGenerator::new(sf, 1, 1).iter(),
+        |sf| LineItemGeneratorBuilder::new(sf, 1, 1).iter(),
         "data/sf-0.01/lineitem.tbl.gz",
         0.01,
         |item| {


### PR DESCRIPTION
This is a non-working attempt to keep the `Iterator` interface but return references

Specifically trying to compile it results in the following error

```
error: lifetime may not live long enough
    --> tpchgen/src/generators.rs:2021:9
     |
2015 | impl<'a> Iterator for LineItemIterator<'a> {
     |      -- lifetime `'a` defined here
...
2018 |     fn next(&mut self) -> Option<Self::Item> {
     |             - let's call the lifetime of this reference `'1`
...
2021 |         self.generator.next_line_item(advance)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
```

I couldn't figure out how to make it work, so I am going to work on a non iterator based approach