### PR TITLE
Unbox writer (3-5% faster)

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -102,12 +102,10 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
-fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<Box<dyn Write>> {
+fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<BufWriter<File>> {
     let path = cli.output_dir.join(filename);
     let file = File::create(path)?;
-    let writer = BufWriter::with_capacity(32 * 1024, file);
-
-    Ok(Box::new(writer))
+    Ok(BufWriter::with_capacity(32 * 1024, file))
 }
 
 fn generate_nation(cli: &Cli) -> io::Result<()> {


### PR DESCRIPTION
- Part of https://github.com/clflushopt/tpchgen-rs/issues/6


### Rationale
Using a `Box<dyn Write>` when there is only one actual writer implementation prevents certain inlining from occurring.

I noticed this while looking at some performance traces

### Changes
Use the actual types for the writer rather than `Box<dyn Write>`

I measured a small but measurable 3-5% improvement using `time target/release/tpchgen-cli -s 1 --output-dir=/tmp/tpchdbgen-rs`

| branch | time |
|--------|--------|
| `main` | 0m8.573s |
| this branch | 0m8.297s | 