### PR TITLE
(POC) Line item generation in parallel

### DIFF
--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -7,3 +7,7 @@ authors = ["clflushopt", "alamb"]
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
 tpchgen = { path = "../tpchgen" }
+tokio = { version = "1.44.1", features = ["full"]}
+futures = "0.3.31"
+num_cpus = "1.0"
+

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -14,11 +14,17 @@
 // The main function is the entry point for the CLI and it uses the `clap` crate
 // to parse the command line arguments and then generate the data.
 
+use std::collections::VecDeque;
 // tpchgen-cli/src/main.rs
 use clap::{Parser, ValueEnum};
+use futures::StreamExt;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Instant;
+use tokio::task::JoinSet;
+use tpchgen::dates::GenerateUtils;
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
@@ -61,7 +67,8 @@ enum Table {
     LineItem,
 }
 
-fn main() -> io::Result<()> {
+#[tokio::main]
+async fn main() -> io::Result<()> {
     // Parse command line arguments
     let cli = Cli::parse();
 
@@ -94,7 +101,7 @@ fn main() -> io::Result<()> {
             Table::PartSupp => generate_partsupp(&cli)?,
             Table::Customer => generate_customer(&cli)?,
             Table::Orders => generate_orders(&cli)?,
-            Table::LineItem => generate_lineitem(&cli)?,
+            Table::LineItem => generate_lineitem(&cli).await?,
         }
     }
 
@@ -242,32 +249,124 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
     writer.flush()
 }
 
-fn generate_lineitem(cli: &Cli) -> io::Result<()> {
+async fn generate_lineitem(cli: &Cli) -> io::Result<()> {
     let filename = "lineitem.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for item in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
-            item.l_orderkey,
-            item.l_partkey,
-            item.l_suppkey,
-            item.l_linenumber,
-            item.l_quantity,
-            item.l_extendedprice,
-            item.l_discount,
-            item.l_tax,
-            item.l_returnflag,
-            item.l_linestatus,
-            item.l_shipdate,
-            item.l_commitdate,
-            item.l_receiptdate,
-            item.l_shipinstruct,
-            item.l_shipmode,
-            item.l_comment
-        )?;
+    let start = Instant::now();
+    // figure out how to evenly divide the workload
+    let total_orders = GenerateUtils::calculate_row_count(
+        OrderGenerator::SCALE_BASE,
+        cli.scale_factor,
+        cli.part,
+        cli.parts,
+    );
+    // each order has some random number of line items between 1 and 7
+    // We target 10000 orders for an average 35000 line items per part
+    let num_parts = (total_orders / 10000) + 1;
+    let num_parts: i32 = num_parts.try_into().unwrap();
+    println!("Total orders: {total_orders}, num parts: {num_parts}");
+
+    let recycler = BufferRecycler::new();
+    let captured_recycler = &recycler;
+    // use all cores to make dta
+    let num_tasks = num_cpus::get() - 1;
+    println!("Using {num_tasks} parallel tasks");
+
+    let generators =
+        (0..num_parts).map(|part0| LineItemGenerator::new(cli.scale_factor, part0 + 1, num_parts));
+    // convert to an async stream to run on tokio
+    let mut stream = futures::stream::iter(generators)
+        // each job will generate a buffer holding its part  of the lineitem table
+        .map(async move |generator| {
+            let buffer = captured_recycler.new_buffer(1024 * 1024 * 8);
+            generate_buffer(generator, buffer).await
+        })
+        // run in parallel
+        .buffered(num_tasks);
+
+    // write it to the output as fast as we can go
+    let mut num_buffers = 0;
+    let mut num_bytes = 0;
+    while let Some(buffer) = stream.next().await {
+        //println!("writing buffer with {} bytes", buffer.len());
+        num_buffers += 1;
+        num_bytes += buffer.len();
+        writer.write_all(&buffer)?;
+        recycler.return_buffer(buffer);
     }
-    writer.flush()
+    let duration = start.elapsed();
+    let bytes_per_second = (num_bytes as f64 / duration.as_secs_f64()) as u64;
+    let gb_per_second = bytes_per_second as f64 / (1024.0 * 1024.0 * 1024.0);
+    let res = writer.flush();
+    println!("wrote {num_buffers} buffers, {num_bytes} bytes ({gb_per_second:02} GB bytes/sec)");
+    res
+}
+
+/// Generate a buffer of data on a different async task using the specified generator
+/// and return the results
+async fn generate_buffer(generator: LineItemGenerator<'static>, mut buffer: Vec<u8>) -> Vec<u8> {
+    let mut join_set = JoinSet::new();
+    // do the work in a task
+    join_set.spawn(async move {
+        for item in generator.iter() {
+            writeln!(
+                &mut buffer,
+                "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
+                item.l_orderkey,
+                item.l_partkey,
+                item.l_suppkey,
+                item.l_linenumber,
+                item.l_quantity,
+                item.l_extendedprice,
+                item.l_discount,
+                item.l_tax,
+                item.l_returnflag,
+                item.l_linestatus,
+                item.l_shipdate,
+                item.l_commitdate,
+                item.l_receiptdate,
+                item.l_shipinstruct,
+                item.l_shipmode,
+                item.l_comment
+            )
+            .expect("writing to in memory buffer is infallable");
+        }
+        buffer
+    });
+    // wait for the task to be done and return the result
+    let mut buffers = join_set.join_all().await;
+    assert_eq!(buffers.len(), 1);
+    buffers.pop().unwrap()
+}
+
+/// A simple buffer recycler to avoid allocating new buffers for each part
+struct BufferRecycler {
+    buffers: Mutex<VecDeque<Vec<u8>>>,
+}
+
+impl BufferRecycler {
+    fn new() -> Self {
+        Self {
+            buffers: Mutex::new(VecDeque::new()),
+        }
+    }
+    /// return a new empty buffer, with size bytes capacity
+    fn new_buffer(&self, size: usize) -> Vec<u8> {
+        let mut buffers = self.buffers.lock().unwrap();
+        if let Some(mut buffer) = buffers.pop_front() {
+            buffer.clear();
+            if size > buffer.capacity() {
+                buffer.reserve(size - buffer.capacity());
+            }
+            buffer
+        } else {
+            Vec::with_capacity(size)
+        }
+    }
+
+    fn return_buffer(&self, buffer: Vec<u8>) {
+        let mut buffers = self.buffers.lock().unwrap();
+        buffers.push_back(buffer);
+    }
 }


### PR DESCRIPTION
POC: Multi-threaded LineItem generation

- part of https://github.com/clflushopt/tpchgen-rs/issues/10

This is a POC showing how we might implement multi-threaded generation with the idea in https://github.com/clflushopt/tpchgen-rs/issues/10#issuecomment-2730451061


## `lineitem` at SF=10. From 37s --> 5s :bowtie: 

```shell
time target/release/tpchgen-cli -s 10 --tables line-item  --output-dir=/tmp/tpchdbgen-rs
```

| branch | time |
|--------|--------|
| main | 0m37.383s |
| this pr | 0m5.215s | 

It can generate lineitem at scale factor 100 in 32 seconds:

```
time target/release/tpchgen-cli --tables line-item -s 100 --output-dir=/tmp/tpchdbgen-rs
Total orders: 150000000, num parts: 15001
Using 15 parallel tasks
wrote 15001 buffers, 79579694556 bytes (2.392097480595112 GB bytes/sec)
Generation complete!

real	0m32.470s
user	5m35.949s
sys	0m14.225s
```




## Tokio vs Rayon
This uses tokio rather than Rayon. 

I tried to figure out something similar to `buffered` with Rayon but I couldn't find any way to limit the number of things that were buffered at once (as in if I have 16 cores, I only want to have at most 16 jobs running in parallel so as to avoid trying to buffer the entire output set)

I want to run the jobs  in parallel like this:

```
job1
job2
job3
...
jobN
```
And process the output in that order too, but also limit the number of jobs that are currently outstanding

