### PR TITLE
Add lifetimes to generators and generated types

### DIFF
--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -18,7 +18,7 @@ pub struct NationGenerator<'a> {
     text_pool: &'a TextPool,
 }
 
-impl<'a> Default for NationGenerator<'a> {
+impl Default for NationGenerator<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -46,7 +46,7 @@ impl<'a> NationGenerator<'a> {
 
     /// Returns an iterator over the nation rows
     pub fn iter(&self) -> NationGeneratorIterator {
-        NationGeneratorIterator::new(self.distributions.nations(), &self.text_pool)
+        NationGeneratorIterator::new(self.distributions.nations(), self.text_pool)
     }
 }
 
@@ -181,7 +181,7 @@ pub struct RegionGenerator<'a> {
     text_pool: &'a TextPool,
 }
 
-impl<'a> Default for RegionGenerator<'a> {
+impl Default for RegionGenerator<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -209,7 +209,7 @@ impl<'a> RegionGenerator<'a> {
 
     /// Returns an iterator over the region rows
     pub fn iter(&self) -> RegionGeneratorIterator {
-        RegionGeneratorIterator::new(self.distributions.regions(), &self.text_pool)
+        RegionGeneratorIterator::new(self.distributions.regions(), self.text_pool)
     }
 }
 
@@ -361,7 +361,7 @@ impl<'a> PartGenerator<'a> {
     pub fn iter(&self) -> PartGeneratorIterator {
         PartGeneratorIterator::new(
             &self.distributions,
-            &self.text_pool,
+            self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -427,7 +427,7 @@ impl<'a> PartGeneratorIterator<'a> {
         let mut container_random = RandomString::new(727633698, distributions.part_containers());
         let mut comment_random = RandomText::new(
             804159733,
-            &text_pool,
+            text_pool,
             PartGenerator::COMMENT_AVERAGE_LENGTH as f64,
         );
 
@@ -605,7 +605,7 @@ impl<'a> SupplierGenerator<'a> {
     pub fn iter(&self) -> SupplierGeneratorIterator {
         SupplierGeneratorIterator::new(
             &self.distributions,
-            &self.text_pool,
+            self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -667,7 +667,7 @@ impl<'a> SupplierGeneratorIterator<'a> {
         );
         let mut comment_random = RandomText::new(
             1341315363,
-            &text_pool,
+            text_pool,
             SupplierGenerator::COMMENT_AVERAGE_LENGTH as f64,
         );
         let mut bbb_comment_random =
@@ -761,7 +761,7 @@ impl<'a> SupplierGeneratorIterator<'a> {
     }
 }
 
-impl<'a> Iterator for SupplierGeneratorIterator<'a> {
+impl Iterator for SupplierGeneratorIterator<'_> {
     type Item = Supplier;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -876,7 +876,7 @@ impl<'a> CustomerGenerator<'a> {
     pub fn iter(&self) -> CustomerGeneratorIterator {
         CustomerGeneratorIterator::new(
             &self.distributions,
-            &self.text_pool,
+            self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -937,7 +937,7 @@ impl<'a> CustomerGeneratorIterator<'a> {
             RandomString::new(1140279430, distributions.market_segments());
         let mut comment_random = RandomText::new(
             1335826707,
-            &text_pool,
+            text_pool,
             CustomerGenerator::COMMENT_AVERAGE_LENGTH as f64,
         );
 
@@ -979,7 +979,7 @@ impl<'a> CustomerGeneratorIterator<'a> {
     }
 }
 
-impl<'a> Iterator for CustomerGeneratorIterator<'a> {
+impl Iterator for CustomerGeneratorIterator<'_> {
     type Item = Customer;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1076,7 +1076,7 @@ impl<'a> PartSupplierGenerator<'a> {
         let scale_base = PartGenerator::SCALE_BASE;
 
         PartSupplierGeneratorIterator::new(
-            &self.text_pool,
+            self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 scale_base,
@@ -1133,7 +1133,7 @@ impl<'a> PartSupplierGeneratorIterator<'a> {
         );
         let mut comment_random = RandomText::new_with_expected_row_count(
             1961692154,
-            &text_pool,
+            text_pool,
             PartSupplierGenerator::COMMENT_AVERAGE_LENGTH as f64,
             PartSupplierGenerator::SUPPLIERS_PER_PART,
         );
@@ -1315,7 +1315,7 @@ impl<'a> OrderGenerator<'a> {
     pub fn iter(&self) -> OrderGeneratorIterator {
         OrderGeneratorIterator::new(
             &self.distributions,
-            &self.text_pool,
+            self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
@@ -1413,7 +1413,7 @@ impl<'a> OrderGeneratorIterator<'a> {
 
         let mut comment_random = RandomText::new(
             276090261,
-            &text_pool,
+            text_pool,
             OrderGenerator::COMMENT_AVERAGE_LENGTH as f64,
         );
 
@@ -1669,7 +1669,7 @@ impl<'a> LineItemGenerator<'a> {
     pub fn iter(&self) -> LineItemGeneratorIterator {
         LineItemGeneratorIterator::new(
             &self.distributions,
-            &self.text_pool,
+            self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 OrderGenerator::SCALE_BASE,
@@ -1837,7 +1837,7 @@ impl<'a> LineItemGeneratorIterator<'a> {
         );
         let mut comment_random = RandomText::new_with_expected_row_count(
             1095462486,
-            &text_pool,
+            text_pool,
             LineItemGenerator::COMMENT_AVERAGE_LENGTH as f64,
             OrderGenerator::LINE_COUNT_MAX,
         );

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -8,24 +8,23 @@ use crate::random::RandomBoundedLong;
 use crate::random::RandomPhoneNumber;
 use crate::random::RowRandomInt;
 use crate::text::TextPool;
-use std::sync::Arc;
 
 use crate::dates::{GenerateUtils, TPCHDate};
 use crate::random::{RandomBoundedInt, RandomString, RandomStringSequence, RandomText};
 
 /// Generator for Nation table data
-pub struct NationGenerator {
+pub struct NationGenerator<'a> {
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl Default for NationGenerator {
+impl<'a> Default for NationGenerator<'a> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl NationGenerator {
+impl<'a> NationGenerator<'a> {
     /// Creates a new NationGenerator with default distributions and text pool
     pub fn new() -> Self {
         Self::new_with_distributions_and_text_pool(
@@ -37,7 +36,7 @@ impl NationGenerator {
     /// Creates a NationGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         NationGenerator {
             distributions,
@@ -51,7 +50,7 @@ impl NationGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a NationGenerator {
+impl<'a> IntoIterator for &'a NationGenerator<'a> {
     type Item = Nation;
     type IntoIter = NationGeneratorIterator<'a>;
 
@@ -177,18 +176,18 @@ impl Region {
 }
 
 /// Generator for Region table data
-pub struct RegionGenerator {
+pub struct RegionGenerator<'a> {
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl Default for RegionGenerator {
+impl<'a> Default for RegionGenerator<'a> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RegionGenerator {
+impl<'a> RegionGenerator<'a> {
     /// Creates a new RegionGenerator with default distributions and text pool
     pub fn new() -> Self {
         Self::new_with_distributions_and_text_pool(
@@ -200,7 +199,7 @@ impl RegionGenerator {
     /// Creates a RegionGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         RegionGenerator {
             distributions,
@@ -214,7 +213,7 @@ impl RegionGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a RegionGenerator {
+impl<'a> IntoIterator for &'a RegionGenerator<'a> {
     type Item = Region;
     type IntoIter = RegionGeneratorIterator<'a>;
 
@@ -309,15 +308,15 @@ impl fmt::Display for Part {
 }
 
 /// Generator for Part table data
-pub struct PartGenerator {
+pub struct PartGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl PartGenerator {
+impl<'a> PartGenerator<'a> {
     /// Base scale for part generation
     const SCALE_BASE: i32 = 200_000;
 
@@ -347,7 +346,7 @@ impl PartGenerator {
         part: i32,
         part_count: i32,
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         PartGenerator {
             scale_factor,
@@ -379,7 +378,7 @@ impl PartGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a PartGenerator {
+impl<'a> IntoIterator for &'a PartGenerator<'a> {
     type Item = Part;
     type IntoIter = PartGeneratorIterator<'a>;
 
@@ -547,15 +546,15 @@ impl fmt::Display for Supplier {
 }
 
 /// Generator for Supplier table data
-pub struct SupplierGenerator {
+pub struct SupplierGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl SupplierGenerator {
+impl<'a> SupplierGenerator<'a> {
     /// Base scale for supplier generation
     const SCALE_BASE: i32 = 10_000;
 
@@ -566,9 +565,9 @@ impl SupplierGenerator {
     const COMMENT_AVERAGE_LENGTH: i32 = 63;
 
     // Better Business Bureau comment constants
-    pub const BBB_BASE_TEXT: &str = "Customer ";
-    pub const BBB_COMPLAINT_TEXT: &str = "Complaints";
-    pub const BBB_RECOMMEND_TEXT: &str = "Recommends";
+    pub const BBB_BASE_TEXT: &'static str = "Customer ";
+    pub const BBB_COMPLAINT_TEXT: &'static str = "Complaints";
+    pub const BBB_RECOMMEND_TEXT: &'static str = "Recommends";
     pub const BBB_COMMENT_LENGTH: usize =
         Self::BBB_BASE_TEXT.len() + Self::BBB_COMPLAINT_TEXT.len();
     pub const BBB_COMMENTS_PER_SCALE_BASE: i32 = 10;
@@ -591,7 +590,7 @@ impl SupplierGenerator {
         part: i32,
         part_count: i32,
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         SupplierGenerator {
             scale_factor,
@@ -623,7 +622,7 @@ impl SupplierGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a SupplierGenerator {
+impl<'a> IntoIterator for &'a SupplierGenerator<'a> {
     type Item = Supplier;
     type IntoIter = SupplierGeneratorIterator<'a>;
 
@@ -827,15 +826,15 @@ impl fmt::Display for Customer {
 }
 
 /// Generator for Customer table data
-pub struct CustomerGenerator {
+pub struct CustomerGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl CustomerGenerator {
+impl<'a> CustomerGenerator<'a> {
     /// Base scale for customer generation
     const SCALE_BASE: i32 = 150_000;
 
@@ -862,7 +861,7 @@ impl CustomerGenerator {
         part: i32,
         part_count: i32,
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         CustomerGenerator {
             scale_factor,
@@ -894,7 +893,7 @@ impl CustomerGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a CustomerGenerator {
+impl<'a> IntoIterator for &'a CustomerGenerator<'a> {
     type Item = Customer;
     type IntoIter = CustomerGeneratorIterator<'a>;
 
@@ -1028,14 +1027,14 @@ impl fmt::Display for PartSupp {
 }
 
 /// Generator for PartSupplier table data
-pub struct PartSupplierGenerator {
+pub struct PartSupplierGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl PartSupplierGenerator {
+impl<'a> PartSupplierGenerator<'a> {
     /// Base scale for part-supplier generation
     const SUPPLIERS_PER_PART: i32 = 4;
 
@@ -1061,7 +1060,7 @@ impl PartSupplierGenerator {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         PartSupplierGenerator {
             scale_factor,
@@ -1095,7 +1094,7 @@ impl PartSupplierGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a PartSupplierGenerator {
+impl<'a> IntoIterator for &'a PartSupplierGenerator<'a> {
     type Item = PartSupp;
     type IntoIter = PartSupplierGeneratorIterator<'a>;
 
@@ -1254,15 +1253,15 @@ impl fmt::Display for Order {
 }
 
 /// Generator for Order table data
-pub struct OrderGenerator {
+pub struct OrderGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl OrderGenerator {
+impl<'a> OrderGenerator<'a> {
     /// Base scale for order generation
     pub const SCALE_BASE: i32 = 1_500_000;
 
@@ -1297,7 +1296,7 @@ impl OrderGenerator {
         part: i32,
         part_count: i32,
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         OrderGenerator {
             scale_factor,
@@ -1353,7 +1352,7 @@ impl OrderGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a OrderGenerator {
+impl<'a> IntoIterator for &'a OrderGenerator<'a> {
     type Item = Order;
     type IntoIter = OrderGeneratorIterator<'a>;
 
@@ -1605,15 +1604,15 @@ impl fmt::Display for LineItem {
 }
 
 /// Generator for LineItem table data
-pub struct LineItemGenerator {
+pub struct LineItemGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
     distributions: Distributions,
-    text_pool: Arc<TextPool>,
+    text_pool: &'a TextPool,
 }
 
-impl LineItemGenerator {
+impl<'a> LineItemGenerator<'a> {
     // Constants for line item generation
     const QUANTITY_MIN: i32 = 1;
     const QUANTITY_MAX: i32 = 50;
@@ -1651,7 +1650,7 @@ impl LineItemGenerator {
         part: i32,
         part_count: i32,
         distributions: Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
     ) -> Self {
         LineItemGenerator {
             scale_factor,
@@ -1737,7 +1736,7 @@ impl LineItemGenerator {
     }
 }
 
-impl<'a> IntoIterator for &'a LineItemGenerator {
+impl<'a> IntoIterator for &'a LineItemGenerator<'a> {
     type Item = LineItem;
     type IntoIter = LineItemGeneratorIterator<'a>;
 

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -51,9 +51,9 @@ impl NationGenerator {
     }
 }
 
-impl IntoIterator for NationGenerator {
+impl<'a> IntoIterator for &'a NationGenerator {
     type Item = Nation;
-    type IntoIter = NationGeneratorIterator;
+    type IntoIter = NationGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -96,16 +96,16 @@ impl Nation {
 }
 
 /// Iterator that generates Nation rows
-pub struct NationGeneratorIterator {
+pub struct NationGeneratorIterator<'a> {
     nations: Distribution,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
     index: usize,
 }
 
-impl NationGeneratorIterator {
+impl<'a> NationGeneratorIterator<'a> {
     const COMMENT_AVERAGE_LENGTH: i32 = 72;
 
-    fn new(nations: &Distribution, text_pool: &TextPool) -> Self {
+    fn new(nations: &Distribution, text_pool: &'a TextPool) -> Self {
         NationGeneratorIterator {
             nations: nations.clone(),
             comment_random: RandomText::new(
@@ -118,7 +118,7 @@ impl NationGeneratorIterator {
     }
 }
 
-impl Iterator for NationGeneratorIterator {
+impl<'a> Iterator for NationGeneratorIterator<'a> {
     type Item = Nation;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -214,9 +214,9 @@ impl RegionGenerator {
     }
 }
 
-impl IntoIterator for RegionGenerator {
+impl<'a> IntoIterator for &'a RegionGenerator {
     type Item = Region;
-    type IntoIter = RegionGeneratorIterator;
+    type IntoIter = RegionGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -224,16 +224,16 @@ impl IntoIterator for RegionGenerator {
 }
 
 /// Iterator that generates Region rows
-pub struct RegionGeneratorIterator {
+pub struct RegionGeneratorIterator<'a> {
     regions: Distribution,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
     index: usize,
 }
 
-impl RegionGeneratorIterator {
+impl<'a> RegionGeneratorIterator<'a> {
     const COMMENT_AVERAGE_LENGTH: i32 = 72;
 
-    fn new(regions: Distribution, text_pool: &TextPool) -> Self {
+    fn new(regions: Distribution, text_pool: &'a TextPool) -> Self {
         RegionGeneratorIterator {
             regions,
             comment_random: RandomText::new(
@@ -246,7 +246,7 @@ impl RegionGeneratorIterator {
     }
 }
 
-impl Iterator for RegionGeneratorIterator {
+impl<'a> Iterator for RegionGeneratorIterator<'a> {
     type Item = Region;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -362,7 +362,7 @@ impl PartGenerator {
     pub fn iter(&self) -> PartGeneratorIterator {
         PartGeneratorIterator::new(
             &self.distributions,
-            self.text_pool.clone(),
+            &self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -379,9 +379,9 @@ impl PartGenerator {
     }
 }
 
-impl IntoIterator for PartGenerator {
+impl<'a> IntoIterator for &'a PartGenerator {
     type Item = Part;
-    type IntoIter = PartGeneratorIterator;
+    type IntoIter = PartGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -389,24 +389,24 @@ impl IntoIterator for PartGenerator {
 }
 
 /// Iterator that generates Part rows
-pub struct PartGeneratorIterator {
+pub struct PartGeneratorIterator<'a> {
     name_random: RandomStringSequence,
     manufacturer_random: RandomBoundedInt,
     brand_random: RandomBoundedInt,
     type_random: RandomString,
     size_random: RandomBoundedInt,
     container_random: RandomString,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
 
     start_index: i64,
     row_count: i64,
     index: i64,
 }
 
-impl PartGeneratorIterator {
+impl<'a> PartGeneratorIterator<'a> {
     fn new(
         distributions: &Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
         start_index: i64,
         row_count: i64,
     ) -> Self {
@@ -487,7 +487,7 @@ impl PartGeneratorIterator {
     }
 }
 
-impl Iterator for PartGeneratorIterator {
+impl<'a> Iterator for PartGeneratorIterator<'a> {
     type Item = Part;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -606,7 +606,7 @@ impl SupplierGenerator {
     pub fn iter(&self) -> SupplierGeneratorIterator {
         SupplierGeneratorIterator::new(
             &self.distributions,
-            self.text_pool.clone(),
+            &self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -623,9 +623,9 @@ impl SupplierGenerator {
     }
 }
 
-impl IntoIterator for SupplierGenerator {
+impl<'a> IntoIterator for &'a SupplierGenerator {
     type Item = Supplier;
-    type IntoIter = SupplierGeneratorIterator;
+    type IntoIter = SupplierGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -633,12 +633,12 @@ impl IntoIterator for SupplierGenerator {
 }
 
 /// Iterator that generates Supplier rows
-pub struct SupplierGeneratorIterator {
+pub struct SupplierGeneratorIterator<'a> {
     address_random: RandomAlphaNumeric,
     nation_key_random: RandomBoundedInt,
     phone_random: RandomPhoneNumber,
     account_balance_random: RandomBoundedInt,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
     bbb_comment_random: RandomBoundedInt,
     bbb_junk_random: RowRandomInt,
     bbb_offset_random: RowRandomInt,
@@ -649,10 +649,10 @@ pub struct SupplierGeneratorIterator {
     index: i64,
 }
 
-impl SupplierGeneratorIterator {
+impl<'a> SupplierGeneratorIterator<'a> {
     fn new(
         distributions: &Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
         start_index: i64,
         row_count: i64,
     ) -> Self {
@@ -762,7 +762,7 @@ impl SupplierGeneratorIterator {
     }
 }
 
-impl Iterator for SupplierGeneratorIterator {
+impl<'a> Iterator for SupplierGeneratorIterator<'a> {
     type Item = Supplier;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -877,7 +877,7 @@ impl CustomerGenerator {
     pub fn iter(&self) -> CustomerGeneratorIterator {
         CustomerGeneratorIterator::new(
             &self.distributions,
-            self.text_pool.clone(),
+            &self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
                 self.scale_factor,
@@ -894,9 +894,9 @@ impl CustomerGenerator {
     }
 }
 
-impl IntoIterator for CustomerGenerator {
+impl<'a> IntoIterator for &'a CustomerGenerator {
     type Item = Customer;
-    type IntoIter = CustomerGeneratorIterator;
+    type IntoIter = CustomerGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -904,23 +904,23 @@ impl IntoIterator for CustomerGenerator {
 }
 
 /// Iterator that generates Customer rows
-pub struct CustomerGeneratorIterator {
+pub struct CustomerGeneratorIterator<'a> {
     address_random: RandomAlphaNumeric,
     nation_key_random: RandomBoundedInt,
     phone_random: RandomPhoneNumber,
     account_balance_random: RandomBoundedInt,
     market_segment_random: RandomString,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
 
     start_index: i64,
     row_count: i64,
     index: i64,
 }
 
-impl CustomerGeneratorIterator {
+impl<'a> CustomerGeneratorIterator<'a> {
     fn new(
         distributions: &Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
         start_index: i64,
         row_count: i64,
     ) -> Self {
@@ -980,7 +980,7 @@ impl CustomerGeneratorIterator {
     }
 }
 
-impl Iterator for CustomerGeneratorIterator {
+impl<'a> Iterator for CustomerGeneratorIterator<'a> {
     type Item = Customer;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1077,7 +1077,7 @@ impl PartSupplierGenerator {
         let scale_base = PartGenerator::SCALE_BASE;
 
         PartSupplierGeneratorIterator::new(
-            self.text_pool.clone(),
+            &self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 scale_base,
@@ -1095,9 +1095,9 @@ impl PartSupplierGenerator {
     }
 }
 
-impl IntoIterator for PartSupplierGenerator {
+impl<'a> IntoIterator for &'a PartSupplierGenerator {
     type Item = PartSupp;
-    type IntoIter = PartSupplierGeneratorIterator;
+    type IntoIter = PartSupplierGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1105,21 +1105,21 @@ impl IntoIterator for PartSupplierGenerator {
 }
 
 /// Iterator that generates PartSupplier rows
-pub struct PartSupplierGeneratorIterator {
+pub struct PartSupplierGeneratorIterator<'a> {
     scale_factor: f64,
     start_index: i64,
     row_count: i64,
 
     available_quantity_random: RandomBoundedInt,
     supply_cost_random: RandomBoundedInt,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
 
     index: i64,
     part_supplier_number: i32,
 }
 
-impl PartSupplierGeneratorIterator {
-    fn new(text_pool: Arc<TextPool>, scale_factor: f64, start_index: i64, row_count: i64) -> Self {
+impl<'a> PartSupplierGeneratorIterator<'a> {
+    fn new(text_pool: &'a TextPool, scale_factor: f64, start_index: i64, row_count: i64) -> Self {
         let mut available_quantity_random = RandomBoundedInt::new_with_seeds_per_row(
             1671059989,
             PartSupplierGenerator::AVAILABLE_QUANTITY_MIN,
@@ -1187,7 +1187,7 @@ impl PartSupplierGeneratorIterator {
     }
 }
 
-impl Iterator for PartSupplierGeneratorIterator {
+impl<'a> Iterator for PartSupplierGeneratorIterator<'a> {
     type Item = PartSupp;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1312,7 +1312,7 @@ impl OrderGenerator {
     pub fn iter(&self) -> OrderGeneratorIterator {
         OrderGeneratorIterator::new(
             &self.distributions,
-            self.text_pool.clone(),
+            &self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
@@ -1353,9 +1353,9 @@ impl OrderGenerator {
     }
 }
 
-impl IntoIterator for OrderGenerator {
+impl<'a> IntoIterator for &'a OrderGenerator {
     type Item = Order;
-    type IntoIter = OrderGeneratorIterator;
+    type IntoIter = OrderGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1363,13 +1363,13 @@ impl IntoIterator for OrderGenerator {
 }
 
 /// Iterator that generates Order rows
-pub struct OrderGeneratorIterator {
+pub struct OrderGeneratorIterator<'a> {
     order_date_random: RandomBoundedInt,
     line_count_random: RandomBoundedInt,
     customer_key_random: RandomBoundedLong,
     order_priority_random: RandomString,
     clerk_random: RandomBoundedInt,
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
 
     // For line item simulation to determine order status
     line_quantity_random: RandomBoundedInt,
@@ -1385,10 +1385,10 @@ pub struct OrderGeneratorIterator {
     index: i64,
 }
 
-impl OrderGeneratorIterator {
+impl<'a> OrderGeneratorIterator<'a> {
     fn new(
         distributions: &Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
         scale_factor: f64,
         start_index: i64,
         row_count: i64,
@@ -1513,7 +1513,7 @@ impl OrderGeneratorIterator {
     }
 }
 
-impl Iterator for OrderGeneratorIterator {
+impl<'a> Iterator for OrderGeneratorIterator<'a> {
     type Item = Order;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1666,7 +1666,7 @@ impl LineItemGenerator {
     pub fn iter(&self) -> LineItemGeneratorIterator {
         LineItemGeneratorIterator::new(
             &self.distributions,
-            self.text_pool.clone(),
+            &self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
                 OrderGenerator::SCALE_BASE,
@@ -1737,9 +1737,9 @@ impl LineItemGenerator {
     }
 }
 
-impl IntoIterator for LineItemGenerator {
+impl<'a> IntoIterator for &'a LineItemGenerator {
     type Item = LineItem;
-    type IntoIter = LineItemGeneratorIterator;
+    type IntoIter = LineItemGeneratorIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -1747,7 +1747,7 @@ impl IntoIterator for LineItemGenerator {
 }
 
 /// Iterator that generates LineItem rows
-pub struct LineItemGeneratorIterator {
+pub struct LineItemGeneratorIterator<'a> {
     order_date_random: RandomBoundedInt,
     line_count_random: RandomBoundedInt,
 
@@ -1767,7 +1767,7 @@ pub struct LineItemGeneratorIterator {
     ship_instructions_random: RandomString,
     ship_mode_random: RandomString,
 
-    comment_random: RandomText,
+    comment_random: RandomText<'a>,
 
     scale_factor: f64,
     start_index: i64,
@@ -1779,10 +1779,10 @@ pub struct LineItemGeneratorIterator {
     line_number: i32,
 }
 
-impl LineItemGeneratorIterator {
+impl<'a> LineItemGeneratorIterator<'a> {
     fn new(
         distributions: &Distributions,
-        text_pool: Arc<TextPool>,
+        text_pool: &'a TextPool,
         scale_factor: f64,
         start_index: i64,
         row_count: i64,
@@ -1954,7 +1954,7 @@ impl LineItemGeneratorIterator {
     }
 }
 
-impl Iterator for LineItemGeneratorIterator {
+impl<'a> Iterator for LineItemGeneratorIterator<'a> {
     type Item = LineItem;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -425,19 +425,19 @@ impl Display for PhoneNumberInstance {
 
 /// Fetches random strings from a distribution.
 #[derive(Debug, Clone)]
-pub struct RandomString {
+pub struct RandomString<'a> {
     inner: RowRandomInt,
-    distribution: Distribution,
+    distribution: &'a Distribution,
 }
 
-impl RandomString {
-    pub fn new(seed: i64, distribution: &Distribution) -> Self {
-        Self::new_with_expected_row_count(seed, distribution.clone(), 1)
+impl<'a> RandomString<'a> {
+    pub fn new(seed: i64, distribution: &'a Distribution) -> Self {
+        Self::new_with_expected_row_count(seed, distribution, 1)
     }
 
     pub fn new_with_expected_row_count(
         seed: i64,
-        distribution: Distribution,
+        distribution: &'a Distribution,
         seeds_per_row: i32,
     ) -> Self {
         Self {
@@ -446,7 +446,7 @@ impl RandomString {
         }
     }
 
-    pub fn next_value(&mut self) -> &str {
+    pub fn next_value(&mut self) -> &'a str {
         self.distribution.random_value(&mut self.inner)
     }
 

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -461,31 +461,31 @@ impl RandomString {
 }
 
 /// Generates sequences of random sequence of strings from a distribution
-pub struct RandomStringSequence {
+pub struct RandomStringSequence<'a> {
     inner: RowRandomInt,
     count: i32,
-    distribution: Distribution,
+    distribution: &'a Distribution,
 }
 
-impl RandomStringSequence {
-    pub fn new(seed: i64, count: i32, distribution: &Distribution) -> Self {
+impl<'a> RandomStringSequence<'a> {
+    pub fn new(seed: i64, count: i32, distribution: &'a Distribution) -> Self {
         Self::new_with_expected_row_count(seed, count, distribution, 1)
     }
 
     pub fn new_with_expected_row_count(
         seed: i64,
         count: i32,
-        distribution: &Distribution,
+        distribution: &'a Distribution,
         seeds_per_row: i32,
     ) -> Self {
         Self {
             inner: RowRandomInt::new(seed, distribution.size() as i32 * seeds_per_row),
             count,
-            distribution: distribution.clone(),
+            distribution,
         }
     }
 
-    pub fn next_value(&mut self) -> StringSequenceInstance<'_> {
+    pub fn next_value(&mut self) -> StringSequenceInstance<'a> {
         // Get all values from the distribution
         let mut values: Vec<&str> = self
             .distribution
@@ -577,7 +577,7 @@ impl<'a> RandomText<'a> {
         }
     }
 
-    pub fn next_value(&mut self) -> &str {
+    pub fn next_value(&mut self) -> &'a str {
         let offset = self
             .inner
             .next_int(0, self.text_pool.size() - self.max_length);

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -548,30 +548,30 @@ impl Display for StringSequenceInstance<'_> {
 
 /// Generates random text according to TPC-H spec
 #[derive(Debug, Clone)]
-pub struct RandomText {
+pub struct RandomText<'a> {
     inner: RowRandomInt,
-    text_pool: TextPool,
+    text_pool: &'a TextPool,
     min_length: i32,
     max_length: i32,
 }
 
-impl RandomText {
+impl<'a> RandomText<'a> {
     const LOW_LENGTH_MULTIPLIER: f64 = 0.4;
     const HIGH_LENGTH_MULTIPLIER: f64 = 1.6;
 
-    pub fn new(seed: i64, text_pool: &TextPool, average_text_length: f64) -> Self {
+    pub fn new(seed: i64, text_pool: &'a TextPool, average_text_length: f64) -> Self {
         Self::new_with_expected_row_count(seed, text_pool, average_text_length, 1)
     }
 
     pub fn new_with_expected_row_count(
         seed: i64,
-        text_pool: &TextPool,
+        text_pool: &'a TextPool,
         average_text_length: f64,
         expected_row_count: i32,
     ) -> Self {
         Self {
             inner: RowRandomInt::new(seed, expected_row_count * 2),
-            text_pool: text_pool.clone(),
+            text_pool,
             min_length: (average_text_length * Self::LOW_LENGTH_MULTIPLIER) as i32,
             max_length: (average_text_length * Self::HIGH_LENGTH_MULTIPLIER) as i32,
         }

--- a/tpchgen/src/text.rs
+++ b/tpchgen/src/text.rs
@@ -9,7 +9,7 @@ use crate::{
     distribution::{Distribution, Distributions},
     random::RowRandomInt,
 };
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 /// Pool of random text that follows TPC-H grammar.
 #[derive(Debug, Clone)]
@@ -20,7 +20,7 @@ pub struct TextPool {
 
 /// The default global text pool is lazily initialized once and shared across
 /// all the table generators.
-static DEFAULT_TEXT_POOL: OnceLock<Arc<TextPool>> = OnceLock::new();
+static DEFAULT_TEXT_POOL: OnceLock<TextPool> = OnceLock::new();
 
 impl TextPool {
     /// Default text pool size.
@@ -30,13 +30,9 @@ impl TextPool {
 
     /// Returns the default text pool or initializes for the first time if
     /// that's not already the case.
-    pub fn get_or_init_default() -> Arc<Self> {
-        Arc::clone(DEFAULT_TEXT_POOL.get_or_init(|| {
-            Arc::new(Self::new(
-                Self::DEFAULT_TEXT_POOL_SIZE,
-                &Distributions::default(),
-            ))
-        }))
+    pub fn get_or_init_default() -> &'static Self {
+        DEFAULT_TEXT_POOL
+            .get_or_init(|| Self::new(Self::DEFAULT_TEXT_POOL_SIZE, &Distributions::default()))
     }
 
     /// Returns a new text pool with a predefined size and set of distributions.


### PR DESCRIPTION
Adds lifetimes to all generators and relevant types to remove many cases of using `String`.

Essentially this ties the lifetimes of all strings that aren't modified to either the `TextPool` or `Distribution`. This also remove the `Arc` around `TextPool` to help accommodate this.

There's still a few `String` instances when `format!` (or other string formatting) is needed. I opted to hold off on changing those in this pr.