### PR TITLE
Remove more String copying (5% faster)

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -147,17 +147,7 @@ fn generate_supplier(cli: &Cli) -> io::Result<()> {
 
     let generator = SupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for supplier in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|{}|{:.2}|{}|",
-            supplier.s_suppkey,
-            supplier.s_name,
-            supplier.s_address,
-            supplier.s_nationkey,
-            supplier.s_phone,
-            supplier.s_acctbal,
-            supplier.s_comment
-        )?;
+        writeln!(writer, "{supplier}")?;
     }
     writer.flush()
 }
@@ -179,18 +169,7 @@ fn generate_customer(cli: &Cli) -> io::Result<()> {
 
     let generator = CustomerGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for customer in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|{}|{:.2}|{}|{}|",
-            customer.c_custkey,
-            customer.c_name,
-            customer.c_address,
-            customer.c_nationkey,
-            customer.c_phone,
-            customer.c_acctbal,
-            customer.c_mktsegment,
-            customer.c_comment
-        )?;
+        writeln!(writer, "{customer}",)?;
     }
     writer.flush()
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -114,11 +114,7 @@ fn generate_nation(cli: &Cli) -> io::Result<()> {
 
     let generator = NationGenerator::new();
     for nation in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|",
-            nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment
-        )?;
+        writeln!(writer, "{nation}",)?;
     }
     writer.flush()
 }
@@ -129,11 +125,7 @@ fn generate_region(cli: &Cli) -> io::Result<()> {
 
     let generator = RegionGenerator::new();
     for region in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|",
-            region.r_regionkey, region.r_name, region.r_comment
-        )?;
+        writeln!(writer, "{region}",)?;
     }
     writer.flush()
 }
@@ -144,19 +136,7 @@ fn generate_part(cli: &Cli) -> io::Result<()> {
 
     let generator = PartGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for part in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}|",
-            part.p_partkey,
-            part.p_name,
-            part.p_mfgr,
-            part.p_brand,
-            part.p_type,
-            part.p_size,
-            part.p_container,
-            part.p_retailprice,
-            part.p_comment
-        )?;
+        writeln!(writer, "{part}",)?;
     }
     writer.flush()
 }
@@ -188,11 +168,7 @@ fn generate_partsupp(cli: &Cli) -> io::Result<()> {
 
     let generator = PartSupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for ps in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{:.2}|{}|",
-            ps.ps_partkey, ps.ps_suppkey, ps.ps_availqty, ps.ps_supplycost, ps.ps_comment
-        )?;
+        writeln!(writer, "{ps}")?;
     }
     writer.flush()
 }
@@ -225,19 +201,7 @@ fn generate_orders(cli: &Cli) -> io::Result<()> {
 
     let generator = OrderGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for order in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}|",
-            order.o_orderkey,
-            order.o_custkey,
-            order.o_orderstatus,
-            order.o_totalprice,
-            order.o_orderdate,
-            order.o_orderpriority,
-            order.o_clerk,
-            order.o_shippriority,
-            order.o_comment
-        )?;
+        writeln!(writer, "{order}")?;
     }
     writer.flush()
 }
@@ -248,26 +212,7 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
 
     let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
     for item in generator.iter() {
-        writeln!(
-            writer,
-            "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
-            item.l_orderkey,
-            item.l_partkey,
-            item.l_suppkey,
-            item.l_linenumber,
-            item.l_quantity,
-            item.l_extendedprice,
-            item.l_discount,
-            item.l_tax,
-            item.l_returnflag,
-            item.l_linestatus,
-            item.l_shipdate,
-            item.l_commitdate,
-            item.l_receiptdate,
-            item.l_shipinstruct,
-            item.l_shipmode,
-            item.l_comment
-        )?;
+        writeln!(writer, "{item}")?;
     }
     writer.flush()
 }

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -281,6 +281,22 @@ impl<'a> Iterator for RegionGeneratorIterator<'a> {
     }
 }
 
+/// A Part Manufacturer, formatted as "Manufacturer#<n>"
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PartManufacturerName(i32);
+
+impl PartManufacturerName {
+    pub fn new(value: i32) -> Self {
+        PartManufacturerName(value)
+    }
+}
+
+impl fmt::Display for PartManufacturerName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Manufacturer#{}", self.0)
+    }
+}
+
 /// The PART table
 ///
 /// The Display trait is implemented to format the line item data as a string
@@ -296,8 +312,8 @@ pub struct Part<'a> {
     pub p_partkey: i64,
     /// Part name
     pub p_name: StringSequenceInstance<'a>,
-    /// Part manufacturer. Formatted as "Manufacturer#<n>"
-    pub p_mfgr: i32,
+    /// Part manufacturer.
+    pub p_mfgr: PartManufacturerName,
     /// Part brand. Formatted as "Brand#<n>"
     pub p_brand: i32,
     /// Part type
@@ -316,7 +332,7 @@ impl fmt::Display for Part<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}|{}|Manufacturer#{}|Brand#{}|{}|{}|{}|{:.2}|{}|",
+            "{}|{}|{}|Brand#{}|{}|{}|{}|{:.2}|{}|",
             self.p_partkey,
             self.p_name,
             self.p_mfgr,
@@ -487,7 +503,7 @@ impl<'a> PartGeneratorIterator<'a> {
         Part {
             p_partkey: part_key,
             p_name: name,
-            p_mfgr: manufacturer,
+            p_mfgr: PartManufacturerName::new(manufacturer),
             p_brand: brand,
             p_type: self.type_random.next_value(),
             p_size: self.size_random.next_value(),

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -897,7 +897,7 @@ impl fmt::Display for CustomerName {
 pub struct Customer<'a> {
     /// Primary key
     pub c_custkey: i64,
-    /// Customer name: Formatted as "Customer#<n>"
+    /// Customer name
     pub c_name: CustomerName,
     /// Customer address
     pub c_address: String,
@@ -1329,6 +1329,23 @@ impl<'a> Iterator for PartSupplierGeneratorIterator<'a> {
     }
 }
 
+/// A clerk name, formatted as "Clerk#<n>"
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClerkName(i32);
+
+impl ClerkName {
+    /// Creates a new ClerkName with the given value
+    pub fn new(value: i32) -> Self {
+        ClerkName(value)
+    }
+}
+
+impl fmt::Display for ClerkName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Clerk#{:09}", self.0)
+    }
+}
+
 /// The ORDERS table
 ///
 /// The Display trait is implemented to format the line item data as a string
@@ -1351,8 +1368,8 @@ pub struct Order<'a> {
     pub o_orderdate: TPCHDate,
     /// Order priority
     pub o_orderpriority: &'a str,
-    /// Clerk who processed the order. Formatted as "Clerk#<n>"
-    pub o_clerk: i32,
+    /// Clerk who processed the order.
+    pub o_clerk: ClerkName,
     /// Order shipping priority
     pub o_shippriority: i32,
     /// Variable length comment
@@ -1363,7 +1380,7 @@ impl fmt::Display for Order<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}|{}|{}|{:.2}|{}|{}|Clerk#{:09}|{}|{}|",
+            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}|",
             self.o_orderkey,
             self.o_custkey,
             self.o_orderstatus,
@@ -1622,6 +1639,9 @@ impl<'a> OrderGeneratorIterator<'a> {
             'O' // Open - no line items shipped
         };
 
+        let clerk_id = self.clerk_random.next_value();
+        let clerk_name = ClerkName::new(clerk_id);
+
         Order {
             o_orderkey: order_key,
             o_custkey: customer_key,
@@ -1629,7 +1649,7 @@ impl<'a> OrderGeneratorIterator<'a> {
             o_totalprice: total_price as f64 / 100.,
             o_orderdate: TPCHDate::new(order_date),
             o_orderpriority: self.order_priority_random.next_value(),
-            o_clerk: self.clerk_random.next_value(),
+            o_clerk: clerk_name,
             o_shippriority: 0, // Fixed value per TPC-H spec
             o_comment: self.comment_random.next_value(),
         }

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -297,6 +297,22 @@ impl fmt::Display for PartManufacturerName {
     }
 }
 
+/// A Part brand name, formatted as "Brand#<n>"
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PartBrandName(i32);
+
+impl PartBrandName {
+    pub fn new(value: i32) -> Self {
+        PartBrandName(value)
+    }
+}
+
+impl fmt::Display for PartBrandName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Brand#{}", self.0)
+    }
+}
+
 /// The PART table
 ///
 /// The Display trait is implemented to format the line item data as a string
@@ -314,8 +330,8 @@ pub struct Part<'a> {
     pub p_name: StringSequenceInstance<'a>,
     /// Part manufacturer.
     pub p_mfgr: PartManufacturerName,
-    /// Part brand. Formatted as "Brand#<n>"
-    pub p_brand: i32,
+    /// Part brand.
+    pub p_brand: PartBrandName,
     /// Part type
     pub p_type: &'a str,
     /// Part size
@@ -332,7 +348,7 @@ impl fmt::Display for Part<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}|{}|{}|Brand#{}|{}|{}|{}|{:.2}|{}|",
+            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}|",
             self.p_partkey,
             self.p_name,
             self.p_mfgr,
@@ -504,7 +520,7 @@ impl<'a> PartGeneratorIterator<'a> {
             p_partkey: part_key,
             p_name: name,
             p_mfgr: PartManufacturerName::new(manufacturer),
-            p_brand: brand,
+            p_brand: PartBrandName::new(brand),
             p_type: self.type_random.next_value(),
             p_size: self.size_random.next_value(),
             p_container: self.container_random.next_value(),

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -565,6 +565,23 @@ impl<'a> Iterator for PartGeneratorIterator<'a> {
     }
 }
 
+/// A supplier name, formatted as "Supplier#<n>"
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SupplierName(i64);
+
+impl SupplierName {
+    /// Creates a new SupplierName with the given value
+    pub fn new(value: i64) -> Self {
+        SupplierName(value)
+    }
+}
+
+impl fmt::Display for SupplierName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Supplier#{:09}", self.0)
+    }
+}
+
 /// Records for the SUPPLIER table.
 ///
 /// The Display trait is implemented to format the line item data as a string
@@ -578,8 +595,8 @@ impl<'a> Iterator for PartGeneratorIterator<'a> {
 pub struct Supplier {
     /// Primary key
     pub s_suppkey: i64,
-    /// Supplier name. Formatted as "Supplier#<n>"
-    pub s_name: i64,
+    /// Supplier name.
+    pub s_name: SupplierName,
     /// Supplier address
     pub s_address: String,
     /// Foreign key to NATION
@@ -596,7 +613,7 @@ impl fmt::Display for Supplier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}|Supplier#{:09}|{}|{}|{}|{:.2}|{}|",
+            "{}|{}|{}|{}|{}|{:.2}|{}|",
             self.s_suppkey,
             self.s_name,
             self.s_address,
@@ -814,7 +831,7 @@ impl<'a> SupplierGeneratorIterator<'a> {
 
         Supplier {
             s_suppkey: supplier_key,
-            s_name: supplier_key,
+            s_name: SupplierName::new(supplier_key),
             s_address: self.address_random.next_value().to_string(),
             s_nationkey: nation_key,
             s_phone: self.phone_random.next_value(nation_key),

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -152,6 +152,7 @@ impl<'a> Iterator for NationGeneratorIterator<'a> {
 }
 
 /// The REGION table
+
 /// The Display trait is implemented to format the line item data as a string
 /// in the default TPC-H 'tbl' format.
 ///

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -2118,8 +2118,7 @@ mod tests {
         // Check first supplier
         let first = &suppliers[0];
         assert_eq!(first.s_suppkey, 1);
-        assert_eq!(first.s_name, "Supplier#000000001");
-        assert!(!first.s_address.is_empty());
+        assert_eq!(first.to_string(), "1|Supplier#000000001| N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ|17|27-918-335-1736|5755.94|each slyly above the careful|")
     }
 
     #[test]
@@ -2134,8 +2133,7 @@ mod tests {
         // Check first customer
         let first = &customers[0];
         assert_eq!(first.c_custkey, 1);
-        assert_eq!(first.c_name, "Customer#000000001");
-        assert!(!first.c_address.is_empty());
+        assert_eq!(first.to_string(), "1|Customer#000000001|IVhzIApeRb ot,c,E|15|25-989-741-2988|711.56|BUILDING|to the even, regular platelets. regular, ironic epitaphs nag e|");
 
         // Check market segment distribution
         let market_segments: std::collections::HashSet<_> =

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -154,7 +154,7 @@ impl<'a> Iterator for NationGeneratorIterator<'a> {
 }
 
 /// The REGION table
-
+///
 /// The Display trait is implemented to format the line item data as a string
 /// in the default TPC-H 'tbl' format.
 ///

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -818,6 +818,23 @@ impl Iterator for SupplierGeneratorIterator<'_> {
     }
 }
 
+/// A Customer Name, formatted as "Customer#<n>"
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CustomerName(i64);
+
+impl CustomerName {
+    /// Creates a new CustomerName with the given value
+    pub fn new(value: i64) -> Self {
+        CustomerName(value)
+    }
+}
+
+impl fmt::Display for CustomerName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Customer#{:09}", self.0)
+    }
+}
+
 /// The CUSTOMER table
 ///
 /// The Display trait is implemented to format the line item data as a string
@@ -832,7 +849,7 @@ pub struct Customer<'a> {
     /// Primary key
     pub c_custkey: i64,
     /// Customer name: Formatted as "Customer#<n>"
-    pub c_name: i64,
+    pub c_name: CustomerName,
     /// Customer address
     pub c_address: String,
     /// Foreign key to NATION
@@ -851,7 +868,7 @@ impl fmt::Display for Customer<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{}|Customer#{:09}|{}|{}|{}|{:.2}|{}|{}|",
+            "{}|{}|{}|{}|{}|{:.2}|{}|{}|",
             self.c_custkey,
             self.c_name,
             self.c_address,
@@ -1007,7 +1024,7 @@ impl<'a> CustomerGeneratorIterator<'a> {
 
         Customer {
             c_custkey: customer_key,
-            c_name: customer_key,
+            c_name: CustomerName::new(customer_key),
             c_address: self.address_random.next_value().to_string(),
             c_nationkey: nation_key,
             c_phone: self.phone_random.next_value(nation_key),

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -1387,7 +1387,6 @@ pub struct OrderGeneratorIterator<'a> {
 
     index: i64,
 }
-
 impl<'a> OrderGeneratorIterator<'a> {
     fn new(
         distributions: &'a Distributions,
@@ -1546,6 +1545,15 @@ impl<'a> Iterator for OrderGeneratorIterator<'a> {
 }
 
 /// The LINEITEM table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// Example
+/// ```text
+/// 1|156|4|1|17|17954.55|0.04|0.02|N|O|1996-03-13|1996-02-12|1996-03-22|DELIVER IN PERSON|TRUCK|egular courts above the|
+/// 1|68|9|2|36|34850.16|0.09|0.06|N|O|1996-04-12|1996-02-28|1996-04-20|TAKE BACK RETURN|MAIL|ly final dependencies: slyly bold |
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct LineItem<'a> {
     /// Foreign key to ORDERS

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -60,6 +60,14 @@ impl<'a> IntoIterator for &'a NationGenerator<'a> {
 }
 
 /// The NATION table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 0|ALGERIA|0| haggle. carefully final deposits detect slyly agai|
+/// 1|ARGENTINA|1|al foxes promise slyly according to the regular accounts. bold requests alon|
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Nation<'a> {
     /// Primary key (0-24)
@@ -144,6 +152,13 @@ impl<'a> Iterator for NationGeneratorIterator<'a> {
 }
 
 /// The REGION table
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 0|AFRICA|lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to |
+/// 1|AMERICA|hs use ironic, even requests. s|
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Region<'a> {
     /// Primary key (0-4)
@@ -267,6 +282,14 @@ impl<'a> Iterator for RegionGeneratorIterator<'a> {
 }
 
 /// The PART table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
+/// 2|blush thistle blue yellow saddle|Manufacturer#1|Brand#13|LARGE BRUSHED BRASS|1|LG CASE|902.00|lar accounts amo|
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Part<'a> {
     /// Primary key
@@ -511,6 +534,14 @@ impl<'a> Iterator for PartGeneratorIterator<'a> {
 }
 
 /// Records for the SUPPLIER table.
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 1|Supplier#000000001| N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ|17|27-918-335-1736|5755.94|each slyly above the careful|
+/// 2|Supplier#000000002|89eJ5ksX3ImxJQBvxObC,|5|15-679-861-2259|4032.68| slyly bold instructions. idle dependen|
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Supplier {
     /// Primary key
@@ -788,6 +819,14 @@ impl Iterator for SupplierGeneratorIterator<'_> {
 }
 
 /// The CUSTOMER table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 1|Customer#000000001|IVhzIApeRb ot,c,E|15|25-989-741-2988|711.56|BUILDING|to the even, regular platelets. regular, ironic epitaphs nag e|
+/// 2|Customer#000000002|XSTf4,NCwDVaWNe6tEgvwfmRchLXak|13|23-768-687-3665|121.65|AUTOMOBILE|l accounts. blithely ironic theodolites integrate boldly: caref|
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Customer<'a> {
     /// Primary key
@@ -1002,7 +1041,15 @@ impl<'a> Iterator for CustomerGeneratorIterator<'a> {
     }
 }
 
-/// The PARTSUPP table
+/// The PARTSUPP (part supplier) table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 1|2|3325|771.64|, even theodolites. regular, final theodolites eat after the carefully pending foxes. ...
+/// 1|4|8076|993.49|ven ideas. quickly even packages print. pending multipliers must have to are fluff|
+/// ```
 pub struct PartSupp<'a> {
     /// Primary key, foreign key to PART
     pub ps_partkey: i64,
@@ -1217,6 +1264,14 @@ impl<'a> Iterator for PartSupplierGeneratorIterator<'a> {
 }
 
 /// The ORDERS table
+///
+/// The Display trait is implemented to format the line item data as a string
+/// in the default TPC-H 'tbl' format.
+///
+/// ```text
+/// 1|37|O|131251.81|1996-01-02|5-LOW|Clerk#000000951|0|nstructions sleep furiously among |
+///  2|79|O|40183.29|1996-12-01|1-URGENT|Clerk#000000880|0| foxes. pending accounts at the pending, silent asymptot|
+/// ```
 pub struct Order<'a> {
     /// Primary key
     pub o_orderkey: i64,

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -405,7 +405,7 @@ impl RandomPhoneNumber {
 /// ```text
 /// 27-918-335-1736
 /// ```
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct PhoneNumberInstance {
     country_code: i32,
     local1: i32,
@@ -528,7 +528,7 @@ impl<'a> RandomStringSequence<'a> {
 /// ```text
 /// "value1 value2 value3"
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct StringSequenceInstance<'a> {
     values: Vec<&'a str>,
 }

--- a/tpchgen/tests/integration_tests.rs
+++ b/tpchgen/tests/integration_tests.rs
@@ -58,10 +58,7 @@ fn test_nation_sf_0_001() {
     let _sf = 0.001;
     let generator = NationGenerator::new();
     test_generator(generator.iter(), "data/sf-0.001/nation.tbl.gz", |nation| {
-        format!(
-            "{}|{}|{}|{}|",
-            nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment
-        )
+        nation.to_string()
     });
 }
 
@@ -70,10 +67,7 @@ fn test_region_sf_0_001() {
     let _sf = 0.001;
     let generator = RegionGenerator::new();
     test_generator(generator.iter(), "data/sf-0.001/region.tbl.gz", |region| {
-        format!(
-            "{}|{}|{}|",
-            region.r_regionkey, region.r_name, region.r_comment
-        )
+        region.to_string()
     });
 }
 
@@ -82,18 +76,7 @@ fn test_part_sf_0_001() {
     let sf = 0.001;
     let generator = PartGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.001/part.tbl.gz", |part| {
-        format!(
-            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}|",
-            part.p_partkey,
-            part.p_name,
-            part.p_mfgr,
-            part.p_brand,
-            part.p_type,
-            part.p_size,
-            part.p_container,
-            part.p_retailprice,
-            part.p_comment
-        )
+        part.to_string()
     });
 }
 
@@ -104,18 +87,7 @@ fn test_supplier_sf_0_001() {
     test_generator(
         generator.iter(),
         "data/sf-0.001/supplier.tbl.gz",
-        |supplier| {
-            format!(
-                "{}|{}|{}|{}|{}|{:.2}|{}|",
-                supplier.s_suppkey,
-                supplier.s_name,
-                supplier.s_address,
-                supplier.s_nationkey,
-                supplier.s_phone,
-                supplier.s_acctbal,
-                supplier.s_comment
-            )
-        },
+        |supplier| supplier.to_string(),
     );
 }
 
@@ -124,10 +96,7 @@ fn test_partsupp_sf_0_001() {
     let sf = 0.001;
     let generator = PartSupplierGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.001/partsupp.tbl.gz", |ps| {
-        format!(
-            "{}|{}|{}|{:.2}|{}|",
-            ps.ps_partkey, ps.ps_suppkey, ps.ps_availqty, ps.ps_supplycost, ps.ps_comment
-        )
+        ps.to_string()
     });
 }
 
@@ -138,19 +107,7 @@ fn test_customer_sf_0_001() {
     test_generator(
         generator.iter(),
         "data/sf-0.001/customer.tbl.gz",
-        |customer| {
-            format!(
-                "{}|{}|{}|{}|{}|{:.2}|{}|{}|",
-                customer.c_custkey,
-                customer.c_name,
-                customer.c_address,
-                customer.c_nationkey,
-                customer.c_phone,
-                customer.c_acctbal,
-                customer.c_mktsegment,
-                customer.c_comment
-            )
-        },
+        |customer| customer.to_string(),
     );
 }
 
@@ -159,18 +116,7 @@ fn test_orders_sf_0_001() {
     let sf = 0.001;
     let generator = OrderGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.001/orders.tbl.gz", |order| {
-        format!(
-            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}|",
-            order.o_orderkey,
-            order.o_custkey,
-            order.o_orderstatus,
-            order.o_totalprice,
-            order.o_orderdate,
-            order.o_orderpriority,
-            order.o_clerk,
-            order.o_shippriority,
-            order.o_comment
-        )
+        order.to_string()
     });
 }
 
@@ -179,25 +125,7 @@ fn test_lineitem_sf_0_001() {
     let sf = 0.001;
     let generator = LineItemGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.001/lineitem.tbl.gz", |item| {
-        format!(
-            "{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
-            item.l_orderkey,
-            item.l_partkey,
-            item.l_suppkey,
-            item.l_linenumber,
-            item.l_quantity,
-            item.l_extendedprice,
-            item.l_discount,
-            item.l_tax,
-            item.l_returnflag,
-            item.l_linestatus,
-            item.l_shipdate,
-            item.l_commitdate,
-            item.l_receiptdate,
-            item.l_shipinstruct,
-            item.l_shipmode,
-            item.l_comment
-        )
+        item.to_string()
     });
 }
 
@@ -206,10 +134,7 @@ fn test_nation_sf_0_01() {
     let _sf = 0.01;
     let generator = NationGenerator::new();
     test_generator(generator.iter(), "data/sf-0.01/nation.tbl.gz", |nation| {
-        format!(
-            "{}|{}|{}|{}|",
-            nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment
-        )
+        nation.to_string()
     });
 }
 
@@ -218,10 +143,7 @@ fn test_region_sf_0_01() {
     let _sf = 0.01;
     let generator = RegionGenerator::new();
     test_generator(generator.iter(), "data/sf-0.01/region.tbl.gz", |region| {
-        format!(
-            "{}|{}|{}|",
-            region.r_regionkey, region.r_name, region.r_comment
-        )
+        region.to_string()
     });
 }
 
@@ -230,18 +152,7 @@ fn test_part_sf_0_01() {
     let sf = 0.01;
     let generator = PartGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/part.tbl.gz", |part| {
-        format!(
-            "{}|{}|{}|{}|{}|{}|{}|{:.2}|{}|",
-            part.p_partkey,
-            part.p_name,
-            part.p_mfgr,
-            part.p_brand,
-            part.p_type,
-            part.p_size,
-            part.p_container,
-            part.p_retailprice,
-            part.p_comment
-        )
+        part.to_string()
     });
 }
 
@@ -252,18 +163,7 @@ fn test_supplier_sf_0_01() {
     test_generator(
         generator.iter(),
         "data/sf-0.01/supplier.tbl.gz",
-        |supplier| {
-            format!(
-                "{}|{}|{}|{}|{}|{:.2}|{}|",
-                supplier.s_suppkey,
-                supplier.s_name,
-                supplier.s_address,
-                supplier.s_nationkey,
-                supplier.s_phone,
-                supplier.s_acctbal,
-                supplier.s_comment
-            )
-        },
+        |supplier| supplier.to_string(),
     );
 }
 
@@ -272,10 +172,7 @@ fn test_partsupp_sf_0_01() {
     let sf = 0.01;
     let generator = PartSupplierGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/partsupp.tbl.gz", |ps| {
-        format!(
-            "{}|{}|{}|{:.2}|{}|",
-            ps.ps_partkey, ps.ps_suppkey, ps.ps_availqty, ps.ps_supplycost, ps.ps_comment
-        )
+        ps.to_string()
     });
 }
 
@@ -286,19 +183,7 @@ fn test_customer_sf_0_01() {
     test_generator(
         generator.iter(),
         "data/sf-0.01/customer.tbl.gz",
-        |customer| {
-            format!(
-                "{}|{}|{}|{}|{}|{:.2}|{}|{}|",
-                customer.c_custkey,
-                customer.c_name,
-                customer.c_address,
-                customer.c_nationkey,
-                customer.c_phone,
-                customer.c_acctbal,
-                customer.c_mktsegment,
-                customer.c_comment
-            )
-        },
+        |customer| customer.to_string(),
     );
 }
 
@@ -307,19 +192,8 @@ fn test_orders_sf_0_01() {
     let sf = 0.01;
     let generator = OrderGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/orders.tbl.gz", |order| {
-        format!(
-            "{}|{}|{}|{:.2}|{}|{}|{}|{}|{}|",
-            order.o_orderkey,
-            order.o_custkey,
-            order.o_orderstatus,
-            order.o_totalprice,
-            order.o_orderdate,
-            order.o_orderpriority,
-            order.o_clerk,
-            order.o_shippriority,
-            order.o_comment
-        )
-    });
+        order.to_string()
+    })
 }
 
 #[test]
@@ -327,24 +201,6 @@ fn test_lineitem_sf_0_01() {
     let sf = 0.01;
     let generator = LineItemGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/lineitem.tbl.gz", |item| {
-        format!(
-            "{}|{}|{}|{}|{}|{:.2}|{:.2}|{:.2}|{}|{}|{}|{}|{}|{}|{}|{}|",
-            item.l_orderkey,
-            item.l_partkey,
-            item.l_suppkey,
-            item.l_linenumber,
-            item.l_quantity,
-            item.l_extendedprice,
-            item.l_discount,
-            item.l_tax,
-            item.l_returnflag,
-            item.l_linestatus,
-            item.l_shipdate,
-            item.l_commitdate,
-            item.l_receiptdate,
-            item.l_shipinstruct,
-            item.l_shipmode,
-            item.l_comment
-        )
-    });
+        item.to_string()
+    })
 }


### PR DESCRIPTION
- Part of https://github.com/clflushopt/tpchgen-rs/issues/10

This PR removes some more
1. Consolidates format strings in the cli and tests to use the `Display` impl 
2. Avoids some more String copies by postponing formatting

Performance of running
```shell
time target/release/tpchgen-cli -s 1 --output-dir=/tmp/tpchdbgen-rs
```
| branch | time |
|--------|--------|
| main | 0m6.637s |
| this PR | 0m6.265s | 