### PR TITLE
Pass distribution references to generators

### DIFF
--- a/tpchgen/src/distribution.rs
+++ b/tpchgen/src/distribution.rs
@@ -1,5 +1,8 @@
 use crate::random::RowRandomInt;
-use std::io::{self, BufRead};
+use std::{
+    io::{self, BufRead},
+    sync::LazyLock,
+};
 
 use indexmap::IndexMap;
 
@@ -211,6 +214,11 @@ impl DistributionLoader {
     }
 }
 
+/// Static global instance of the default distributions.
+///
+/// Initialized once on first access.
+static DEFAULT_DISTRIBUTIONS: LazyLock<Distributions> = LazyLock::new(Distributions::default);
+
 /// Distributions wraps all TPC-H distributions and provides methods to access them.
 #[derive(Debug, Clone)]
 pub struct Distributions {
@@ -231,6 +239,11 @@ impl Distributions {
     /// Creates a new distributions wrapper.
     pub fn new(distributions: IndexMap<String, Distribution>) -> Self {
         Distributions { distributions }
+    }
+
+    /// Returns a static reference to the default distributions.
+    pub fn static_default() -> &'static Distributions {
+        &DEFAULT_DISTRIBUTIONS
     }
 
     /// Returns the `adjectives` distribution.

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -14,7 +14,7 @@ use crate::random::{RandomBoundedInt, RandomString, RandomStringSequence, Random
 
 /// Generator for Nation table data
 pub struct NationGenerator<'a> {
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -28,14 +28,14 @@ impl<'a> NationGenerator<'a> {
     /// Creates a new NationGenerator with default distributions and text pool
     pub fn new() -> Self {
         Self::new_with_distributions_and_text_pool(
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
 
     /// Creates a NationGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         NationGenerator {
@@ -177,7 +177,7 @@ impl<'a> Region<'a> {
 
 /// Generator for Region table data
 pub struct RegionGenerator<'a> {
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -191,14 +191,14 @@ impl<'a> RegionGenerator<'a> {
     /// Creates a new RegionGenerator with default distributions and text pool
     pub fn new() -> Self {
         Self::new_with_distributions_and_text_pool(
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
 
     /// Creates a RegionGenerator with the specified distributions and text pool
     pub fn new_with_distributions_and_text_pool(
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         RegionGenerator {
@@ -312,7 +312,7 @@ pub struct PartGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -335,7 +335,7 @@ impl<'a> PartGenerator<'a> {
             scale_factor,
             part,
             part_count,
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
@@ -345,7 +345,7 @@ impl<'a> PartGenerator<'a> {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         PartGenerator {
@@ -360,7 +360,7 @@ impl<'a> PartGenerator<'a> {
     /// Returns an iterator over the part rows
     pub fn iter(&self) -> PartGeneratorIterator {
         PartGeneratorIterator::new(
-            &self.distributions,
+            self.distributions,
             self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
@@ -550,7 +550,7 @@ pub struct SupplierGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -579,7 +579,7 @@ impl<'a> SupplierGenerator<'a> {
             scale_factor,
             part,
             part_count,
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
@@ -589,7 +589,7 @@ impl<'a> SupplierGenerator<'a> {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         SupplierGenerator {
@@ -604,7 +604,7 @@ impl<'a> SupplierGenerator<'a> {
     /// Returns an iterator over the supplier rows
     pub fn iter(&self) -> SupplierGeneratorIterator {
         SupplierGeneratorIterator::new(
-            &self.distributions,
+            self.distributions,
             self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
@@ -830,7 +830,7 @@ pub struct CustomerGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -850,7 +850,7 @@ impl<'a> CustomerGenerator<'a> {
             scale_factor,
             part,
             part_count,
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
@@ -860,7 +860,7 @@ impl<'a> CustomerGenerator<'a> {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         CustomerGenerator {
@@ -875,7 +875,7 @@ impl<'a> CustomerGenerator<'a> {
     /// Returns an iterator over the customer rows
     pub fn iter(&self) -> CustomerGeneratorIterator {
         CustomerGeneratorIterator::new(
-            &self.distributions,
+            self.distributions,
             self.text_pool,
             GenerateUtils::calculate_start_index(
                 Self::SCALE_BASE,
@@ -1261,7 +1261,7 @@ pub struct OrderGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -1289,7 +1289,7 @@ impl<'a> OrderGenerator<'a> {
             scale_factor,
             part,
             part_count,
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
@@ -1299,7 +1299,7 @@ impl<'a> OrderGenerator<'a> {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         OrderGenerator {
@@ -1314,7 +1314,7 @@ impl<'a> OrderGenerator<'a> {
     /// Returns an iterator over the order rows
     pub fn iter(&self) -> OrderGeneratorIterator {
         OrderGeneratorIterator::new(
-            &self.distributions,
+            self.distributions,
             self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(
@@ -1612,7 +1612,7 @@ pub struct LineItemGenerator<'a> {
     scale_factor: f64,
     part: i32,
     part_count: i32,
-    distributions: Distributions,
+    distributions: &'a Distributions,
     text_pool: &'a TextPool,
 }
 
@@ -1643,7 +1643,7 @@ impl<'a> LineItemGenerator<'a> {
             scale_factor,
             part,
             part_count,
-            Distributions::default(),
+            Distributions::static_default(),
             TextPool::get_or_init_default(),
         )
     }
@@ -1653,7 +1653,7 @@ impl<'a> LineItemGenerator<'a> {
         scale_factor: f64,
         part: i32,
         part_count: i32,
-        distributions: Distributions,
+        distributions: &'a Distributions,
         text_pool: &'a TextPool,
     ) -> Self {
         LineItemGenerator {
@@ -1668,7 +1668,7 @@ impl<'a> LineItemGenerator<'a> {
     /// Returns an iterator over the line item rows
     pub fn iter(&self) -> LineItemGeneratorIterator {
         LineItemGeneratorIterator::new(
-            &self.distributions,
+            self.distributions,
             self.text_pool,
             self.scale_factor,
             GenerateUtils::calculate_start_index(

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -45,12 +45,12 @@ impl<'a> NationGenerator<'a> {
     }
 
     /// Returns an iterator over the nation rows
-    pub fn iter(&self) -> NationGeneratorIterator {
+    pub fn iter(&self) -> NationGeneratorIterator<'a> {
         NationGeneratorIterator::new(self.distributions.nations(), self.text_pool)
     }
 }
 
-impl<'a> IntoIterator for &'a NationGenerator<'a> {
+impl<'a> IntoIterator for NationGenerator<'a> {
     type Item = Nation<'a>;
     type IntoIter = NationGeneratorIterator<'a>;
 
@@ -208,7 +208,7 @@ impl<'a> RegionGenerator<'a> {
     }
 
     /// Returns an iterator over the region rows
-    pub fn iter(&self) -> RegionGeneratorIterator {
+    pub fn iter(&self) -> RegionGeneratorIterator<'a> {
         RegionGeneratorIterator::new(self.distributions.regions(), self.text_pool)
     }
 }
@@ -358,7 +358,7 @@ impl<'a> PartGenerator<'a> {
     }
 
     /// Returns an iterator over the part rows
-    pub fn iter(&self) -> PartGeneratorIterator {
+    pub fn iter(&self) -> PartGeneratorIterator<'a> {
         PartGeneratorIterator::new(
             self.distributions,
             self.text_pool,
@@ -602,7 +602,7 @@ impl<'a> SupplierGenerator<'a> {
     }
 
     /// Returns an iterator over the supplier rows
-    pub fn iter(&self) -> SupplierGeneratorIterator {
+    pub fn iter(&self) -> SupplierGeneratorIterator<'a> {
         SupplierGeneratorIterator::new(
             self.distributions,
             self.text_pool,
@@ -873,7 +873,7 @@ impl<'a> CustomerGenerator<'a> {
     }
 
     /// Returns an iterator over the customer rows
-    pub fn iter(&self) -> CustomerGeneratorIterator {
+    pub fn iter(&self) -> CustomerGeneratorIterator<'a> {
         CustomerGeneratorIterator::new(
             self.distributions,
             self.text_pool,
@@ -1071,7 +1071,7 @@ impl<'a> PartSupplierGenerator<'a> {
     }
 
     /// Returns an iterator over the part supplier rows
-    pub fn iter(&self) -> PartSupplierGeneratorIterator {
+    pub fn iter(&self) -> PartSupplierGeneratorIterator<'a> {
         // Use the part generator's scale base for start/row calculation
         let scale_base = PartGenerator::SCALE_BASE;
 
@@ -1312,7 +1312,7 @@ impl<'a> OrderGenerator<'a> {
     }
 
     /// Returns an iterator over the order rows
-    pub fn iter(&self) -> OrderGeneratorIterator {
+    pub fn iter(&self) -> OrderGeneratorIterator<'a> {
         OrderGeneratorIterator::new(
             self.distributions,
             self.text_pool,
@@ -1666,7 +1666,7 @@ impl<'a> LineItemGenerator<'a> {
     }
 
     /// Returns an iterator over the line item rows
-    pub fn iter(&self) -> LineItemGeneratorIterator {
+    pub fn iter(&self) -> LineItemGeneratorIterator<'a> {
         LineItemGeneratorIterator::new(
             self.distributions,
             self.text_pool,
@@ -2264,5 +2264,21 @@ mod tests {
             line_items.iter().map(|l| &l.l_linestatus).collect();
 
         assert!(!line_statuses.is_empty());
+    }
+
+    #[test]
+    fn check_iter_static_lifetimes() {
+        // Lifetimes of iterators should be independent of the generator that
+        // created it. This test case won't compile if that's not the case.
+
+        let _iter: NationGeneratorIterator<'static> = NationGenerator::new().iter();
+        let _iter: RegionGeneratorIterator<'static> = RegionGenerator::new().iter();
+        let _iter: PartGeneratorIterator<'static> = PartGenerator::new(0.1, 1, 1).iter();
+        let _iter: SupplierGeneratorIterator<'static> = SupplierGenerator::new(0.1, 1, 1).iter();
+        let _iter: CustomerGeneratorIterator<'static> = CustomerGenerator::new(0.1, 1, 1).iter();
+        let _iter: PartSupplierGeneratorIterator<'static> =
+            PartSupplierGenerator::new(0.1, 1, 1).iter();
+        let _iter: OrderGeneratorIterator<'static> = OrderGenerator::new(0.1, 1, 1).iter();
+        let _iter: LineItemGeneratorIterator<'static> = LineItemGenerator::new(0.1, 1, 1).iter();
     }
 }

--- a/tpchgen/src/text.rs
+++ b/tpchgen/src/text.rs
@@ -31,8 +31,12 @@ impl TextPool {
     /// Returns the default text pool or initializes for the first time if
     /// that's not already the case.
     pub fn get_or_init_default() -> &'static Self {
-        DEFAULT_TEXT_POOL
-            .get_or_init(|| Self::new(Self::DEFAULT_TEXT_POOL_SIZE, &Distributions::default()))
+        DEFAULT_TEXT_POOL.get_or_init(|| {
+            Self::new(
+                Self::DEFAULT_TEXT_POOL_SIZE,
+                Distributions::static_default(),
+            )
+        })
     }
 
     /// Returns a new text pool with a predefined size and set of distributions.


### PR DESCRIPTION
Closes https://github.com/clflushopt/tpchgen-rs/issues/42

Passes references to generators instead of each creating the default one.

The goal of this change is to remove needing to hang onto the generator after creating the iterator (since it owned the distribution data).

Retains the `'static` semantics for all `new` methods on the generators.