### PR TITLE
Add `ARCHITECTURE.md` documentation with design goals (keep data generator crate dependencies minimal)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,4 +20,4 @@ has many more dependencies.
 Speed is a very important aspect of this project, and care has been taken to keep 
 the code as fast as possible, using some of the following techniques:
 1. Avoiding heap allocations during data generation
-2. Integer arithmetic instead of floating point arithmetic
+2. Integer arithmetic and display instead of floating point arithmetic and display

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Architecture Guide
+
+## Crate Organization
+The project is organized into two crates:
+
+1. `tpchgen`: The core library that implements the data generation logic for TPCH.
+2. `tpchgen-cli`: A CLI tool that uses the `tpchgen` library to generate TPCH data.
+
+## Dependencies
+
+The `tpchgen` crate is designed to be embeddable in as many locations as
+possible and thus has very minimal dependencies by design. For example, it does
+not depend on arrow or parquet crates or display libraries.
+
+The `tpchgen-cli` crate is designed to include many useful features, and thus
+has many more dependencies.
+
+## Speed
+
+Speed is a very important aspect of this project, and care has been taken to keep 
+the code as fast as possible, using some of the following techniques:
+1. Avoiding heap allocations during data generation
+2. Integer arithmetic instead of floating point arithmetic

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ $ tpchgen-cli -s 1 --output-dir=/tmp/tpch
 Pull requests are welcome. For major changes, please open an issue first for
 discussion. See our [contributors guide](CONTRIBUTING.md) for more details.
 
+## Architecture
+
+Please see [architecture guide](ARCHITECTURE.md) for details on how the code
+is structured.
+
 ## License
 
 The project is licensed under the [APACHE 2.0](LICENSE) license.
@@ -57,3 +62,4 @@ The project is licensed under the [APACHE 2.0](LICENSE) license.
 
 - The TPC-H Specification, see the specification [page](https://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp).
 - The Original `dbgen` Implementation you must submit an official request to access the software `dbgen` at their official [website](https://www.tpc.org/tpch/)
+

--- a/tpchgen/Cargo.toml
+++ b/tpchgen/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 authors = ["clflushopt", "alamb"]
 
+# Designed to have minimal depdencies to make it easy to use in other projects
+# See ../ARCHITECTURE.md for more details
 [dependencies]
 chrono = "0.4.40"
 indexmap = "2.7.1"

--- a/tpchgen/data/README.md
+++ b/tpchgen/data/README.md
@@ -83,7 +83,8 @@ C data generator to verify they are the same. To do so:
 Step 1: create `tbl` files.
 
 One way to do this is using a docker container that has the classic
-data generator prebuilt, though you could also build it from scratch:
+data generator prebuilt, though you could also build it from 
+[source](https://github.com/electrum/tpch-dbgen):
 
 ```shell
 docker run -v `pwd`:/data -it  ghcr.io/scalytics/tpch-docker:main -vf -s 0.001
@@ -111,5 +112,5 @@ cat sf-0.001/customer.tbl.gz | gunzip > /tmp/customer.java.tbl
 And then compare with `diff`
 
 ```shell
-diff du /tmp/customer.c.tbl /tmp/customer.java.tbl
+diff -du /tmp/customer.c.tbl /tmp/customer.java.tbl
 ```


### PR DESCRIPTION
# Rationale
@scsmithr @clflushopt and I were discussing the crates design here: https://github.com/clflushopt/tpchgen-rs/issues/46#issuecomment-2738433070

I wanted to capture the consensus in documentation. 

Please let me know if I got it right