### PR TITLE
Add `into_inner` for wrapper types, and derive some more traits`

### DIFF
--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -57,7 +57,7 @@ impl GenerateUtils {
 /// Represents a date (day/year)
 ///
 /// Example display: 1992-01-01
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TPCHDate {
     /// Index of this date in the date to string lookup table
     date_index: i32,
@@ -80,6 +80,11 @@ impl TPCHDate {
     /// Returns a chrono [`NaiveDate`] representing this date
     pub fn to_chrono(&self) -> NaiveDate {
         make_date(self.date_index + 1)
+    }
+
+    /// Return the inner date index
+    pub fn into_inner(self) -> i32 {
+        self.date_index
     }
 
     /// Format money value (convert to decimal)

--- a/tpchgen/src/decimal.rs
+++ b/tpchgen/src/decimal.rs
@@ -18,18 +18,23 @@ impl TPCHDecimal {
     }
 
     /// Returns if this decimal is negative.
-    const fn is_negative(&self) -> bool {
+    pub const fn is_negative(&self) -> bool {
         self.0.is_negative()
     }
 
     /// Returns the digits before the decimal point.
-    const fn int_digits(&self) -> i64 {
+    pub const fn int_digits(&self) -> i64 {
         (self.0 / 100).abs()
     }
 
     /// Returns the digits after the decimal point.
-    const fn decimal_digits(&self) -> i64 {
+    pub const fn decimal_digits(&self) -> i64 {
         (self.0 % 100).abs()
+    }
+
+    /// Return the inner i64 value.
+    pub const fn into_inner(self) -> i64 {
+        self.0
     }
 }
 

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -353,7 +353,7 @@ impl RandomAlphaNumeric {
 
 /// A random alphanumeric string. To avoid allocations
 /// the string is created on demand with the Display implementation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RandomAlphaNumericInstance {
     length: usize,
     /// snapshot of the random number generator
@@ -396,7 +396,7 @@ impl Display for RandomAlphaNumericInstance {
 }
 
 /// Generates phone numbers according to TPC-H spec
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RandomPhoneNumber {
     inner: RowRandomInt,
 }
@@ -440,7 +440,7 @@ impl RandomPhoneNumber {
 /// ```text
 /// 27-918-335-1736
 /// ```
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PhoneNumberInstance {
     country_code: i32,
     local1: i32,


### PR DESCRIPTION
Inspired by @scsmithr's comments https://github.com/clflushopt/tpchgen-rs/pull/50#pullrequestreview-2702915563

We now have date and decimal so called "newtype" wrappers around `i32`/`i64` that allow formatting into a single location

Right now it is easy to go from `i32` -> newtype, but not the other way around

Typically, there is a function in rust programs `into_inner` that does the conversion.

We could also consider adding `From` impls, but I think these functions are more explicit and we can add from impls later

I also added some more `derive` traits while I was at it