### PR TITLE
Implement output as CSV

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -19,6 +19,9 @@ use clap::{Parser, ValueEnum};
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use tpchgen::csv::{
+    CustomerCsv, LineItemCsv, NationCsv, OrderCsv, PartCsv, PartSuppCsv, RegionCsv, SupplierCsv,
+};
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
@@ -28,12 +31,12 @@ use tpchgen::generators::{
 #[command(name = "tpchgen")]
 #[command(about = "TPC-H Data Generator", long_about = None)]
 struct Cli {
-    /// Scale factor to address defaults to 1.
+    /// Scale factor to address (default: 1)
     #[arg(short, long, default_value_t = 1.)]
     scale_factor: f64,
 
-    /// Output directory for generated files
-    #[arg(short, long)]
+    /// Output directory for generated files (default: current directory)
+    #[arg(short, long, default_value = ".")]
     output_dir: PathBuf,
 
     /// Which tables to generate (default: all)
@@ -47,6 +50,10 @@ struct Cli {
     /// Which part to generate (1-based, only relevant if parts > 1)
     #[arg(long, default_value_t = 1)]
     part: i32,
+
+    /// Output format: tbl, csv, parquet (default: tbl)
+    #[arg(short, long, default_value = "tbl")]
+    format: OutputFormat,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -61,137 +68,323 @@ enum Table {
     LineItem,
 }
 
+impl Table {
+    fn name(&self) -> &'static str {
+        match self {
+            Table::Nation => "nation",
+            Table::Region => "region",
+            Table::Part => "part",
+            Table::Supplier => "supplier",
+            Table::PartSupp => "partsupp",
+            Table::Customer => "customer",
+            Table::Orders => "orders",
+            Table::LineItem => "lineitem",
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum OutputFormat {
+    Tbl,
+    Csv,
+    Parquet,
+}
+
 fn main() -> io::Result<()> {
     // Parse command line arguments
     let cli = Cli::parse();
+    cli.main()
+}
 
-    // Create output directory if it doesn't exist
-    fs::create_dir_all(&cli.output_dir)?;
+impl Cli {
+    fn main(self) -> io::Result<()> {
+        // Create output directory if it doesn't exist
+        fs::create_dir_all(&self.output_dir)?;
 
-    // Determine which tables to generate
-    let tables: Vec<Table> = if let Some(tables) = cli.tables.as_ref() {
-        tables.clone()
-    } else {
-        vec![
-            Table::Nation,
-            Table::Region,
-            Table::Part,
-            Table::Supplier,
-            Table::PartSupp,
-            Table::Customer,
-            Table::Orders,
-            Table::LineItem,
-        ]
-    };
+        // Determine which tables to generate
+        let tables: Vec<Table> = if let Some(tables) = self.tables.as_ref() {
+            tables.clone()
+        } else {
+            vec![
+                Table::Nation,
+                Table::Region,
+                Table::Part,
+                Table::Supplier,
+                Table::PartSupp,
+                Table::Customer,
+                Table::Orders,
+                Table::LineItem,
+            ]
+        };
 
-    // Generate each table
-    for table in tables {
-        match table {
-            Table::Nation => generate_nation(&cli)?,
-            Table::Region => generate_region(&cli)?,
-            Table::Part => generate_part(&cli)?,
-            Table::Supplier => generate_supplier(&cli)?,
-            Table::PartSupp => generate_partsupp(&cli)?,
-            Table::Customer => generate_customer(&cli)?,
-            Table::Orders => generate_orders(&cli)?,
-            Table::LineItem => generate_lineitem(&cli)?,
+        // Generate each table
+        for table in tables {
+            match table {
+                Table::Nation => self.generate_nation()?,
+                Table::Region => self.generate_region()?,
+                Table::Part => self.generate_part()?,
+                Table::Supplier => self.generate_supplier()?,
+                Table::PartSupp => self.generate_partsupp()?,
+                Table::Customer => self.generate_customer()?,
+                Table::Orders => self.generate_orders()?,
+                Table::LineItem => self.generate_lineitem()?,
+            }
+        }
+
+        println!("Generation complete!");
+        Ok(())
+    }
+
+    /// return the output filename for the given table
+    fn output_filename(&self, table: Table) -> String {
+        let extension = match self.format {
+            OutputFormat::Tbl => "tbl",
+            OutputFormat::Csv => "csv",
+            OutputFormat::Parquet => "parquet",
+        };
+        format!("{}.{extension}", table.name())
+    }
+
+    /// return a buffered file for writing the given filename in the output directory
+    fn new_output_writer(&self, filename: &str) -> io::Result<BufWriter<File>> {
+        let path = self.output_dir.join(filename);
+        let file = File::create(path)?;
+        Ok(BufWriter::with_capacity(32 * 1024, file))
+    }
+
+    fn generate_nation(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Nation);
+        let writer = self.new_output_writer(&filename)?;
+
+        let generator = NationGenerator::new();
+        match self.format {
+            OutputFormat::Tbl => self.nation_tbl(writer, generator),
+            OutputFormat::Csv => self.nation_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
         }
     }
 
-    println!("Generation complete!");
-    Ok(())
-}
+    fn generate_region(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Region);
+        let writer = self.new_output_writer(&filename)?;
 
-fn new_table_writer(cli: &Cli, filename: &str) -> io::Result<BufWriter<File>> {
-    let path = cli.output_dir.join(filename);
-    let file = File::create(path)?;
-    Ok(BufWriter::with_capacity(32 * 1024, file))
-}
-
-fn generate_nation(cli: &Cli) -> io::Result<()> {
-    let filename = "nation.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
-
-    let generator = NationGenerator::new();
-    for nation in generator.iter() {
-        writeln!(writer, "{nation}",)?;
+        let generator = RegionGenerator::new();
+        match self.format {
+            OutputFormat::Tbl => self.region_tbl(writer, generator),
+            OutputFormat::Csv => self.region_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_region(cli: &Cli) -> io::Result<()> {
-    let filename = "region.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_part(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Part);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = RegionGenerator::new();
-    for region in generator.iter() {
-        writeln!(writer, "{region}",)?;
+        let generator = PartGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.part_tbl(writer, generator),
+            OutputFormat::Csv => self.part_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_part(cli: &Cli) -> io::Result<()> {
-    let filename = "part.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_supplier(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Supplier);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = PartGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for part in generator.iter() {
-        writeln!(writer, "{part}",)?;
+        let generator = SupplierGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.supplier_tbl(writer, generator),
+            OutputFormat::Csv => self.supplier_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_supplier(cli: &Cli) -> io::Result<()> {
-    let filename = "supplier.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_partsupp(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::PartSupp);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = SupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for supplier in generator.iter() {
-        writeln!(writer, "{supplier}")?;
+        let generator = PartSupplierGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.partsupp_tbl(writer, generator),
+            OutputFormat::Csv => self.partsupp_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_partsupp(cli: &Cli) -> io::Result<()> {
-    let filename = "partsupp.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_customer(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Customer);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = PartSupplierGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for ps in generator.iter() {
-        writeln!(writer, "{ps}")?;
+        let generator = CustomerGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.customer_tbl(writer, generator),
+            OutputFormat::Csv => self.customer_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_customer(cli: &Cli) -> io::Result<()> {
-    let filename = "customer.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_orders(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::Orders);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = CustomerGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for customer in generator.iter() {
-        writeln!(writer, "{customer}",)?;
+        let generator = OrderGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.orders_tbl(writer, generator),
+            OutputFormat::Csv => self.orders_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_orders(cli: &Cli) -> io::Result<()> {
-    let filename = "orders.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    fn generate_lineitem(&self) -> io::Result<()> {
+        let filename = self.output_filename(Table::LineItem);
+        let writer = self.new_output_writer(&filename)?;
 
-    let generator = OrderGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for order in generator.iter() {
-        writeln!(writer, "{order}")?;
+        let generator = LineItemGenerator::new(self.scale_factor, self.part, self.parts);
+        match self.format {
+            OutputFormat::Tbl => self.lineitem_tbl(writer, generator),
+            OutputFormat::Csv => self.lineitem_csv(writer, generator),
+            OutputFormat::Parquet => {
+                unimplemented!("Parquet output not yet implemented");
+            }
+        }
     }
-    writer.flush()
-}
 
-fn generate_lineitem(cli: &Cli) -> io::Result<()> {
-    let filename = "lineitem.tbl";
-    let mut writer = new_table_writer(cli, filename)?;
+    // Separate functions for each table/output format combination
+    // to ensure they are inlined / a single function doesn't get out of hand
+    // TODO: make these via macros
 
-    let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
-    for item in generator.iter() {
-        writeln!(writer, "{item}")?;
+    fn nation_tbl<W: Write>(&self, mut w: W, gen: NationGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
     }
-    writer.flush()
+
+    fn nation_csv<W: Write>(&self, mut w: W, gen: NationGenerator) -> io::Result<()> {
+        writeln!(w, "{}", NationCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", NationCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn region_tbl<W: Write>(&self, mut w: W, gen: RegionGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn region_csv<W: Write>(&self, mut w: W, gen: RegionGenerator) -> io::Result<()> {
+        writeln!(w, "{}", RegionCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", RegionCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn part_tbl<W: Write>(&self, mut w: W, gen: PartGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn part_csv<W: Write>(&self, mut w: W, gen: PartGenerator) -> io::Result<()> {
+        writeln!(w, "{}", PartCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", PartCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn supplier_tbl<W: Write>(&self, mut w: W, gen: SupplierGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn supplier_csv<W: Write>(&self, mut w: W, generator: SupplierGenerator) -> io::Result<()> {
+        writeln!(w, "{}", SupplierCsv::header())?;
+        for item in generator.iter() {
+            writeln!(&mut w, "{}", SupplierCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn partsupp_tbl<W: Write>(&self, mut w: W, gen: PartSupplierGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn partsupp_csv<W: Write>(&self, mut w: W, gen: PartSupplierGenerator) -> io::Result<()> {
+        writeln!(w, "{}", PartSuppCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", PartSuppCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn customer_tbl<W: Write>(&self, mut w: W, gen: CustomerGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn customer_csv<W: Write>(&self, mut w: W, gen: CustomerGenerator) -> io::Result<()> {
+        writeln!(w, "{}", CustomerCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", CustomerCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn orders_tbl<W: Write>(&self, mut w: W, gen: OrderGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn orders_csv<W: Write>(&self, mut w: W, gen: OrderGenerator) -> io::Result<()> {
+        writeln!(w, "{}", OrderCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", OrderCsv::new(item))?;
+        }
+        w.flush()
+    }
+
+    fn lineitem_tbl<W: Write>(&self, mut w: W, gen: LineItemGenerator) -> io::Result<()> {
+        for item in gen.iter() {
+            writeln!(&mut w, "{item}")?;
+        }
+        w.flush()
+    }
+
+    fn lineitem_csv<W: Write>(&self, mut w: W, gen: LineItemGenerator) -> io::Result<()> {
+        writeln!(w, "{}", LineItemCsv::header())?;
+        for item in gen.iter() {
+            writeln!(&mut w, "{}", LineItemCsv::new(item))?;
+        }
+        w.flush()
+    }
 }

--- a/tpchgen/src/csv.rs
+++ b/tpchgen/src/csv.rs
@@ -1,0 +1,446 @@
+//! CSV Formatting for TPCH data
+
+use crate::generators::{Customer, LineItem, Nation, Order, Part, PartSupp, Region, Supplier};
+use core::fmt;
+use std::fmt::Display;
+
+/// Write [`Nation`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::NationGenerator;
+/// # use tpchgen::csv::NationCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = NationGenerator::new();
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", NationCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", NationCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "n_nationkey,n_name,n_regionkey,n_comment\n\
+///    0,ALGERIA,0,\" haggle. carefully final deposits detect slyly agai\"\n\
+///    1,ARGENTINA,1,\"al foxes promise slyly according to the regular accounts. bold requests alon\"\n\
+///    2,BRAZIL,1,\"y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special \"\n"
+/// );
+/// ```
+pub struct NationCsv<'a> {
+    inner: Nation<'a>,
+}
+
+impl<'a> NationCsv<'a> {
+    pub fn new(inner: Nation<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Nation table
+    pub fn header() -> &'static str {
+        "n_nationkey,n_name,n_regionkey,n_comment"
+    }
+}
+
+impl Display for NationCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},\"{}\"",
+            self.inner.n_nationkey, self.inner.n_name, self.inner.n_regionkey, self.inner.n_comment
+        )
+    }
+}
+
+/// Write [`Region`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::{RegionGenerator};
+/// # use tpchgen::csv::{NationCsv, RegionCsv};
+/// # use std::fmt::Write;
+/// let generator = RegionGenerator::new();
+/// // Output the first 3 rows in CSV format
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", RegionCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", RegionCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "r_regionkey,r_name,r_comment\n\
+///    0,AFRICA,\"lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to \"\n\
+///    1,AMERICA,\"hs use ironic, even requests. s\"\n\
+///    2,ASIA,\"ges. thinly even pinto beans ca\"\n"
+/// );
+/// ```
+pub struct RegionCsv<'a> {
+    inner: Region<'a>,
+}
+
+impl<'a> RegionCsv<'a> {
+    pub fn new(inner: Region<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Region table
+    pub fn header() -> &'static str {
+        "r_regionkey,r_name,r_comment"
+    }
+}
+
+impl Display for RegionCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},\"{}\"",
+            self.inner.r_regionkey, self.inner.r_name, self.inner.r_comment
+        )
+    }
+}
+
+/// Write [`Part`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::PartGenerator;
+/// # use tpchgen::csv::PartCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = PartGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", PartCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", PartCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "p_partkey,p_name,p_mfgr,p_brand,p_type,p_size,p_container,p_retailprice,p_comment\n\
+///    1,goldenrod lavender spring chocolate lace,Manufacturer#1,Brand#13,PROMO BURNISHED COPPER,7,JUMBO PKG,901.00,\"ly. slyly ironi\"\n\
+///    2,blush thistle blue yellow saddle,Manufacturer#1,Brand#13,LARGE BRUSHED BRASS,1,LG CASE,902.00,\"lar accounts amo\"\n\
+///    3,spring green yellow purple cornsilk,Manufacturer#4,Brand#42,STANDARD POLISHED BRASS,21,WRAP CASE,903.00,\"egular deposits hag\"\n"
+/// );
+/// ```
+pub struct PartCsv<'a> {
+    inner: Part<'a>,
+}
+
+impl<'a> PartCsv<'a> {
+    pub fn new(inner: Part<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Part table
+    pub fn header() -> &'static str {
+        "p_partkey,p_name,p_mfgr,p_brand,p_type,p_size,p_container,p_retailprice,p_comment"
+    }
+}
+
+impl Display for PartCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},{},{},{},{},\"{}\"",
+            self.inner.p_partkey,
+            self.inner.p_name,
+            self.inner.p_mfgr,
+            self.inner.p_brand,
+            self.inner.p_type,
+            self.inner.p_size,
+            self.inner.p_container,
+            self.inner.p_retailprice,
+            self.inner.p_comment
+        )
+    }
+}
+
+/// Write [`Supplier`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::SupplierGenerator;
+/// # use tpchgen::csv::SupplierCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = SupplierGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", SupplierCsv::header()).unwrap(); // write header
+///   for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", SupplierCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "s_suppkey,s_name,s_address,s_nationkey,s_phone,s_acctbal,s_comment\n\
+///    1,Supplier#000000001, N kD4on9OM Ipw3,gf0JBoQDd7tgrzrddZ,17,27-918-335-1736,5755.94,\"each slyly above the careful\"\n\
+///    2,Supplier#000000002,89eJ5ksX3ImxJQBvxObC,,5,15-679-861-2259,4032.68,\" slyly bold instructions. idle dependen\"\n\
+///    3,Supplier#000000003,q1,G3Pj6OjIuUYfUoH18BFTKP5aU9bEV3,1,11-383-516-1199,4192.40,\"blithely silent requests after the express dependencies are sl\"\n"
+/// );
+/// ```
+pub struct SupplierCsv {
+    inner: Supplier,
+}
+
+impl SupplierCsv {
+    pub fn new(inner: Supplier) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Supplier table
+    pub fn header() -> &'static str {
+        "s_suppkey,s_name,s_address,s_nationkey,s_phone,s_acctbal,s_comment"
+    }
+}
+
+impl Display for SupplierCsv {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},{},{},\"{}\"",
+            self.inner.s_suppkey,
+            self.inner.s_name,
+            self.inner.s_address,
+            self.inner.s_nationkey,
+            self.inner.s_phone,
+            self.inner.s_acctbal,
+            self.inner.s_comment
+        )
+    }
+}
+
+/// Write [`Customer`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::CustomerGenerator;
+/// # use tpchgen::csv::CustomerCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = CustomerGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", CustomerCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", CustomerCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "c_custkey,c_name,c_address,c_nationkey,c_phone,c_acctbal,c_mktsegment,c_comment\n\
+///    1,Customer#000000001,IVhzIApeRb ot,c,E,15,25-989-741-2988,711.56,BUILDING,\"to the even, regular platelets. regular, ironic epitaphs nag e\"\n\
+///    2,Customer#000000002,XSTf4,NCwDVaWNe6tEgvwfmRchLXak,13,23-768-687-3665,121.65,AUTOMOBILE,\"l accounts. blithely ironic theodolites integrate boldly: caref\"\n\
+///    3,Customer#000000003,MG9kdTD2WBHm,1,11-719-748-3364,7498.12,AUTOMOBILE,\" deposits eat slyly ironic, even instructions. express foxes detect slyly. blithely even accounts abov\"\n"
+/// );
+/// ```
+pub struct CustomerCsv<'a> {
+    inner: Customer<'a>,
+}
+
+impl<'a> CustomerCsv<'a> {
+    pub fn new(inner: Customer<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Customer table
+    pub fn header() -> &'static str {
+        "c_custkey,c_name,c_address,c_nationkey,c_phone,c_acctbal,c_mktsegment,c_comment"
+    }
+}
+
+impl Display for CustomerCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},{},{},{},\"{}\"",
+            self.inner.c_custkey,
+            self.inner.c_name,
+            self.inner.c_address,
+            self.inner.c_nationkey,
+            self.inner.c_phone,
+            self.inner.c_acctbal,
+            self.inner.c_mktsegment,
+            self.inner.c_comment
+        )
+    }
+}
+
+/// Write [`PartSupp`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::PartSupplierGenerator;
+/// # use tpchgen::csv::PartSuppCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = PartSupplierGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", PartSuppCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", PartSuppCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "ps_partkey,ps_suppkey,ps_availqty,ps_supplycost,ps_comment\n\
+///    1,2,3325,771.64,\", even theodolites. regular, final theodolites eat after the carefully pending foxes. furiously regular deposits sleep slyly. carefully bold realms above the ironic dependencies haggle careful\"\n\
+///    1,2502,8076,993.49,\"ven ideas. quickly even packages print. pending multipliers must have to are fluff\"\n\
+///    1,5002,3956,337.09,\"after the fluffily ironic deposits? blithely special dependencies integrate furiously even excuses. blithely silent theodolites could have to haggle pending, express requests; fu\"\n"
+/// );
+/// ```
+pub struct PartSuppCsv<'a> {
+    inner: PartSupp<'a>,
+}
+
+impl<'a> PartSuppCsv<'a> {
+    pub fn new(inner: PartSupp<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the PartSupp table
+    pub fn header() -> &'static str {
+        "ps_partkey,ps_suppkey,ps_availqty,ps_supplycost,ps_comment"
+    }
+}
+
+impl Display for PartSuppCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},\"{}\"",
+            self.inner.ps_partkey,
+            self.inner.ps_suppkey,
+            self.inner.ps_availqty,
+            self.inner.ps_supplycost,
+            self.inner.ps_comment
+        )
+    }
+}
+
+/// Write [`Order`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::OrderGenerator;
+/// # use tpchgen::csv::OrderCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = OrderGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", OrderCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", OrderCsv::new(line)).unwrap();
+/// }
+/// assert_eq!(
+///   csv,
+///   "o_orderkey,o_custkey,o_orderstatus,o_totalprice,o_orderdate,o_orderpriority,o_clerk,o_shippriority,o_comment\n\
+///    1,36901,O,173665.47,1996-01-02,5-LOW,Clerk#000000951,0,\"nstructions sleep furiously among \"\n\
+///    2,78002,O,46929.18,1996-12-01,1-URGENT,Clerk#000000880,0,\" foxes. pending accounts at the pending, silent asymptot\"\n\
+///    3,123314,F,193846.25,1993-10-14,5-LOW,Clerk#000000955,0,\"sly final accounts boost. carefully regular ideas cajole carefully. depos\"\n"
+/// );
+/// ```
+pub struct OrderCsv<'a> {
+    inner: Order<'a>,
+}
+
+impl<'a> OrderCsv<'a> {
+    pub fn new(inner: Order<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the Order table
+    pub fn header() -> &'static str {
+        "o_orderkey,o_custkey,o_orderstatus,o_totalprice,o_orderdate,o_orderpriority,o_clerk,o_shippriority,o_comment"
+    }
+}
+
+impl Display for OrderCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},{},{},{},{},\"{}\"",
+            self.inner.o_orderkey,
+            self.inner.o_custkey,
+            self.inner.o_orderstatus,
+            self.inner.o_totalprice,
+            self.inner.o_orderdate,
+            self.inner.o_orderpriority,
+            self.inner.o_clerk,
+            self.inner.o_shippriority,
+            self.inner.o_comment
+        )
+    }
+}
+
+/// Write [`LineItem`]s in CSV format.
+///
+/// # Example
+/// ```
+/// # use tpchgen::generators::LineItemGenerator;
+/// # use tpchgen::csv::LineItemCsv;
+/// # use std::fmt::Write;
+/// // Output the first 3 rows in CSV format
+/// let generator = LineItemGenerator::new(1.0, 1, 1);
+/// let mut csv = String::new();
+/// writeln!(&mut csv, "{}", LineItemCsv::header()).unwrap(); // write header
+/// for line in generator.iter().take(3) {
+///   // write line using CSV formatter
+///   writeln!(&mut csv, "{}", LineItemCsv::new(line)).unwrap();
+/// }
+///  assert_eq!(
+///   csv,
+///   "l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment\n\
+///    1,155190,7706,1,17,21168.23,0.04,0.02,N,O,1996-03-13,1996-02-12,1996-03-22,DELIVER IN PERSON,TRUCK,\"egular courts above the\"\n\
+///    1,67310,7311,2,36,45983.16,0.09,0.06,N,O,1996-04-12,1996-02-28,1996-04-20,TAKE BACK RETURN,MAIL,\"ly final dependencies: slyly bold \"\n\
+///    1,63700,3701,3,8,13309.60,0.10,0.02,N,O,1996-01-29,1996-03-05,1996-01-31,TAKE BACK RETURN,REG AIR,\"riously. regular, express dep\"\n"
+///   );
+/// ```
+///
+/// [crate documentation]: crate
+pub struct LineItemCsv<'a> {
+    inner: LineItem<'a>,
+}
+impl<'a> LineItemCsv<'a> {
+    pub fn new(inner: LineItem<'a>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns the CSV header for the LineItem table
+    pub fn header() -> &'static str {
+        "l_orderkey,l_partkey,l_suppkey,l_linenumber,l_quantity,l_extendedprice,l_discount,l_tax,l_returnflag,l_linestatus,l_shipdate,l_commitdate,l_receiptdate,l_shipinstruct,l_shipmode,l_comment"
+    }
+}
+
+impl Display for LineItemCsv<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            // note must quote the comment field as it may contain commas
+            "{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},\"{}\"",
+            self.inner.l_orderkey,
+            self.inner.l_partkey,
+            self.inner.l_suppkey,
+            self.inner.l_linenumber,
+            self.inner.l_quantity,
+            self.inner.l_extendedprice,
+            self.inner.l_discount,
+            self.inner.l_tax,
+            self.inner.l_returnflag,
+            self.inner.l_linestatus,
+            self.inner.l_shipdate,
+            self.inner.l_commitdate,
+            self.inner.l_receiptdate,
+            self.inner.l_shipinstruct,
+            self.inner.l_shipmode,
+            self.inner.l_comment
+        )
+    }
+}

--- a/tpchgen/src/lib.rs
+++ b/tpchgen/src/lib.rs
@@ -30,9 +30,12 @@
 //! provides the following output formats:
 //!
 //! - TBL: The `Display` impl of the row structs produces the TPCH TBL format.
+//! - CSV: the [`csv`] module has formatters for CSV output (e.g. [`LineItemCsv`]).
 //!
 //! [`LineItem`]: generators::LineItem
+//! [`LineItemCsv`]: csv::LineItemCsv
 
+pub mod csv;
 pub mod dates;
 pub mod decimal;
 pub mod distribution;


### PR DESCRIPTION
Add ability to print tpch tables as csv files

- closes https://github.com/clflushopt/tpchgen-rs/issues/53

This is a step towards parallel generation and parquet output


I also verified you can query these files from datafusion-cli. A teaser:
```sql
> select * from '/tmp/tpchdbgen-rs/lineitem.csv' limit 10;
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
| l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct    | l_shipmode | l_comment                           |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
| 1          | 15519     | 785       | 1            | 17         | 24386.67        | 0.04       | 0.02  | N            | O            | 1996-03-13 | 1996-02-12   | 1996-03-22    | DELIVER IN PERSON | TRUCK      | egular courts above the             |
| 1          | 6731      | 732       | 2            | 36         | 58958.28        | 0.09       | 0.06  | N            | O            | 1996-04-12 | 1996-02-28   | 1996-04-20    | TAKE BACK RETURN  | MAIL       | ly final dependencies: slyly bold   |
| 1          | 6370      | 371       | 3            | 8          | 10210.96        | 0.1        | 0.02  | N            | O            | 1996-01-29 | 1996-03-05   | 1996-01-31    | TAKE BACK RETURN  | REG AIR    | riously. regular, express dep       |
| 1          | 214       | 465       | 4            | 28         | 31197.88        | 0.09       | 0.06  | N            | O            | 1996-04-21 | 1996-03-30   | 1996-05-16    | NONE              | AIR        | lites. fluffily even de             |
| 1          | 2403      | 160       | 5            | 24         | 31329.6         | 0.1        | 0.04  | N            | O            | 1996-03-30 | 1996-03-14   | 1996-04-01    | NONE              | FOB        |  pending foxes. slyly re            |
| 1          | 1564      | 67        | 6            | 32         | 46897.92        | 0.07       | 0.02  | N            | O            | 1996-01-30 | 1996-02-07   | 1996-02-03    | DELIVER IN PERSON | MAIL       | arefully slyly ex                   |
| 2          | 10617     | 138       | 1            | 38         | 58049.18        | 0.0        | 0.05  | N            | O            | 1997-01-28 | 1997-01-14   | 1997-02-02    | TAKE BACK RETURN  | RAIL       | ven requests. deposits breach a     |
| 3          | 430       | 181       | 1            | 45         | 59869.35        | 0.06       | 0.0   | R            | F            | 1994-02-02 | 1994-01-04   | 1994-02-23    | NONE              | AIR        | ongside of the furiously brave acco |
| 3          | 1904      | 658       | 2            | 49         | 88489.1         | 0.1        | 0.0   | R            | F            | 1993-11-09 | 1993-12-20   | 1993-11-24    | TAKE BACK RETURN  | RAIL       |  unusual accounts. eve              |
| 3          | 12845     | 370       | 3            | 27         | 47461.68        | 0.06       | 0.07  | A            | F            | 1994-01-16 | 1993-11-22   | 1994-01-23    | DELIVER IN PERSON | SHIP       | nal foxes wake.                     |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+-------------------------------------+
10 row(s) fetched.
Elapsed 0.029 seconds.
```

<details><summary>Details</summary>
<p>



```sql
> describe '/tmp/tpchdbgen-rs/lineitem.csv';
+-----------------+-----------+-------------+
| column_name     | data_type | is_nullable |
+-----------------+-----------+-------------+
| l_orderkey      | Int64     | YES         |
| l_partkey       | Int64     | YES         |
| l_suppkey       | Int64     | YES         |
| l_linenumber    | Int64     | YES         |
| l_quantity      | Int64     | YES         |
| l_extendedprice | Float64   | YES         |
| l_discount      | Float64   | YES         |
| l_tax           | Float64   | YES         |
| l_returnflag    | Utf8      | YES         |
| l_linestatus    | Utf8      | YES         |
| l_shipdate      | Date32    | YES         |
| l_commitdate    | Date32    | YES         |
| l_receiptdate   | Date32    | YES         |
| l_shipinstruct  | Utf8      | YES         |
| l_shipmode      | Utf8      | YES         |
| l_comment       | Utf8      | YES         |
+-----------------+-----------+-------------+
16 row(s) fetched.
Elapsed 0.006 seconds.

```

you can also use `CREATE EXTERNAL TABLE` syntax:
```sql

DataFusion CLI v46.0.1
> CREATE EXTERNAL TABLE IF NOT EXISTS lineitem (
        l_orderkey BIGINT,
        l_partkey BIGINT,
        l_suppkey BIGINT,
        l_linenumber INTEGER,
        l_quantity DECIMAL(15, 2),
        l_extendedprice DECIMAL(15, 2),
        l_discount DECIMAL(15, 2),
        l_tax DECIMAL(15, 2),
        l_returnflag VARCHAR,
        l_linestatus VARCHAR,
        l_shipdate DATE,
        l_commitdate DATE,
        l_receiptdate DATE,
        l_shipinstruct VARCHAR,
        l_shipmode VARCHAR,
        l_comment VARCHAR,
) STORED AS CSV LOCATION '/tmp/tpchdbgen-rs/lineitem.csv';

0 row(s) fetched.
Elapsed 0.002 seconds.

> select * from lineitem limit 10;
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+------------------------------------------+
| l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct    | l_shipmode | l_comment                                |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+------------------------------------------+
| 75523      | 2979      | 232       | 2            | 44.00      | 82806.68        | 0.09       | 0.00  | N            | O            | 1995-10-06 | 1995-11-05   | 1995-11-04    | NONE              | REG AIR    | ructions sleep blithely deposits. fluff  |
| 75523      | 5359      | 615       | 3            | 14.00      | 17700.90        | 0.02       | 0.05  | N            | O            | 1995-12-07 | 1995-11-11   | 1995-12-18    | NONE              | REG AIR    | eas-- finally even depo                  |
| 75524      | 19433     | 434       | 1            | 28.00      | 37868.04        | 0.06       | 0.07  | N            | O            | 1995-12-28 | 1995-11-07   | 1996-01-11    | COLLECT COD       | REG AIR    | e the quickly regular foxes              |
| 75524      | 17789     | 591       | 2            | 27.00      | 46083.06        | 0.08       | 0.08  | N            | O            | 1995-10-09 | 1995-11-19   | 1995-10-30    | COLLECT COD       | MAIL       | ans. furiously even depo                 |
| 75524      | 16599     | 398       | 3            | 43.00      | 65170.37        | 0.00       | 0.01  | N            | O            | 1995-12-24 | 1995-12-16   | 1996-01-17    | TAKE BACK RETURN  | AIR        | ges. boldly ironic foxes p               |
| 75524      | 15039     | 40        | 4            | 15.00      | 14310.45        | 0.05       | 0.05  | N            | O            | 1995-10-29 | 1995-12-10   | 1995-11-20    | DELIVER IN PERSON | AIR        | nd the theodolites sleep carefully ca    |
| 75525      | 9871      | 872       | 1            | 36.00      | 64111.32        | 0.00       | 0.02  | N            | O            | 1995-08-30 | 1995-07-10   | 1995-09-20    | TAKE BACK RETURN  | TRUCK      | e slyly pending deposits. blithely bo    |
| 75525      | 171       | 172       | 2            | 24.00      | 25708.08        | 0.05       | 0.04  | N            | O            | 1995-07-22 | 1995-07-21   | 1995-08-17    | NONE              | RAIL       | kly special deposits. pending, bold shea |
| 75526      | 9745      | 264       | 1            | 42.00      | 69499.08        | 0.08       | 0.01  | R            | F            | 1994-06-23 | 1994-04-26   | 1994-07-14    | DELIVER IN PERSON | TRUCK      |  excuses are idly. qui                   |
| 75527      | 1682      | 934       | 1            | 31.00      | 49094.08        | 0.00       | 0.06  | N            | O            | 1997-11-02 | 1997-10-10   | 1997-11-26    | DELIVER IN PERSON | REG AIR    | among the furiously sile                 |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+------------------------------------------+
10 row(s) fetched.
Elapsed 0.019 seconds.

> describe lineitem;
+-----------------+-------------------+-------------+
| column_name     | data_type         | is_nullable |
+-----------------+-------------------+-------------+
| l_orderkey      | Int64             | YES         |
| l_partkey       | Int64             | YES         |
| l_suppkey       | Int64             | YES         |
| l_linenumber    | Int32             | YES         |
| l_quantity      | Decimal128(15, 2) | YES         |
| l_extendedprice | Decimal128(15, 2) | YES         |
| l_discount      | Decimal128(15, 2) | YES         |
| l_tax           | Decimal128(15, 2) | YES         |
| l_returnflag    | Utf8              | YES         |
| l_linestatus    | Utf8              | YES         |
| l_shipdate      | Date32            | YES         |
| l_commitdate    | Date32            | YES         |
| l_receiptdate   | Date32            | YES         |
| l_shipinstruct  | Utf8              | YES         |
| l_shipmode      | Utf8              | YES         |
| l_comment       | Utf8              | YES         |
+-----------------+-------------------+-------------+
16 row(s) fetched.
Elapsed 0.001 seconds.
```

</p>
</details> 

# Performance

The time to make tbl format hasn't changed:

```shell
$ time target/release/tpchgen-cli -s 1 --output-dir=/tmp/tpchdbgen-rs
Generation complete!

real	0m5.281s
user	0m5.010s
sys	0m0.250s
```

The time to make CSV format is about th esame:

```shell
$ time target/release/tpchgen-cli -s 1 --format csv --output-dir=/tmp/tpchdbgen-rs
Generation complete!

real	0m5.319s
user	0m5.041s
sys	0m0.235s
```

# Testing

The CSV generation is tested via doc examples (which now also run in CI after https://github.com/clflushopt/tpchgen-rs/pull/55).

I did not add integration tests for tpchgen-cli
