### PR TITLE
Avoid creating Strings during distribution gen (WIP)

### DIFF
--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -523,12 +523,7 @@ impl<'a> RandomStringSequence<'a> {
 
     pub fn next_value(&mut self) -> StringSequenceInstance<'a> {
         // Get all values from the distribution
-        let mut values: Vec<&str> = self
-            .distribution
-            .get_values()
-            .iter()
-            .map(|s| s.as_str())
-            .collect();
+        let mut values: Vec<&str> = self.distribution.get_values().to_vec();
 
         // Randomize first 'count' elements
         for current_position in 0..self.count {


### PR DESCRIPTION
- Related to https://github.com/clflushopt/tpchgen-rs/issues/56

I was trying to make the startup time faster and one thing I figured I could do is stop copying strings during text pool generation. 

However I made the change to avoid copying and it doesn't really seem to have helped, but I figured I would put up the PR in case someone else was interested


Main
```shell
(venv) andrewlamb@Andrews-MacBook-Pro-2:~/Software/tpchgen-rs$ time target/release/tpchgen-cli -s 1 --tables=nation --output-dir=/tmp/tpchdbgen-rs
Generation complete!

real	0m1.955s
user	0m1.901s
sys	0m0.051s
```

This branch:
```
branch 'alamb/faster_table_gen' set up to track 'alamb/alamb/faster_table_gen'.
(venv) andrewlamb@Andrews-MacBook-Pro-2:~/Software/tpchgen-rs$ time target/release/tpchgen-cli -s 1 --tables=nation --output-dir=/tmp/tpchdbgen-rs
Generation complete!

real	0m1.953s
user	0m1.910s
sys	0m0.039s
```