### PR TITLE
Parallel output in tpchgen-cli (Nx faster, where N is number of cores)

### DIFF
--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["clflushopt", "alamb"]
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
 tpchgen = { path = "../tpchgen" }
+tokio = { version = "1.44.1", features = ["full"]}
+futures = "0.3.31"
+num_cpus = "1.0"
+log = "0.4.26"
+env_logger = "0.11.7"

--- a/tpchgen-cli/src/csv.rs
+++ b/tpchgen-cli/src/csv.rs
@@ -1,5 +1,4 @@
-//! Implementations of [`Source`] for various different TPCH tables
-
+//! Implementations of [`Source`] for generating data in TBL format
 use super::generate::Source;
 use std::io::Write;
 use tpchgen::csv::{
@@ -9,31 +8,6 @@ use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
-
-/// Define a Source that writes the table in TBL format
-macro_rules! define_tbl_source {
-    ($SOURCE_NAME:ident, $GENERATOR_TYPE:ty) => {
-        pub struct $SOURCE_NAME {
-            inner: $GENERATOR_TYPE,
-        }
-
-        impl $SOURCE_NAME {
-            pub fn new(inner: $GENERATOR_TYPE) -> Self {
-                Self { inner }
-            }
-        }
-
-        impl Source for $SOURCE_NAME {
-            fn create(self, mut buffer: Vec<u8>) -> Vec<u8> {
-                for item in self.inner.iter() {
-                    // The default Display impl writes TBL format
-                    writeln!(&mut buffer, "{item}").expect("writing to memory is infallible");
-                }
-                buffer
-            }
-        }
-    };
-}
 
 /// Define a Source that writes the table in CSV format
 macro_rules! define_csv_source {
@@ -61,16 +35,6 @@ macro_rules! define_csv_source {
         }
     };
 }
-
-// Define .tbl sources for all tables
-define_tbl_source!(NationTblSource, NationGenerator<'static>);
-define_tbl_source!(RegionTblSource, RegionGenerator<'static>);
-define_tbl_source!(PartTblSource, PartGenerator<'static>);
-define_tbl_source!(SupplierTblSource, SupplierGenerator<'static>);
-define_tbl_source!(PartSuppTblSource, PartSupplierGenerator<'static>);
-define_tbl_source!(CustomerTblSource, CustomerGenerator<'static>);
-define_tbl_source!(OrderTblSource, OrderGenerator<'static>);
-define_tbl_source!(LineItemTblSource, LineItemGenerator<'static>);
 
 // Define .csv sources for all tables
 define_csv_source!(NationCsvSource, NationGenerator<'static>, NationCsv);

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -101,7 +101,7 @@ where
 
 /// A simple buffer recycler to avoid allocating new buffers for each part
 ///
-/// Clones share the same undrlying recycler, so it is not thread safe
+/// Clones share the same underlying recycler, so it is not thread safe
 #[derive(Debug, Clone)]
 struct BufferRecycler {
     buffers: Arc<Mutex<VecDeque<Vec<u8>>>>,

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -26,7 +26,8 @@ pub trait Sink: Send {
     /// Write all data from the buffer to the sink
     fn sink(&mut self, buffer: &[u8]) -> Result<(), io::Error>;
 
-    fn finish(self) -> Result<(), io::Error>;
+    /// Complete and flush any remaining data from the sink
+    fn flush(self) -> Result<(), io::Error>;
 }
 
 /// Creates data from a set of [`Source`] in parallel sending data in order to the Sink.
@@ -84,7 +85,7 @@ where
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
         }
-        sink.finish()
+        sink.flush()
     });
 
     // drive the stream to completion

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -1,0 +1,134 @@
+//! Parallel data generation: [`Source`] and [`Sink`] and [`generate_in_chunks`]
+//!
+//! These traits and function are used to generate data in parallel and write it to a sink
+//! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
+
+use futures::StreamExt;
+use log::debug;
+use std::collections::VecDeque;
+use std::io;
+use std::sync::{Arc, Mutex};
+use tokio::task::JoinSet;
+
+/// Something that knows how to generate data into a buffer
+///
+/// For example, this is implemented for the different generators in the tpchgen
+/// crate
+pub trait Source: Send {
+    /// generates the data for this generator into the buffer, returning the buffer.
+    fn create(self, buffer: Vec<u8>) -> Vec<u8>;
+}
+
+/// Something that can write the contents of a buffer somewhere
+///
+/// For example, this is implemented for a file writer
+pub trait Sink: Send {
+    /// Write all data from the buffer to the sink
+    fn sink(&mut self, buffer: &[u8]) -> Result<(), io::Error>;
+
+    fn finish(self) -> Result<(), io::Error>;
+}
+
+/// Creates data from a set of [`Source`] in parallel sending data in order to the Sink.
+///
+///
+/// G: Generator
+/// I: Iterator<Item = G>
+/// S: Sink that writes buffers somewhere
+pub async fn generate_in_chunks<G, I, S>(mut sink: S, generators: I) -> Result<(), io::Error>
+where
+    G: Source + 'static,
+    I: Iterator<Item = G>,
+    S: Sink + 'static,
+{
+    let recycler = BufferRecycler::new();
+
+    // use all cores to make data
+    let num_tasks = num_cpus::get();
+    debug!("Generating with {num_tasks} parallel tasks");
+
+    // create a channel to communicate between the generator tasks and the writer task
+    let (tx, mut rx) = tokio::sync::mpsc::channel(num_tasks);
+
+    let generators_and_recyclers = generators.map(|generator| (generator, recycler.clone()));
+
+    // convert to an async stream to run on tokio
+    let mut stream = futures::stream::iter(generators_and_recyclers)
+        // each generator writes to a buffer
+        .map(async |(generator, recycler)| {
+            let buffer = recycler.new_buffer(1024 * 1024 * 8);
+            // do the work in a task (on a different thread)
+            let mut join_set = JoinSet::new();
+            join_set.spawn(async move { generator.create(buffer) });
+            // wait for the task to be done and return the result
+            join_set
+                .join_next()
+                .await
+                .expect("had one item")
+                .expect("join_next join is infallible unless task panics")
+        })
+        // run in parallel
+        .buffered(num_tasks)
+        .map(async |buffer| {
+            // send the buffer to the writer task, in order.
+
+            // ignoring error (if the writer errored it means the channel is closed / the program is exiting)
+            if let Err(e) = tx.send(buffer).await {
+                debug!("Error sending buffer to writer: {e}");
+            }
+        });
+
+    let captured_recycler = recycler.clone();
+    let writer_task = tokio::task::spawn_blocking(move || {
+        while let Some(buffer) = rx.blocking_recv() {
+            sink.sink(&buffer)?;
+            captured_recycler.return_buffer(buffer);
+        }
+        sink.finish()
+    });
+
+    // drive the stream to completion
+    while let Some(write_task) = stream.next().await {
+        write_task.await; // sends the buffer to the writer task
+    }
+    drop(stream); // drop any stream references
+    drop(tx); // drop last tx reference to stop the writer
+
+    // wait for writer to finish
+    debug!("waiting for writer task to complete");
+    writer_task.await.expect("writer task panicked")
+}
+
+/// A simple buffer recycler to avoid allocating new buffers for each part
+///
+/// Clones share the same undrlying recycler, so it is not thread safe
+#[derive(Debug, Clone)]
+struct BufferRecycler {
+    buffers: Arc<Mutex<VecDeque<Vec<u8>>>>,
+}
+
+impl BufferRecycler {
+    fn new() -> Self {
+        Self {
+            buffers: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+    /// return a new empty buffer, with size bytes capacity
+    fn new_buffer(&self, size: usize) -> Vec<u8> {
+        let mut buffers = self.buffers.lock().unwrap();
+        if let Some(mut buffer) = buffers.pop_front() {
+            buffer.clear();
+            if size > buffer.capacity() {
+                buffer.reserve(size - buffer.capacity());
+            }
+            buffer
+        } else {
+            Vec::with_capacity(size)
+        }
+    }
+
+    fn return_buffer(&self, buffer: Vec<u8>) {
+        let mut buffers = self.buffers.lock().unwrap();
+        buffers.push_back(buffer);
+    }
+}

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -380,7 +380,7 @@ impl Sink for BufWriterSink {
         self.inner.write_all(buffer)
     }
 
-    fn finish(mut self) -> Result<(), io::Error> {
+    fn flush(mut self) -> Result<(), io::Error> {
         let res = self.inner.flush();
 
         let duration = self.start.elapsed();

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -28,11 +28,13 @@
 //! # see all debug output
 //! RUST_LOG=debug tpchgen -s 1
 //! ```
+mod csv;
 mod generate;
-mod sources;
+mod tbl;
 
+use crate::csv::*;
 use crate::generate::{generate_in_chunks, Sink, Source};
-use crate::sources::*;
+use crate::tbl::*;
 use clap::{Parser, ValueEnum};
 use log::{debug, info, LevelFilter};
 use std::fmt::Display;

--- a/tpchgen-cli/src/sources.rs
+++ b/tpchgen-cli/src/sources.rs
@@ -1,0 +1,87 @@
+//! Implementations of [`Source`] for various different TPCH tables
+
+use super::generate::Source;
+use std::io::Write;
+use tpchgen::csv::{
+    CustomerCsv, LineItemCsv, NationCsv, OrderCsv, PartCsv, PartSuppCsv, RegionCsv, SupplierCsv,
+};
+use tpchgen::generators::{
+    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    PartSupplierGenerator, RegionGenerator, SupplierGenerator,
+};
+
+/// Define a Source that writes the table in TBL format
+macro_rules! define_tbl_source {
+    ($SOURCE_NAME:ident, $GENERATOR_TYPE:ty) => {
+        pub struct $SOURCE_NAME {
+            inner: $GENERATOR_TYPE,
+        }
+
+        impl $SOURCE_NAME {
+            pub fn new(inner: $GENERATOR_TYPE) -> Self {
+                Self { inner }
+            }
+        }
+
+        impl Source for $SOURCE_NAME {
+            fn create(self, mut buffer: Vec<u8>) -> Vec<u8> {
+                for item in self.inner.iter() {
+                    // The default Display impl writes TBL format
+                    writeln!(&mut buffer, "{item}").expect("writing to memory is infallible");
+                }
+                buffer
+            }
+        }
+    };
+}
+
+/// Define a Source that writes the table in CSV format
+macro_rules! define_csv_source {
+    ($SOURCE_NAME:ident, $GENERATOR_TYPE:ty, $FORMATTER:ty) => {
+        pub struct $SOURCE_NAME {
+            inner: $GENERATOR_TYPE,
+        }
+
+        impl $SOURCE_NAME {
+            pub fn new(inner: $GENERATOR_TYPE) -> Self {
+                Self { inner }
+            }
+        }
+
+        impl Source for $SOURCE_NAME {
+            fn create(self, mut buffer: Vec<u8>) -> Vec<u8> {
+                writeln!(&mut buffer, "{}", <$FORMATTER>::header())
+                    .expect("writing to memory is infallible");
+                for item in self.inner.iter() {
+                    let formatter = <$FORMATTER>::new(item);
+                    writeln!(&mut buffer, "{formatter}").expect("writing to memory is infallible");
+                }
+                buffer
+            }
+        }
+    };
+}
+
+// Define .tbl sources for all tables
+define_tbl_source!(NationTblSource, NationGenerator<'static>);
+define_tbl_source!(RegionTblSource, RegionGenerator<'static>);
+define_tbl_source!(PartTblSource, PartGenerator<'static>);
+define_tbl_source!(SupplierTblSource, SupplierGenerator<'static>);
+define_tbl_source!(PartSuppTblSource, PartSupplierGenerator<'static>);
+define_tbl_source!(CustomerTblSource, CustomerGenerator<'static>);
+define_tbl_source!(OrderTblSource, OrderGenerator<'static>);
+define_tbl_source!(LineItemTblSource, LineItemGenerator<'static>);
+
+// Define .csv sources for all tables
+define_csv_source!(NationCsvSource, NationGenerator<'static>, NationCsv);
+define_csv_source!(RegionCsvSource, RegionGenerator<'static>, RegionCsv);
+define_csv_source!(PartCsvSource, PartGenerator<'static>, PartCsv);
+define_csv_source!(SupplierCsvSource, SupplierGenerator<'static>, SupplierCsv);
+define_csv_source!(
+    PartSuppCsvSource,
+    PartSupplierGenerator<'static>,
+    PartSuppCsv
+);
+define_csv_source!(CustomerCsvSource, CustomerGenerator<'static>, CustomerCsv);
+define_csv_source!(OrderCsvSource, OrderGenerator<'static>, OrderCsv);
+define_csv_source!(LineItemCsvSource, LineItemGenerator<'static>, LineItemCsv);

--- a/tpchgen-cli/src/tbl.rs
+++ b/tpchgen-cli/src/tbl.rs
@@ -1,0 +1,43 @@
+//! Implementations of [`Source`] for generating data in TBL format
+
+use super::generate::Source;
+use std::io::Write;
+use tpchgen::generators::{
+    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    PartSupplierGenerator, RegionGenerator, SupplierGenerator,
+};
+
+/// Define a Source that writes the table in TBL format
+macro_rules! define_tbl_source {
+    ($SOURCE_NAME:ident, $GENERATOR_TYPE:ty) => {
+        pub struct $SOURCE_NAME {
+            inner: $GENERATOR_TYPE,
+        }
+
+        impl $SOURCE_NAME {
+            pub fn new(inner: $GENERATOR_TYPE) -> Self {
+                Self { inner }
+            }
+        }
+
+        impl Source for $SOURCE_NAME {
+            fn create(self, mut buffer: Vec<u8>) -> Vec<u8> {
+                for item in self.inner.iter() {
+                    // The default Display impl writes TBL format
+                    writeln!(&mut buffer, "{item}").expect("writing to memory is infallible");
+                }
+                buffer
+            }
+        }
+    };
+}
+
+// Define .tbl sources for all tables
+define_tbl_source!(NationTblSource, NationGenerator<'static>);
+define_tbl_source!(RegionTblSource, RegionGenerator<'static>);
+define_tbl_source!(PartTblSource, PartGenerator<'static>);
+define_tbl_source!(SupplierTblSource, SupplierGenerator<'static>);
+define_tbl_source!(PartSuppTblSource, PartSupplierGenerator<'static>);
+define_tbl_source!(CustomerTblSource, CustomerGenerator<'static>);
+define_tbl_source!(OrderTblSource, OrderGenerator<'static>);
+define_tbl_source!(LineItemTblSource, LineItemGenerator<'static>);

--- a/tpchgen/src/csv.rs
+++ b/tpchgen/src/csv.rs
@@ -12,7 +12,7 @@ use std::fmt::Display;
 /// # use tpchgen::csv::NationCsv;
 /// # use std::fmt::Write;
 /// // Output the first 3 rows in CSV format
-/// let generator = NationGenerator::new();
+/// let generator = NationGenerator::default();
 /// let mut csv = String::new();
 /// writeln!(&mut csv, "{}", NationCsv::header()).unwrap(); // write header
 /// for line in generator.iter().take(3) {
@@ -60,7 +60,7 @@ impl Display for NationCsv<'_> {
 /// # use tpchgen::generators::{RegionGenerator};
 /// # use tpchgen::csv::{NationCsv, RegionCsv};
 /// # use std::fmt::Write;
-/// let generator = RegionGenerator::new();
+/// let generator = RegionGenerator::default();
 /// // Output the first 3 rows in CSV format
 /// let mut csv = String::new();
 /// writeln!(&mut csv, "{}", RegionCsv::header()).unwrap(); // write header

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -23,16 +23,22 @@ pub struct NationGenerator<'a> {
 
 impl Default for NationGenerator<'_> {
     fn default() -> Self {
-        Self::new()
+        // arguments are ignored
+        Self::new(1.0, 1, 1)
     }
 }
 
 impl<'a> NationGenerator<'a> {
     /// Creates a new NationGenerator with default distributions and text pool
     ///
+    /// Nations does not depend on the scale factor or the part number. The signature of
+    /// this method is provided to be consistent with the other generators, but the
+    /// parameters are ignored. You can use [`NationGenerator::default`] to create a
+    /// default generator.
+    ///
     /// The generator's lifetime is `&'static` because it references global
     /// [`Distribution]`s and thus can be shared safely between threads.
-    pub fn new() -> NationGenerator<'static> {
+    pub fn new(_scale_factor: f64, _part: i32, _part_count: i32) -> NationGenerator<'static> {
         // Note: use explicit lifetime to ensure this remains `&'static`
         Self::new_with_distributions_and_text_pool(
             Distributions::static_default(),
@@ -208,16 +214,22 @@ pub struct RegionGenerator<'a> {
 
 impl Default for RegionGenerator<'_> {
     fn default() -> Self {
-        Self::new()
+        // arguments are ignored
+        Self::new(1.0, 1, 1)
     }
 }
 
 impl<'a> RegionGenerator<'a> {
     /// Creates a new RegionGenerator with default distributions and text pool
     ///
+    /// Regions does not depend on the scale factor or the part number. The signature of
+    /// this method is provided to be consistent with the other generators, but the
+    /// parameters are ignored. You can use [`RegionGenerator::default`] to create a
+    /// default generator.
+    ///
     /// Note the generator's lifetime is `&'static`. See [`NationGenerator`] for
     /// more details.
-    pub fn new() -> RegionGenerator<'static> {
+    pub fn new(_scale_factor: f64, _part: i32, _part_count: i32) -> RegionGenerator<'static> {
         // Note: use explicit lifetime to ensure this remains `&'static`
         Self::new_with_distributions_and_text_pool(
             Distributions::static_default(),
@@ -433,6 +445,11 @@ impl<'a> PartGenerator<'a> {
         }
     }
 
+    /// Return the row count for the given scale factor and generator part count
+    pub fn calculate_row_count(scale_factor: f64, part: i32, part_count: i32) -> i64 {
+        GenerateUtils::calculate_row_count(Self::SCALE_BASE, scale_factor, part, part_count)
+    }
+
     /// Returns an iterator over the part rows
     pub fn iter(&self) -> PartGeneratorIterator<'a> {
         PartGeneratorIterator::new(
@@ -444,12 +461,7 @@ impl<'a> PartGenerator<'a> {
                 self.part,
                 self.part_count,
             ),
-            GenerateUtils::calculate_row_count(
-                Self::SCALE_BASE,
-                self.scale_factor,
-                self.part,
-                self.part_count,
-            ),
+            Self::calculate_row_count(self.scale_factor, self.part, self.part_count),
         )
     }
 }
@@ -708,6 +720,11 @@ impl<'a> SupplierGenerator<'a> {
         }
     }
 
+    /// Return the row count for the given scale factor and generator part count
+    pub fn calculate_row_count(scale_factor: f64, part: i32, part_count: i32) -> i64 {
+        GenerateUtils::calculate_row_count(Self::SCALE_BASE, scale_factor, part, part_count)
+    }
+
     /// Returns an iterator over the supplier rows
     pub fn iter(&self) -> SupplierGeneratorIterator<'a> {
         SupplierGeneratorIterator::new(
@@ -719,12 +736,7 @@ impl<'a> SupplierGenerator<'a> {
                 self.part,
                 self.part_count,
             ),
-            GenerateUtils::calculate_row_count(
-                Self::SCALE_BASE,
-                self.scale_factor,
-                self.part,
-                self.part_count,
-            ),
+            Self::calculate_row_count(self.scale_factor, self.part, self.part_count),
         )
     }
 }
@@ -1010,6 +1022,11 @@ impl<'a> CustomerGenerator<'a> {
         }
     }
 
+    /// Return the row count for the given scale factor and generator part count
+    pub fn calculate_row_count(scale_factor: f64, part: i32, part_count: i32) -> i64 {
+        GenerateUtils::calculate_row_count(Self::SCALE_BASE, scale_factor, part, part_count)
+    }
+
     /// Returns an iterator over the customer rows
     pub fn iter(&self) -> CustomerGeneratorIterator<'a> {
         CustomerGeneratorIterator::new(
@@ -1021,12 +1038,7 @@ impl<'a> CustomerGenerator<'a> {
                 self.part,
                 self.part_count,
             ),
-            GenerateUtils::calculate_row_count(
-                Self::SCALE_BASE,
-                self.scale_factor,
-                self.part,
-                self.part_count,
-            ),
+            Self::calculate_row_count(self.scale_factor, self.part, self.part_count),
         )
     }
 }
@@ -1223,9 +1235,19 @@ impl<'a> PartSupplierGenerator<'a> {
         }
     }
 
+    /// Return the row count for the given scale factor and generator part count
+    pub fn calculate_row_count(scale_factor: f64, part: i32, part_count: i32) -> i64 {
+        // Use the part generator's scale base for start/row calculation
+        GenerateUtils::calculate_row_count(
+            PartGenerator::SCALE_BASE,
+            scale_factor,
+            part,
+            part_count,
+        )
+    }
+
     /// Returns an iterator over the part supplier rows
     pub fn iter(&self) -> PartSupplierGeneratorIterator<'a> {
-        // Use the part generator's scale base for start/row calculation
         let scale_base = PartGenerator::SCALE_BASE;
 
         PartSupplierGeneratorIterator::new(
@@ -1237,12 +1259,7 @@ impl<'a> PartSupplierGenerator<'a> {
                 self.part,
                 self.part_count,
             ),
-            GenerateUtils::calculate_row_count(
-                scale_base,
-                self.scale_factor,
-                self.part,
-                self.part_count,
-            ),
+            Self::calculate_row_count(self.scale_factor, self.part, self.part_count),
         )
     }
 }
@@ -1496,6 +1513,11 @@ impl<'a> OrderGenerator<'a> {
         }
     }
 
+    /// Return the row count for the given scale factor and generator part count
+    pub fn calculate_row_count(scale_factor: f64, part: i32, part_count: i32) -> i64 {
+        GenerateUtils::calculate_row_count(Self::SCALE_BASE, scale_factor, part, part_count)
+    }
+
     /// Returns an iterator over the order rows
     pub fn iter(&self) -> OrderGeneratorIterator<'a> {
         OrderGeneratorIterator::new(
@@ -1508,12 +1530,7 @@ impl<'a> OrderGenerator<'a> {
                 self.part,
                 self.part_count,
             ),
-            GenerateUtils::calculate_row_count(
-                Self::SCALE_BASE,
-                self.scale_factor,
-                self.part,
-                self.part_count,
-            ),
+            Self::calculate_row_count(self.scale_factor, self.part, self.part_count),
         )
     }
 
@@ -2211,7 +2228,7 @@ mod tests {
 
     #[test]
     fn test_nation_generator() {
-        let generator = NationGenerator::new();
+        let generator = NationGenerator::default();
         let nations: Vec<_> = generator.iter().collect();
 
         // TPC-H typically has 25 nations
@@ -2220,7 +2237,7 @@ mod tests {
 
     #[test]
     fn test_region_generator() {
-        let generator = RegionGenerator::new();
+        let generator = RegionGenerator::default();
         let regions: Vec<_> = generator.iter().collect();
 
         // TPC-H typically has 5 regions
@@ -2472,8 +2489,8 @@ mod tests {
         // Lifetimes of iterators should be independent of the generator that
         // created it. This test case won't compile if that's not the case.
 
-        let _iter: NationGeneratorIterator<'static> = NationGenerator::new().iter();
-        let _iter: RegionGeneratorIterator<'static> = RegionGenerator::new().iter();
+        let _iter: NationGeneratorIterator<'static> = NationGenerator::default().iter();
+        let _iter: RegionGeneratorIterator<'static> = RegionGenerator::default().iter();
         let _iter: PartGeneratorIterator<'static> = PartGenerator::new(0.1, 1, 1).iter();
         let _iter: SupplierGeneratorIterator<'static> = SupplierGenerator::new(0.1, 1, 1).iter();
         let _iter: CustomerGeneratorIterator<'static> = CustomerGenerator::new(0.1, 1, 1).iter();

--- a/tpchgen/tests/integration_tests.rs
+++ b/tpchgen/tests/integration_tests.rs
@@ -56,7 +56,7 @@ where
 #[test]
 fn test_nation_sf_0_001() {
     let _sf = 0.001;
-    let generator = NationGenerator::new();
+    let generator = NationGenerator::default();
     test_generator(generator.iter(), "data/sf-0.001/nation.tbl.gz", |nation| {
         nation.to_string()
     });
@@ -65,7 +65,7 @@ fn test_nation_sf_0_001() {
 #[test]
 fn test_region_sf_0_001() {
     let _sf = 0.001;
-    let generator = RegionGenerator::new();
+    let generator = RegionGenerator::default();
     test_generator(generator.iter(), "data/sf-0.001/region.tbl.gz", |region| {
         region.to_string()
     });
@@ -131,8 +131,8 @@ fn test_lineitem_sf_0_001() {
 
 #[test]
 fn test_nation_sf_0_01() {
-    let _sf = 0.01;
-    let generator = NationGenerator::new();
+    let sf = 0.01;
+    let generator = NationGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/nation.tbl.gz", |nation| {
         nation.to_string()
     });
@@ -140,8 +140,8 @@ fn test_nation_sf_0_01() {
 
 #[test]
 fn test_region_sf_0_01() {
-    let _sf = 0.01;
-    let generator = RegionGenerator::new();
+    let sf = 0.01;
+    let generator = RegionGenerator::new(sf, 1, 1);
     test_generator(generator.iter(), "data/sf-0.01/region.tbl.gz", |region| {
         region.to_string()
     });


### PR DESCRIPTION
- closes https://github.com/clflushopt/tpchgen-rs/issues/10
- closes https://github.com/clflushopt/tpchgen-rs/pull/34
- builds on https://github.com/clflushopt/tpchgen-rs/pull/54

Features:
1. Logging support via `-v` and `RUST_LOG`
2. Parallel generation for all tables
3. No new dependencies on the tpch core crate and minor changes

# Performance 🌶️ 
In single threaded mode, the generator can create 250MB/sec with each core which is 4GB/s on my 16 core laptop

This scales linearly with 

Here are performance measurements for SF=100 on my Mac M3 (with 16 cores)

| branch | speed | speed (writing to /dev/null) |
|--------|--------|--------|
| main | 6m1.984s | N/A
| this branch | 1m0.099s | 0m28.732s | 




```shell
time target/release/tpchgen-cli -s 100 --output-dir=/tmp/tpchdbgen-rs
```

It actually turns out this can fully saturate the disk bandwidth on my Mac M3 laptop which caps out at 2GB/sec


If I hard code the generator to just throw the data away rather than writing, it keeps all the cores busy and writes at a blistering 4GB/sec
