### PR TITLE
(POC): Remove some hashmap lookups in distribution lookup

### DIFF
--- a/tpchgen/Cargo.toml
+++ b/tpchgen/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["clflushopt", "alamb"]
 # See ../ARCHITECTURE.md for more details
 [dependencies]
 chrono = "0.4.40"
-indexmap = "2.7.1"
 
 [dev-dependencies]
 flate2 = "1.1.0"


### PR DESCRIPTION
Partially addresses https://github.com/clflushopt/tpchgen-rs/issues/56

Also removes IndexMap

Wip. The timings are down, but there might be alternative approaches here that I may try to explore.

This approach would also remove some flexibility with what we allow in a distribution, but I don't think that matter for this.

# Timings

```
$ time cargo run --release -- -s 0.01 --output-dir=/tmp/tpchdbgen-rs-001
```

Tiny SF to capture the initialization time, not actual data generation.

`main`: 2.851s, 2.694s, 2.764s
this branch: 1.860s, 1.867s, 1.864s
