### PR TITLE
Support writing directly to parquet files

### DIFF
--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -5,8 +5,11 @@ edition = "2021"
 authors = ["clflushopt", "alamb"]
 
 [dependencies]
+arrow = "54.3.0"
+parquet = "54.3.0"
 clap = { version = "4.5.32", features = ["derive"] }
 tpchgen = { path = "../tpchgen" }
+tpchgen-arrow = { path = "../tpchgen-arrow" }
 tokio = { version = "1.44.1", features = ["full"]}
 futures = "0.3.31"
 num_cpus = "1.0"

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -168,6 +168,8 @@ macro_rules! define_generate {
         async fn $FUN_NAME(&self) -> io::Result<()> {
             let filename = self.output_filename($TABLE);
             let (num_parts, parts) = self.parallel_target_part_count(&$TABLE);
+            // parquet files can have at most 32K row groups so cap the number of parts
+            let num_parts = num_parts.min(32767);
             let scale_factor = self.scale_factor;
             info!("Writing table {} (SF={scale_factor}) to {filename}", $TABLE);
             debug!("Generating {num_parts} parts in total");

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -30,11 +30,16 @@
 //! ```
 mod csv;
 mod generate;
+mod parquet;
+mod statistics;
 mod tbl;
 
 use crate::csv::*;
 use crate::generate::{generate_in_chunks, Sink, Source};
+use crate::parquet::*;
+use crate::statistics::WriteStatistics;
 use crate::tbl::*;
+use ::parquet::basic::Compression;
 use clap::{Parser, ValueEnum};
 use log::{debug, info, LevelFilter};
 use std::fmt::Display;
@@ -48,6 +53,10 @@ use tpchgen::generators::{
     PartSuppGenerator, RegionGenerator, SupplierGenerator,
 };
 use tpchgen::text::TextPool;
+use tpchgen_arrow::{
+    CustomerArrow, LineItemArrow, NationArrow, OrderArrow, PartArrow, PartSuppArrow,
+    RecordBatchIterator, RegionArrow, SupplierArrow,
+};
 
 #[derive(Parser)]
 #[command(name = "tpchgen")]
@@ -65,7 +74,7 @@ struct Cli {
     #[arg(short, long)]
     tables: Option<Vec<Table>>,
 
-    /// Number of parts to generate (for parallel generation)
+    /// Number of parts to generate (manual parallel generation)
     #[arg(short, long, default_value_t = 1)]
     parts: i32,
 
@@ -76,6 +85,21 @@ struct Cli {
     /// Output format: tbl, csv, parquet (default: tbl)
     #[arg(short, long, default_value = "tbl")]
     format: OutputFormat,
+
+    /// The number of threads for parallel generation, defaults to the number of CPUs
+    #[arg(short, long, default_value_t = num_cpus::get())]
+    num_threads: usize,
+
+    /// The parquet block compression. Default is ZSTD(1)
+    ///
+    /// Supported values: UNCOMPRESSED, ZSTD(N), SNAPPY, GZIP, LZO, BROTLI, LZ4
+    ///
+    /// Using ZSTD results in the best compression, but is about 2x slower than
+    /// UNCOMPRESSED. For example, for the lineitem table at SF=10
+    ///   ZSTD(1):      1.9G  (0.52 GB/sec)
+    ///   UNCOMPRESSED: 3.8G  (1.41 GB/sec)
+    #[arg(short, long, default_value = "ZSTD(1)")]
+    parquet_compression: Compression,
 
     /// Verbose output (default: false)
     #[arg(short, long, default_value_t = false)]
@@ -137,8 +161,9 @@ async fn main() -> io::Result<()> {
 /// $GENERATOR: The generator type to use
 /// $TBL_SOURCE: The [`Source`] type to use for TBL format
 /// $CSV_SOURCE: The [`Source`] type to use for CSV format
+/// $PARQUET_SOURCE: The [`RecordBatchIterator`] type to use for Parquet format
 macro_rules! define_generate {
-    ($FUN_NAME:ident,  $TABLE:expr, $GENERATOR:ident, $TBL_SOURCE:ty, $CSV_SOURCE:ty) => {
+    ($FUN_NAME:ident,  $TABLE:expr, $GENERATOR:ident, $TBL_SOURCE:ty, $CSV_SOURCE:ty, $PARQUET_SOURCE:ty) => {
         async fn $FUN_NAME(&self) -> io::Result<()> {
             let filename = self.output_filename($TABLE);
             let (num_parts, parts) = self.parallel_target_part_count(&$TABLE);
@@ -151,8 +176,10 @@ macro_rules! define_generate {
             match self.format {
                 OutputFormat::Tbl => self.go(&filename, gens.map(<$TBL_SOURCE>::new)).await,
                 OutputFormat::Csv => self.go(&filename, gens.map(<$CSV_SOURCE>::new)).await,
-                // https://github.com/clflushopt/tpchgen-rs/issues/46
-                OutputFormat::Parquet => unimplemented!("Parquet support not yet implemented"),
+                OutputFormat::Parquet => {
+                    self.go_parquet(&filename, gens.map(<$PARQUET_SOURCE>::new))
+                        .await
+                }
             }
         }
     };
@@ -220,56 +247,64 @@ impl Cli {
         Table::Nation,
         NationGenerator,
         NationTblSource,
-        NationCsvSource
+        NationCsvSource,
+        NationArrow
     );
     define_generate!(
         generate_region,
         Table::Region,
         RegionGenerator,
         RegionTblSource,
-        RegionCsvSource
+        RegionCsvSource,
+        RegionArrow
     );
     define_generate!(
         generate_part,
         Table::Part,
         PartGenerator,
         PartTblSource,
-        PartCsvSource
+        PartCsvSource,
+        PartArrow
     );
     define_generate!(
         generate_supplier,
         Table::Supplier,
         SupplierGenerator,
         SupplierTblSource,
-        SupplierCsvSource
+        SupplierCsvSource,
+        SupplierArrow
     );
     define_generate!(
         generate_partsupp,
         Table::PartSupp,
         PartSuppGenerator,
         PartSuppTblSource,
-        PartSuppCsvSource
+        PartSuppCsvSource,
+        PartSuppArrow
     );
     define_generate!(
         generate_customer,
         Table::Customer,
         CustomerGenerator,
         CustomerTblSource,
-        CustomerCsvSource
+        CustomerCsvSource,
+        CustomerArrow
     );
     define_generate!(
         generate_orders,
         Table::Orders,
         OrderGenerator,
         OrderTblSource,
-        OrderCsvSource
+        OrderCsvSource,
+        OrderArrow
     );
     define_generate!(
         generate_lineitem,
         Table::LineItem,
         LineItemGenerator,
         LineItemTblSource,
-        LineItemCsvSource
+        LineItemCsvSource,
+        LineItemArrow
     );
 
     /// return the output filename for the given table
@@ -352,49 +387,42 @@ impl Cli {
         I: Iterator<Item: Source> + 'static,
     {
         let sink = BufWriterSink::new(self.new_output_writer(filename)?);
-        generate_in_chunks(sink, sources).await
+        generate_in_chunks(sink, sources, self.num_threads).await
+    }
+
+    /// Generates an output parquet file from the sources
+    async fn go_parquet<I>(&self, filename: &str, sources: I) -> Result<(), io::Error>
+    where
+        I: Iterator<Item: RecordBatchIterator> + 'static,
+    {
+        let writer = self.new_output_writer(filename)?;
+        generate_parquet(writer, sources, self.num_threads, self.parquet_compression).await
     }
 }
 
 /// Wrapper around a buffer writer that counts the number of buffers and bytes written
 struct BufWriterSink {
-    start: Instant,
+    statistics: WriteStatistics,
     inner: BufWriter<File>,
-    num_buffers: usize,
-    num_bytes: usize,
 }
 
 impl BufWriterSink {
     fn new(inner: BufWriter<File>) -> Self {
         Self {
-            start: Instant::now(),
             inner,
-            num_buffers: 0,
-            num_bytes: 0,
+            statistics: WriteStatistics::new("buffers"),
         }
     }
 }
 
 impl Sink for BufWriterSink {
     fn sink(&mut self, buffer: &[u8]) -> Result<(), io::Error> {
-        self.num_buffers += 1;
-        self.num_bytes += buffer.len();
+        self.statistics.increment_chunks(1);
+        self.statistics.increment_bytes(buffer.len());
         self.inner.write_all(buffer)
     }
 
     fn flush(mut self) -> Result<(), io::Error> {
-        let res = self.inner.flush();
-
-        let duration = self.start.elapsed();
-        let mb_per_buffer = self.num_bytes as f64 / (1024.0 * 1024.0) / self.num_buffers as f64;
-        let bytes_per_second = (self.num_bytes as f64 / duration.as_secs_f64()) as u64;
-        let gb_per_second = bytes_per_second as f64 / (1024.0 * 1024.0 * 1024.0);
-
-        info!("Completed in {duration:?} ({gb_per_second:.02} GB/sec)");
-        debug!(
-            "wrote {} bytes in {} buffers {mb_per_buffer:.02} MB/buffer",
-            self.num_bytes, self.num_buffers,
-        );
-        res
+        self.inner.flush()
     }
 }

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -90,15 +90,16 @@ struct Cli {
     #[arg(short, long, default_value_t = num_cpus::get())]
     num_threads: usize,
 
-    /// The parquet block compression. Default is ZSTD(1)
+    /// The parquet block compression. Default is SNAPPY
     ///
     /// Supported values: UNCOMPRESSED, ZSTD(N), SNAPPY, GZIP, LZO, BROTLI, LZ4
     ///
     /// Using ZSTD results in the best compression, but is about 2x slower than
     /// UNCOMPRESSED. For example, for the lineitem table at SF=10
     ///   ZSTD(1):      1.9G  (0.52 GB/sec)
+    ///   SNAPPY:       2.4G  (0.75 GB/sec)
     ///   UNCOMPRESSED: 3.8G  (1.41 GB/sec)
-    #[arg(short, long, default_value = "ZSTD(1)")]
+    #[arg(short, long, default_value = "SNAPPY")]
     parquet_compression: Compression,
 
     /// Verbose output (default: false)

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -169,7 +169,7 @@ macro_rules! define_generate {
             let filename = self.output_filename($TABLE);
             let (num_parts, parts) = self.parallel_target_part_count(&$TABLE);
             // parquet files can have at most 32K row groups so cap the number of parts
-            let num_parts = num_parts.min(32767);
+            let num_parts = num_parts.min(32767 - 1);
             let scale_factor = self.scale_factor;
             info!("Writing table {} (SF={scale_factor}) to {filename}", $TABLE);
             debug!("Generating {num_parts} parts in total");

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -1,0 +1,157 @@
+//! Parquet output format
+
+use crate::statistics::WriteStatistics;
+use arrow::datatypes::SchemaRef;
+use futures::StreamExt;
+use log::debug;
+use parquet::arrow::arrow_writer::{compute_leaves, get_column_writers, ArrowColumnChunk};
+use parquet::arrow::ArrowSchemaConverter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::types::SchemaDescPtr;
+use std::fs::File;
+use std::io;
+use std::io::BufWriter;
+use std::sync::Arc;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tpchgen_arrow::RecordBatchIterator;
+
+/// Converts a set of RecordBatchIterators into a Parquet file
+///
+/// Uses num_threads to generate the data in parallel
+///
+/// Note the input is an iterator of [`RecordBatchIterator`]; The batches
+/// produced by each iterator is encoded as its own row group.
+pub async fn generate_parquet<I>(
+    writer: BufWriter<File>,
+    iter_iter: I,
+    num_threads: usize,
+    parquet_compression: Compression,
+) -> Result<(), io::Error>
+where
+    I: Iterator<Item: RecordBatchIterator> + 'static,
+{
+    debug!(
+        "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"
+    );
+    // Based on example in https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowColumnWriter.html
+    let mut iter_iter = iter_iter.peekable();
+
+    // get schema from the first iterator
+    let Some(first_iter) = iter_iter.peek() else {
+        return Ok(()); // no data shrug
+    };
+    let schema = Arc::clone(first_iter.schema());
+
+    // Compute the parquet schema
+    let writer_properties = WriterProperties::builder()
+        .set_compression(parquet_compression)
+        .build();
+    let writer_properties = Arc::new(writer_properties);
+    let parquet_schema = Arc::new(
+        ArrowSchemaConverter::new()
+            .with_coerce_types(writer_properties.coerce_types())
+            .convert(&schema)
+            .unwrap(),
+    );
+
+    // create a stream that computes the data for each row group
+    let mut row_group_stream = futures::stream::iter(iter_iter)
+        .map(async |iter| {
+            let parquet_schema = Arc::clone(&parquet_schema);
+            let writer_properties = Arc::clone(&writer_properties);
+            let schema = Arc::clone(&schema);
+            // run on a separate thread
+            tokio::task::spawn(async move {
+                encode_row_group(parquet_schema, writer_properties, schema, iter)
+            })
+            .await
+            .expect("Inner task panicked")
+        })
+        .buffered(num_threads); // generate row groups in parallel
+
+    let mut statistics = WriteStatistics::new("row groups");
+
+    // A blocking task that writes the row groups to the file
+    // done in a blocking task to avoid having a thread waiting on IO
+    // Now, read each completed row group and write it to the file
+    let root_schema = parquet_schema.root_schema_ptr();
+    let writer_properties_captured = Arc::clone(&writer_properties);
+    let (tx, mut rx): (
+        Sender<Vec<ArrowColumnChunk>>,
+        Receiver<Vec<ArrowColumnChunk>>,
+    ) = tokio::sync::mpsc::channel(num_threads);
+    let writer_task = tokio::task::spawn_blocking(move || {
+        // Create parquet writer
+        let mut writer =
+            SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
+
+        while let Some(chunks) = rx.blocking_recv() {
+            // Start row group
+            let mut row_group_writer = writer.next_row_group().unwrap();
+
+            // Slap the chunks into the row group
+            for chunk in chunks {
+                chunk.append_to_row_group(&mut row_group_writer).unwrap();
+            }
+            row_group_writer.close().unwrap();
+            statistics.increment_chunks(1);
+        }
+        let file = writer.into_inner()?.into_inner()?;
+        statistics.increment_bytes(file.metadata()?.len() as usize);
+        Ok(()) as Result<(), io::Error>
+    });
+
+    // now, drive the input stream and send results to the writer task
+    while let Some(chunks) = row_group_stream.next().await {
+        // send the chunks to the writer task
+        if let Err(e) = tx.send(chunks).await {
+            debug!("Error sending chunks to writer: {e}");
+        }
+    }
+    // signal the writer task that we are done
+    drop(tx);
+
+    // Wait for the writer task to finish
+    writer_task.await??;
+
+    Ok(())
+}
+
+/// Creates the data for a particular row group
+///
+/// Note at the moment it does not use multiple tasks/threads but it could
+/// potentially encode multiple columns with different threads .
+///
+/// Returns an array of [`ArrowColumnChunk`]
+fn encode_row_group<I>(
+    parquet_schema: SchemaDescPtr,
+    writer_properties: Arc<WriterProperties>,
+    schema: SchemaRef,
+    iter: I,
+) -> Vec<ArrowColumnChunk>
+where
+    I: RecordBatchIterator,
+{
+    // Create writers for each of the leaf columns
+    let mut col_writers = get_column_writers(&parquet_schema, &writer_properties, &schema).unwrap();
+
+    // generate the data and send it to the tasks (via the sender channels)
+    for batch in iter {
+        let columns = batch.columns().iter();
+        let col_writers = col_writers.iter_mut();
+        let fields = schema.fields().iter();
+
+        for ((col_writer, field), arr) in col_writers.zip(fields).zip(columns) {
+            for leaves in compute_leaves(field.as_ref(), arr).unwrap() {
+                col_writer.write(&leaves).unwrap();
+            }
+        }
+    }
+    // finish the writers and create the column chunks
+    col_writers
+        .into_iter()
+        .map(|col_writer| col_writer.close().unwrap())
+        .collect()
+}

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -30,7 +30,7 @@ pub async fn generate_parquet<I>(
     parquet_compression: Compression,
 ) -> Result<(), io::Error>
 where
-    I: Iterator<Item = impl RecordBatchIterator> + 'static,
+    I: Iterator<Item: RecordBatchIterator> + 'static,
 {
     debug!(
         "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -30,7 +30,7 @@ pub async fn generate_parquet<I>(
     parquet_compression: Compression,
 ) -> Result<(), io::Error>
 where
-    I: Iterator<Item: RecordBatchIterator> + 'static,
+    I: Iterator<Item = impl RecordBatchIterator> + 'static,
 {
     debug!(
         "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"

--- a/tpchgen-cli/src/statistics.rs
+++ b/tpchgen-cli/src/statistics.rs
@@ -1,0 +1,55 @@
+//! Statistics reporter for TPCH data generation.
+
+use log::{debug, info};
+use std::time::Instant;
+
+/// Statisitics for writing data to a file
+///
+/// Reports the statistics on drop
+#[derive(Clone, Debug)]
+pub struct WriteStatistics {
+    /// Time at which the writer was created
+    start: Instant,
+    /// User defined "chunks" (e,g. buffers or row_groups)
+    num_chunks: usize,
+    chunk_label: String,
+    /// total bytes written
+    num_bytes: usize,
+}
+
+impl WriteStatistics {
+    /// Create a new statistics reporter
+    pub fn new(chunk_label: impl Into<String>) -> Self {
+        Self {
+            start: Instant::now(),
+            num_chunks: 0,
+            chunk_label: chunk_label.into(),
+            num_bytes: 0,
+        }
+    }
+
+    /// Increment chunk count
+    pub fn increment_chunks(&mut self, num_chunks: usize) {
+        self.num_chunks += num_chunks;
+    }
+
+    /// Increment byte count
+    pub fn increment_bytes(&mut self, num_bytes: usize) {
+        self.num_bytes += num_bytes;
+    }
+}
+
+impl Drop for WriteStatistics {
+    fn drop(&mut self) {
+        let duration = self.start.elapsed();
+        let mb_per_chunk = self.num_bytes as f64 / (1024.0 * 1024.0) / self.num_chunks as f64;
+        let bytes_per_second = (self.num_bytes as f64 / duration.as_secs_f64()) as u64;
+        let gb_per_second = bytes_per_second as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        info!("Completed in {duration:?} ({gb_per_second:.02} GB/sec)");
+        debug!(
+            "wrote {} bytes in {} {}  {mb_per_chunk:.02} MB/{}",
+            self.num_bytes, self.num_chunks, self.chunk_label, self.chunk_label
+        );
+    }
+}

--- a/tpchgen-cli/src/statistics.rs
+++ b/tpchgen-cli/src/statistics.rs
@@ -45,10 +45,11 @@ impl Drop for WriteStatistics {
         let mb_per_chunk = self.num_bytes as f64 / (1024.0 * 1024.0) / self.num_chunks as f64;
         let bytes_per_second = (self.num_bytes as f64 / duration.as_secs_f64()) as u64;
         let gb_per_second = bytes_per_second as f64 / (1024.0 * 1024.0 * 1024.0);
+        let gb = self.num_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-        info!("Completed in {duration:?} ({gb_per_second:.02} GB/sec)");
+        info!("Created {gb:.02} GB in {duration:?} ({gb_per_second:.02} GB/sec)");
         debug!(
-            "wrote {} bytes in {} {}  {mb_per_chunk:.02} MB/{}",
+            "Wrote {} bytes in {} {}  {mb_per_chunk:.02} MB/{}",
             self.num_bytes, self.num_chunks, self.chunk_label, self.chunk_label
         );
     }

--- a/tpchgen-cli/src/statistics.rs
+++ b/tpchgen-cli/src/statistics.rs
@@ -3,14 +3,14 @@
 use log::{debug, info};
 use std::time::Instant;
 
-/// Statisitics for writing data to a file
+/// Statistics for writing data to a file
 ///
 /// Reports the statistics on drop
 #[derive(Clone, Debug)]
 pub struct WriteStatistics {
     /// Time at which the writer was created
     start: Instant,
-    /// User defined "chunks" (e,g. buffers or row_groups)
+    /// User defined "chunks" (e.g. buffers or row_groups)
     num_chunks: usize,
     chunk_label: String,
     /// total bytes written

--- a/tpchgen/Cargo.toml
+++ b/tpchgen/Cargo.toml
@@ -12,3 +12,4 @@ repository = "https://github.com/clflushopt/tpchgen-rs"
 
 [dev-dependencies]
 flate2 = "1.1.0"
+


### PR DESCRIPTION
- Closes #46 

This PR adds the ability to write directly generate parquet files using all available cores with minimal buffering

Among other things it can generate the entire TPCH SF 100 dataset in less than a minute and less than 400MB peak memory usage (as measured by top).

My measurements show it can do about 0.5 G/sec for `ZSTD` parquet

Example
```shell
 andrewlamb@Andrews-MacBook-Pro-2:~/Software/tpchgen-rs$ time target/release/tpchgen-cli -v --scale-factor=100 --format=parquet --output-dir=/tmp/repo
[2025-03-28T00:30:52Z INFO  tpchgen_cli] Verbose output enabled (ignoring RUST_LOG environment variable)
[2025-03-28T00:30:53Z INFO  tpchgen_cli] Created static distributions and text pools in 806.286541ms
[2025-03-28T00:30:53Z INFO  tpchgen_cli] Writing table nation (SF=100) to nation.parquet
[2025-03-28T00:30:53Z INFO  tpchgen_cli::statistics] Completed in 461.291µs (0.01 GB/sec)
[2025-03-28T00:30:53Z INFO  tpchgen_cli] Writing table region (SF=100) to region.parquet
[2025-03-28T00:30:53Z INFO  tpchgen_cli::statistics] Completed in 175.75µs (0.01 GB/sec)
[2025-03-28T00:30:53Z INFO  tpchgen_cli] Writing table part (SF=100) to part.parquet
[2025-03-28T00:30:54Z INFO  tpchgen_cli::statistics] Completed in 1.829104083s (0.26 GB/sec)
[2025-03-28T00:30:54Z INFO  tpchgen_cli] Writing table supplier (SF=100) to supplier.parquet
[2025-03-28T00:30:55Z INFO  tpchgen_cli::statistics] Completed in 129.034209ms (0.43 GB/sec)
[2025-03-28T00:30:55Z INFO  tpchgen_cli] Writing table partsupp (SF=100) to partsupp.parquet
[2025-03-28T00:30:59Z INFO  tpchgen_cli::statistics] Completed in 3.936936958s (0.73 GB/sec)
[2025-03-28T00:30:59Z INFO  tpchgen_cli] Writing table customer (SF=100) to customer.parquet
[2025-03-28T00:31:00Z INFO  tpchgen_cli::statistics] Completed in 1.129056875s (0.76 GB/sec)
[2025-03-28T00:31:00Z INFO  tpchgen_cli] Writing table orders (SF=100) to orders.parquet
[2025-03-28T00:31:09Z INFO  tpchgen_cli::statistics] Completed in 8.914675s (0.53 GB/sec)
[2025-03-28T00:31:09Z INFO  tpchgen_cli] Writing table lineitem (SF=100) to lineitem.parquet
[2025-03-28T00:31:46Z INFO  tpchgen_cli::statistics] Completed in 36.228818167s (0.54 GB/sec)
[2025-03-28T00:31:46Z INFO  tpchgen_cli] Generation complete!

real	0m53.795s
user	10m23.254s
sys	1m47.903s
```

Then check out the output
```
andrewlamb@Andrews-MacBook-Pro-2:~/Software/tpchgen-rs$ datafusion-cli -c "select * from '/tmp/repo/lineitem.parquet' limit 10"
DataFusion CLI v46.0.1
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+----------------------------------------+
| l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct    | l_shipmode | l_comment                              |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+----------------------------------------+
| 112673607  | 14299286  | 549301    | 1            | 29.00      | 37252.53        | 0.08       | 0.06  | N            | O            | 1996-01-12 | 1995-12-10   | 1996-02-10    | DELIVER IN PERSON | MAIL       | lly bold ideas ar                      |
| 112673607  | 8086586   | 586603    | 2            | 1.00       | 1572.18         | 0.10       | 0.05  | N            | O            | 1995-10-15 | 1995-12-01   | 1995-11-13    | DELIVER IN PERSON | MAIL       | ts sleep carefully a                   |
| 112673607  | 11234349  | 234350    | 3            | 33.00      | 42331.74        | 0.06       | 0.08  | N            | O            | 1995-11-23 | 1995-12-28   | 1995-12-20    | COLLECT COD       | AIR        | ngly pending theodolites lose          |
| 112673607  | 15699713  | 449759    | 4            | 44.00      | 75324.92        | 0.01       | 0.01  | N            | O            | 1995-12-25 | 1995-12-29   | 1996-01-05    | DELIVER IN PERSON | FOB        | inal plate                             |
| 112673632  | 6085764   | 85765     | 1            | 50.00      | 87473.00        | 0.05       | 0.06  | N            | O            | 1996-04-22 | 1996-07-02   | 1996-05-01    | DELIVER IN PERSON | MAIL       |  ironic de                             |
| 112673632  | 3422639   | 922646    | 2            | 40.00      | 62458.40        | 0.10       | 0.05  | N            | O            | 1996-04-30 | 1996-05-29   | 1996-05-17    | COLLECT COD       | MAIL       |  ironic ide                            |
| 112673632  | 4283483   | 33496     | 3            | 29.00      | 42521.83        | 0.09       | 0.08  | N            | O            | 1996-06-11 | 1996-05-14   | 1996-06-17    | DELIVER IN PERSON | SHIP       | odolites above the s                   |
| 112673633  | 12683461  | 433498    | 1            | 9.00       | 12994.47        | 0.06       | 0.05  | N            | O            | 1997-09-03 | 1997-10-08   | 1997-09-30    | NONE              | REG AIR    | s. carefully even accounts haggle care |
| 112673633  | 10912554  | 162565    | 2            | 41.00      | 64206.41        | 0.05       | 0.00  | N            | O            | 1997-11-30 | 1997-11-27   | 1997-12-14    | DELIVER IN PERSON | AIR        | lithely blithely pending platelets. fu |
| 112673633  | 7287863   | 537871    | 3            | 14.00      | 25907.00        | 0.02       | 0.00  | N            | O            | 1997-09-22 | 1997-10-27   | 1997-10-16    | NONE              | MAIL       | xes use slyly special deposits. q      |
+------------+-----------+-----------+--------------+------------+-----------------+------------+-------+--------------+--------------+------------+--------------+---------------+-------------------+------------+----------------------------------------+
10 row(s) fetched.
Elapsed 0.140 seconds.

andrewlamb@Andrews-MacBook-Pro-2:~/Software/tpchgen-rs$ du -s -h /tmp/repo/*.parquet
896M	/tmp/repo/customer.parquet
 20G	/tmp/repo/lineitem.parquet
4.0K	/tmp/repo/nation.parquet
4.8G	/tmp/repo/orders.parquet
480M	/tmp/repo/part.parquet
2.9G	/tmp/repo/partsupp.parquet
4.0K	/tmp/repo/region.parquet
 57M	/tmp/repo/supplier.parquet
```

TODO:
- [ ] Avoid so many string copies for low cardinality string values (precompute StringViews) faster
- [ ] Tests somehow