### PR TITLE
Avoid String creation while loading `Distributions` (2% less startup time)

### DIFF
--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -523,12 +523,7 @@ impl<'a> RandomStringSequence<'a> {
 
     pub fn next_value(&mut self) -> StringSequenceInstance<'a> {
         // Get all values from the distribution
-        let mut values: Vec<&str> = self
-            .distribution
-            .get_values()
-            .iter()
-            .map(|s| s.as_str())
-            .collect();
+        let mut values: Vec<&str> = self.distribution.get_values().to_vec();
 
         // Randomize first 'count' elements
         for current_position in 0..self.count {


### PR DESCRIPTION
- Part of #56 

This PR avoids copying / creating `String`s while loading the inital distributions,

It yields a small but measurable 2% improvement

Timings

```
time target/release/tpchgen-cli --tables line-item -s 0.001 --output-dir=/tmp/tpchdbgen-rs
```

| branch | time |
|--------|--------|
| main | 0m0.973s |
| this pr | 0m0.952s | 