### PR TITLE
WIP optimize lineitem conversion to arrow

### DIFF
--- a/tpchgen-arrow/src/conversions.rs
+++ b/tpchgen-arrow/src/conversions.rs
@@ -1,9 +1,11 @@
 //! Routines to convert TPCH types to Arrow types
 
-use arrow::array::{StringViewArray, StringViewBuilder};
+use arrow::array::{GenericByteViewArray, StringViewArray, StringViewBuilder};
+use arrow::buffer::{Buffer, ScalarBuffer};
 use std::fmt::Write;
 use tpchgen::dates::TPCHDate;
 use tpchgen::decimal::TPCHDecimal;
+use tpchgen::generators::LineItemStatus;
 
 /// Convert a TPCHDecimal to an Arrow Decimal(15,2)
 #[inline(always)]
@@ -48,6 +50,255 @@ where
         builder.append_value(&buffer);
     }
     builder.finish()
+}
+
+/// Coverts an iterator of [`ReturnFlag`] to an Arrow [`StringViewArray`] avoiding
+/// an extra copy of the data
+///
+/// Example
+/// ```
+/// # use arrow::array::StringViewArray;
+/// # use arrow::array::Array;
+/// # use tpchgen_arrow::conversions::string_view_array_from_return_flag_iter;
+/// let return_flags = vec![
+///    "A", // 'A' for Accepted
+///    "R", // 'R' for Returned
+///    "N", // 'N' for No"
+/// ];
+/// // This will convert the ReturnItem values to a StringViewArray with minimal overhead
+/// let actual = string_view_array_from_return_flag_iter(return_flags);
+/// assert_eq!(actual.len(), 3);
+/// // check the values in the StringViewArray build with the builder
+/// let expected = StringViewArray::from_iter_values(["A", "R", "N"]);
+/// assert_eq!(actual, expected);
+/// ```
+pub fn string_view_array_from_return_flag_iter<I>(values: I) -> StringViewArray
+where
+    I: IntoIterator<Item = &'static str>,
+{
+    let values = values.into_iter();
+    // All valid values of LineItemStatus are less than 12 bytes long and thus
+    // is entirely inlined, we can use precomputed u128 views
+    let views: ScalarBuffer<u128> = values.map(|s| {
+        // Views in Arrow's StringViewArray are represented as u128 values
+        // low 32 bits of the u128 represent the length (1)
+        // then the inlined the string 'A' (0x41), 'R' (0x52), or 'N' (0x4E)
+        // https://docs.rs/arrow/latest/arrow/array/struct.GenericByteViewArray.html#layout-views-and-buffers
+        match s {
+            "A" => 0x00000000000000000000004100000001,
+            "R" => 0x00000000000000000000005200000001,
+            "N" => 0x00000000000000000000004E00000001,
+            _ => panic!("Invalid return flag value: {s}. This function only supports the values 'A', 'R', and 'N'."),
+        }
+    }).collect();
+    let buffers = vec![]; // all values are inlined in the u128, so no need for a buffer
+    let nulls = None;
+
+    // SAFETY: valid by construction
+    unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) }
+}
+
+/// Converts an iterator of [`LineItemStatus`] to an Arrow [`StringViewArray`] avoiding
+/// an extra copy of the data
+///
+/// Example
+/// ```
+/// # use arrow::array::StringViewArray;
+/// # use arrow::array::Array;
+/// # use tpchgen::generators::LineItemStatus;
+/// # use tpchgen_arrow::conversions::string_view_array_from_line_item_status_iter;
+/// let line_item_statuses = vec![
+///    LineItemStatus::Fulfilled,
+///    LineItemStatus::Open,
+/// ];
+/// // This will convert the LineItemStatus values to a StringViewArray with minimal overhead
+/// let actual = string_view_array_from_line_item_status_iter(line_item_statuses);
+/// assert_eq!(actual.len(), 2);
+/// // check the values in the StringViewArray build with the builder
+/// let expected = StringViewArray::from_iter_values(["F", "O"]);
+/// assert_eq!(actual, expected);
+/// ```
+pub fn string_view_array_from_line_item_status_iter<I>(values: I) -> StringViewArray
+where
+    I: IntoIterator<Item = LineItemStatus>,
+{
+    let values = values.into_iter();
+    // All valid values of LineItemStatus are less than 12 bytes long and thus
+    // is entirely inlined, we can use precomputed u128 views
+    let views: ScalarBuffer<u128> = values
+        .map(|status| {
+            // There are only two valid values for LineItemStatus: 'F' and 'P'
+            // Views in Arrow's StringViewArray are represented as u128 values
+            // low 32 bits of the u128 represent the length (1)
+            // then the inlined the string 'F' (0x46) or 'P' (0x4F)
+            // https://docs.rs/arrow/latest/arrow/array/struct.GenericByteViewArray.html#layout-views-and-buffers
+            match status {
+                LineItemStatus::Fulfilled => 0x00000000000000000000004600000001,
+                LineItemStatus::Open => 0x00000000000000000000004F00000001,
+            }
+        })
+        .collect();
+    let buffers = vec![]; // all values are inlined in the u128, so no need for a buffer
+    let nulls = None;
+
+    // SAFETY: valid by construction
+    unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) }
+}
+
+/// Converts an iterator of shipmode fields to an Arrow [`StringViewArray`] avoiding
+/// an extra copy of the data
+///
+/// This takes advantage of the fact there are only 7 distinct values for
+/// l_shipmode in the TPCH schema and all are less than 12 bytes so can be inlined
+///
+/// Example
+/// ```
+/// # use arrow::array::StringViewArray;
+/// # use arrow::array::Array;
+/// # use tpchgen_arrow::conversions::string_view_array_from_shipmode_iter;
+/// let ship_modes = vec![
+///    "TRUCK",
+///    "RAIL",
+///    "REG AIR",
+///    "FOB",
+///    "MAIL",
+///    "AIR",
+///    "SHIP",
+/// ];
+/// // This will convert the LineItemStatus values to a StringViewArray with minimal overhead
+/// let actual = string_view_array_from_shipmode_iter(ship_modes.clone());
+/// assert_eq!(actual.len(), 7);
+/// // check the values in the StringViewArray build with the builder
+/// let expected = StringViewArray::from_iter_values(ship_modes);
+/// assert_eq!(actual, expected);
+/// ```
+pub fn string_view_array_from_shipmode_iter<I>(values: I) -> StringViewArray
+where
+    I: IntoIterator<Item = &'static str>,
+{
+    let values = values.into_iter();
+    // we know the only valid values for shipmode in the TPCH schema are less than
+    let views: ScalarBuffer<u128> = values.map(shipmode_to_view).collect();
+    let buffers = vec![]; // all values are inlined in the u128, so no need for a buffer
+    let nulls = None;
+
+    // SAFETY: valid by construction
+    unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) }
+}
+
+/// Converts a shipmode to a valid u128 view (which is used in Arrow's
+/// StringViewArray)
+///
+/// All valid values for `l_shipmode` in the TPCH schema are less than 12 bytes
+/// long
+///
+/// ```sql
+/// DataFusion CLI v46.0.1
+/// +------------+
+/// | l_shipmode |
+/// +------------+
+/// | TRUCK      |
+/// | RAIL       |
+/// | REG AIR    |
+/// | FOB        |
+/// | MAIL       |
+/// | AIR        |
+/// | SHIP       |
+/// +------------+
+/// ```
+fn shipmode_to_view(ship_mode: &'static str) -> u128 {
+    // Views in Arrow's StringViewArray are represented as u128 values
+    // low 32 bits of the u128 represent the length (1)
+    // https://docs.rs/arrow/latest/arrow/array/struct.GenericByteViewArray.html#layout-views-and-buffers
+    match ship_mode {
+        "TRUCK" => 0x000000000000004b4355525400000005, // 0x4b43555254 = 'TRUCK'
+        "RAIL" => 0x000000000000004c49415200000004,    // 0x4c494152 = 'RAIL'
+        "REG AIR" => 0x000000000000005249412047455200000007, // 0x5249472041474552 = 'REG AIR'
+        "FOB" => 0x00000000000000424f4600000003,       // 0x424f46 = 'FOB'
+        "MAIL" => 0x000000000000004c49414d00000004,    // 0x4c49414d = 'MAIL'
+        "AIR" => 0x0000000000000052494100000003,       // 0x524941 = 'AIR'
+        "SHIP" => 0x000000000000005049485300000004,    // 0x50495048 = 'SHIP'
+        _ => panic!(
+            "Invalid ship mode value: {ship_mode}. This function only supports the 7 valid values for l_shipmode in the TPCH schema."
+        ),
+    }
+}
+/// Converts an iterator of shipmode fields to an Arrow [`StringViewArray`] avoiding
+/// an extra copy of the data
+///
+/// This takes advantage of the fact there are only 4 distinct values for
+/// l_shipinstruct in the TPCH schema
+///
+/// ```sql
+/// DataFusion CLI v46.0.1
+/// +-------------------+
+/// | l_shipinstruct    |
+/// +-------------------+
+/// | COLLECT COD       |
+/// | TAKE BACK RETURN  |
+/// | DELIVER IN PERSON |
+/// | NONE              |
+/// +-------------------+
+/// ```
+///
+/// Example
+/// ```
+/// # use arrow::array::StringViewArray;
+/// # use arrow::array::Array;
+/// # use tpchgen_arrow::conversions::string_view_array_from_shipinstruct_iter;
+/// let ship_instructs = vec![
+///    "COLLECT COD",
+///    "TAKE BACK RETURN",
+///    "DELIVER IN PERSON",
+///    "NONE",
+/// ];
+/// // This will convert the instructions values to a StringViewArray with minimal overhead
+/// let actual = string_view_array_from_shipinstruct_iter(ship_instructs.clone());
+/// assert_eq!(actual.len(), 4);
+/// // check the values in the StringViewArray build with the builder
+/// let expected = StringViewArray::from_iter_values(ship_instructs);
+/// for i in expected.views() {
+/// println!("view: {i:#x}");
+/// }
+/// assert_eq!(actual, expected);
+/// ```
+pub fn string_view_array_from_shipinstruct_iter<I>(values: I) -> StringViewArray
+where
+    I: IntoIterator<Item = &'static str>,
+{
+    let values = values.into_iter();
+    // values less than 12 bytes are inlined in the u128
+    // values larger than 12 bytes will be stored in a buffer, but since we know
+    // the valid values for `l_shipinstruct` we precompute it here
+    let mut buffer: Vec<u8> = vec![];
+    // "COLLECT COD" is 11 bytes long, so it can be inlined in a u128
+    // 0x444f43205443454c4c4f43 = 'COLLECT COD'
+    let collect_cod_view = 0x00444f43205443454c4c4f430000000b;
+    // "TAKE BACK RETURN" is 16 bytes long, so it must stored in the buffer
+    // 0x454b4154 = 'TAKE' (prefix)
+    buffer.extend_from_slice(b"TAKE BACK RETURN");
+    let take_back_return_view = 0x0000000000000000454b415400000010;
+    // "DELIVER IN PERSON" is 17 bytes long, so it must stored in the buffer
+    // 0x494c4544 = 'DELI' (prefix)
+    buffer.extend_from_slice(b"DELIVER IN PERSON");
+    let deliver_in_person_view = 0x0000001000000000494c454400000011;
+    // "NONE" is 4 bytes long, so it can be inlined in a u128
+    let none_view = 0x0000000000000000454e4f4e00000004; // 0x454e4f4e = 'NONE'
+
+    let views: ScalarBuffer<u128> = values.map(|s| {
+        match s {
+            "COLLECT COD" => collect_cod_view,
+            "TAKE BACK RETURN" => take_back_return_view,
+            "DELIVER IN PERSON" => deliver_in_person_view,
+            "NONE" => none_view,
+            _ => panic!("Invalid ship instruction value: {s}. This function only supports the 4 valid values for l_shipinstruct in the TPCH schema.")
+        }
+    }).collect();
+    let buffers = vec![Buffer::from(buffer)];
+    let nulls = None;
+
+    // SAFETY: valid by construction
+    unsafe { GenericByteViewArray::new_unchecked(views, buffers, nulls) }
 }
 
 /// Number of days that must be added to a TPCH date to get an Arrow `Date32` value.

--- a/tpchgen-arrow/src/lineitem.rs
+++ b/tpchgen-arrow/src/lineitem.rs
@@ -1,4 +1,8 @@
-use crate::conversions::{decimal128_array_from_iter, to_arrow_date32};
+use crate::conversions::{
+    decimal128_array_from_iter, string_view_array_from_line_item_status_iter,
+    string_view_array_from_return_flag_iter, string_view_array_from_shipinstruct_iter,
+    string_view_array_from_shipmode_iter, to_arrow_date32,
+};
 use crate::{DEFAULT_BATCH_SIZE, RecordBatchIterator};
 use arrow::array::{
     Date32Array, Decimal128Array, Int32Array, Int64Array, RecordBatch, StringViewArray,
@@ -103,9 +107,9 @@ impl Iterator for LineItemArrow {
         let l_discount = decimal128_array_from_iter(rows.iter().map(|row| row.l_discount));
         let l_tax = decimal128_array_from_iter(rows.iter().map(|row| row.l_tax));
         let l_returnflag =
-            StringViewArray::from_iter_values(rows.iter().map(|row| row.l_returnflag));
+            string_view_array_from_return_flag_iter(rows.iter().map(|row| row.l_returnflag));
         let l_linestatus =
-            StringViewArray::from_iter_values(rows.iter().map(|row| row.l_linestatus));
+            string_view_array_from_line_item_status_iter(rows.iter().map(|row| row.l_linestatus));
         let l_shipdate = Date32Array::from_iter_values(
             rows.iter().map(|row| row.l_shipdate).map(to_arrow_date32),
         );
@@ -118,8 +122,9 @@ impl Iterator for LineItemArrow {
                 .map(to_arrow_date32),
         );
         let l_shipinstruct =
-            StringViewArray::from_iter_values(rows.iter().map(|row| row.l_shipinstruct));
-        let l_shipmode = StringViewArray::from_iter_values(rows.iter().map(|row| row.l_shipmode));
+            string_view_array_from_shipinstruct_iter(rows.iter().map(|row| row.l_shipinstruct));
+        let l_shipmode =
+            string_view_array_from_shipmode_iter(rows.iter().map(|row| row.l_shipmode));
         let l_comment = StringViewArray::from_iter_values(rows.iter().map(|row| row.l_comment));
 
         let batch = RecordBatch::try_new(

--- a/tpchgen-arrow/src/lineitem.rs
+++ b/tpchgen-arrow/src/lineitem.rs
@@ -1,12 +1,10 @@
 use crate::conversions::{
     decimal128_array_from_iter, string_view_array_from_line_item_status_iter,
     string_view_array_from_return_flag_iter, string_view_array_from_shipinstruct_iter,
-    string_view_array_from_shipmode_iter, to_arrow_date32,
+    string_view_array_from_shipmode_iter, string_view_array_from_string_iter, to_arrow_date32,
 };
 use crate::{DEFAULT_BATCH_SIZE, RecordBatchIterator};
-use arrow::array::{
-    Date32Array, Decimal128Array, Int32Array, Int64Array, RecordBatch, StringViewArray,
-};
+use arrow::array::{Date32Array, Decimal128Array, Int32Array, Int64Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use std::sync::{Arc, LazyLock};
 use tpchgen::generators::{LineItemGenerator, LineItemGeneratorIterator};
@@ -125,7 +123,7 @@ impl Iterator for LineItemArrow {
             string_view_array_from_shipinstruct_iter(rows.iter().map(|row| row.l_shipinstruct));
         let l_shipmode =
             string_view_array_from_shipmode_iter(rows.iter().map(|row| row.l_shipmode));
-        let l_comment = StringViewArray::from_iter_values(rows.iter().map(|row| row.l_comment));
+        let l_comment = string_view_array_from_string_iter(rows.iter().map(|row| row.l_comment));
 
         let batch = RecordBatch::try_new(
             Arc::clone(self.schema()),

--- a/tpchgen-arrow/src/order.rs
+++ b/tpchgen-arrow/src/order.rs
@@ -1,5 +1,6 @@
 use crate::conversions::{
-    decimal128_array_from_iter, string_view_array_from_display_iter, to_arrow_date32,
+    decimal128_array_from_iter, string_view_array_from_display_iter,
+    string_view_array_from_string_iter, to_arrow_date32,
 };
 use crate::{DEFAULT_BATCH_SIZE, RecordBatchIterator};
 use arrow::array::{Date32Array, Int32Array, Int64Array, RecordBatch, StringViewArray};
@@ -91,7 +92,7 @@ impl Iterator for OrderArrow {
             StringViewArray::from_iter_values(rows.iter().map(|r| r.o_orderpriority));
         let o_clerk = string_view_array_from_display_iter(rows.iter().map(|r| r.o_clerk));
         let o_shippriority = Int32Array::from_iter_values(rows.iter().map(|r| r.o_shippriority));
-        let o_comment = StringViewArray::from_iter_values(rows.iter().map(|r| r.o_comment));
+        let o_comment = string_view_array_from_string_iter(rows.iter().map(|r| r.o_comment));
 
         let batch = RecordBatch::try_new(
             Arc::clone(self.schema()),

--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -1850,13 +1850,13 @@ pub struct LineItem<'a> {
     pub l_commitdate: TPCHDate,
     /// Date received
     pub l_receiptdate: TPCHDate,
-    /// Shipping instructions. One of:
+    /// Shipping instructions.
+    /// One of "COLLECT COD", "TAKE BACK RETURN", "DELIVER IN PERSON", "NONE",
     pub l_shipinstruct: &'a str,
     /// Shipping mode.
     /// One of: "TRUCK", "RAIL", "REG AIR", "FOB", "MAIL", "AIR", "SHIP"
     pub l_shipmode: &'a str,
     /// Variable length comment.
-    /// One of "COLLECT COD", "TAKE BACK RETURN", "DELIVER IN PERSON", "NONE",
     pub l_comment: &'a str,
 }
 


### PR DESCRIPTION
WIP optimize lineitem conversion to arrow

This PR contains an attempt to skip the string representation and go directly to byte views 

TLDR is I found it didn't really make much difference. 

Another thing that might be more compelling would be to reuse allocations / buffers

But for now let's call it good enough

Main
```
$ time ./target/release/tpchgen-cli -s 10 --format=parquet --stdout > /dev/null

real	0m5.436s
user	0m55.109s
sys	0m8.402s
```


This PR
```
time ./target/release/tpchgen-cli -s 10 --format=parquet --stdout > /dev/null

real	0m5.461s
user	0m53.384s
sys	0m9.874s
```