### PR TITLE
Stop early on parquet write error

### DIFF
--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -108,6 +108,7 @@ where
         // send the chunks to the writer task
         if let Err(e) = tx.send(chunks).await {
             debug!("Error sending chunks to writer: {e}");
+            break; // stop early
         }
     }
     // signal the writer task that we are done


### PR DESCRIPTION
- Related to https://github.com/clflushopt/tpchgen-rs/issues/81

If the generators get a panic, stop early, don't keep trying to write

On main when I hit the error I get many errors about not being able to write

```
thread 'tokio-runtime-worker' panicked at tpchgen-cli/src/parquet.rs:92:64:
called `Result::unwrap()` on an `Err` value: General("Parquet does not support more than 32767 row groups per file (currently: 32768)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:29:15Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
...
...
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
[2025-03-29T11:32:59Z DEBUG tpchgen_cli::parquet] Error sending chunks to writer: channel closed
```