### PR TITLE
feat: allow writing to stdout

### DIFF
--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -21,7 +21,7 @@ pub trait Source: Send {
 
 /// Something that can write the contents of a buffer somewhere
 ///
-/// For example, this is implemented for a file writer
+/// For example, this is implemented for a file writer.
 pub trait Sink: Send {
     /// Write all data from the buffer to the sink
     fn sink(&mut self, buffer: &[u8]) -> Result<(), io::Error>;

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -105,6 +105,11 @@ struct Cli {
     /// Verbose output (default: false)
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
+
+    /// Write the output to stdout instead of a file, this is only supported
+    /// for the tbl formats.
+    #[arg(long, default_value_t = false)]
+    stdout: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -199,8 +204,10 @@ impl Cli {
             debug!("Logging configured from environment variables");
         }
 
-        // Create output directory if it doesn't exist
-        fs::create_dir_all(&self.output_dir)?;
+        // Create output directory if it doesn't exist and we are not writing to stdout.
+        if !self.stdout {
+            fs::create_dir_all(&self.output_dir)?;
+        }
 
         // Determine which tables to generate
         let tables: Vec<Table> = if let Some(tables) = self.tables.as_ref() {
@@ -389,8 +396,13 @@ impl Cli {
         I: Iterator<Item: Source> + 'static,
     {
         // Since generate_in_chunks already buffers, there is no need to buffer again
-        let sink = WriterSink::new(self.new_output_file(filename)?);
-        generate_in_chunks(sink, sources, self.num_threads).await
+        if self.stdout {
+            let sink = WriterSink::new(io::stdout());
+            generate_in_chunks(sink, sources, self.num_threads).await
+        } else {
+            let sink = WriterSink::new(self.new_output_file(filename)?);
+            generate_in_chunks(sink, sources, self.num_threads).await
+        }
     }
 
     /// Generates an output parquet file from the sources

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -107,7 +107,7 @@ struct Cli {
     verbose: bool,
 
     /// Write the output to stdout instead of a file, this is only supported
-    /// for the tbl formats.
+    /// for the tbl and csv formats.
     #[arg(long, default_value_t = false)]
     stdout: bool,
 }


### PR DESCRIPTION
The goal of this change (Closes #77 ) is to allow writing to `stdout` which can be useful when we want to measure throughput via `pv` for example.

```
~/G/P/tpchgen-rs (cl/feat/write-to-stdout)> ./target/release/tpchgen-cli -s 100 --stdout | pv > /dev/null
 106GiB 0:01:07 [1.57GiB/s]
 ~/G/P/tpchgen-rs (cl/feat/write-to-stdout) [SIGINT|32]> ./target/release/tpchgen-cli -s 100 --stdout | pv -arb > /dev/null
 106GiB [1.36GiB/s] (1.36GiB/s)s)
```