### PR TITLE
Quit early on error for tbl/csv

### DIFF
--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -104,6 +104,11 @@ where
 
     // drive the stream to completion
     while let Some(write_task) = stream.next().await {
+        // break early if the writer stream is done (errored)
+        if writer_task.is_finished() {
+            debug!("writer task is done early, stopping writer");
+            break;
+        }
         write_task.await; // sends the buffer to the writer task
     }
     drop(stream); // drop any stream references


### PR DESCRIPTION
- Similarly to https://github.com/clflushopt/tpchgen-rs/pull/82

If there is an error writing (like out of disk space) when writing to csv, the program generates much more data and discards it rather than stopping early

Let's stop early so tpchgen-cli can report the error quick and concisely


```
[2025-03-29T19:32:49Z DEBUG tpchgen_cli] Logging configured from environment variables
[2025-03-29T19:32:49Z DEBUG tpchgen_cli] Creating distributions and text pool
[2025-03-29T19:32:50Z INFO  tpchgen_cli] Created static distributions and text pools in 1.030596141s
[2025-03-29T19:32:50Z INFO  tpchgen_cli] Writing table lineitem (SF=100) to lineitem.tbl
[2025-03-29T19:32:50Z DEBUG tpchgen_cli] Generating 4883 parts in total
[2025-03-29T19:32:51Z DEBUG tpchgen_cli::generate] Using 22 threads
[2025-03-29T19:33:13Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:33:13Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:33:13Z INFO  tpchgen_cli::statistics] Created 3.32 GB in 22.024473445s (0.15 GB/sec)
[2025-03-29T19:33:13Z DEBUG tpchgen_cli::statistics] Wrote 3567903086 bytes in 221 buffers  15.40 MB/buffers
[2025-03-29T19:33:13Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:33:13Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
.... (many more) ....
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:35:59Z DEBUG tpchgen_cli::generate] waiting for writer task to complete
Error: Os { code: 28, kind: StorageFull, message: "No space left on device" }
```


With this PR:
```
alamb@aal-perf:~$ RUST_LOG=debug tpchgen-cli --tables=line-item -s 100   --tables=line-item
[2025-03-29T19:41:56Z DEBUG tpchgen_cli] Logging configured from environment variables
[2025-03-29T19:41:56Z DEBUG tpchgen_cli] Creating distributions and text pool
[2025-03-29T19:41:57Z INFO  tpchgen_cli] Created static distributions and text pools in 1.03640647s
[2025-03-29T19:41:57Z INFO  tpchgen_cli] Writing table lineitem (SF=100) to lineitem.tbl
[2025-03-29T19:41:57Z DEBUG tpchgen_cli] Generating 4883 parts in total
[2025-03-29T19:41:57Z DEBUG tpchgen_cli::generate] Using 22 threads
[2025-03-29T19:42:20Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:42:20Z DEBUG tpchgen_cli::generate] Error sending buffer to writer: channel closed
[2025-03-29T19:42:20Z INFO  tpchgen_cli::statistics] Created 3.32 GB in 22.478921973s (0.15 GB/sec)
[2025-03-29T19:42:20Z DEBUG tpchgen_cli::statistics] Wrote 3567903086 bytes in 221 buffers  15.40 MB/buffers
[2025-03-29T19:42:20Z DEBUG tpchgen_cli::generate] writer task is done early, stopping writer
[2025-03-29T19:42:20Z DEBUG tpchgen_cli::generate] waiting for writer task to complete
Error: Os { code: 28, kind: StorageFull, message: "No space left on device" }
```