### PR TITLE
Support writing  parquet to stdout, document use of `pv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ Blazing fast TPCH benchmark data generator in pure Rust !
 
 (coming soon)
 
+## Measuring Performance
+
+This generator is so fast it can saturate the throughput of most IO devices at
+time of writing. To see its true speed, you need to run it on a machine with a
+fast IO device (SSD or NVMe). Alternately you can use the `--stdout` flag and
+the `pv` command to send the output to `/dev/null` and measure the throughput.
+
+For example:
+
+```sh
+# Generate SF=100, about 100GB of data, piped to /dev/null, reporting statistics 
+tpchgen-cli -- -s 100 --stdout | pv -arb > /dev/null
+# Reports something like 
+# 106GiB [3.09GiB/s] (3.09GiB/s)
+```
+
+Similarly for parquet
+
+```
+# Generate SF=100 in parquet format, piped to /dev/null, reporting statistics
+tpchgen-cli -- -s 100 --format=parquet --stdout | pv -arb > /dev/null
+# 38.2GiB [ 865MiB/s] ( 865MiB/s)
+```
+
 ## Structure
 
 `tpchgen-cli` is a [`dbgen`](https://github.com/databricks/tpch-dbgen) compatible CLI tool

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -44,7 +44,7 @@ use clap::{Parser, ValueEnum};
 use log::{debug, info, LevelFilter};
 use std::fmt::Display;
 use std::fs::{self, File};
-use std::io::{self, BufWriter, Write};
+use std::io::{self, BufWriter, Stdout, Write};
 use std::path::PathBuf;
 use std::time::Instant;
 use tpchgen::distribution::Distributions;
@@ -106,8 +106,7 @@ struct Cli {
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
 
-    /// Write the output to stdout instead of a file, this is only supported
-    /// for the tbl and csv formats.
+    /// Write the output to stdout instead of a file.
     #[arg(long, default_value_t = false)]
     stdout: bool,
 }
@@ -410,9 +409,31 @@ impl Cli {
     where
         I: Iterator<Item: RecordBatchIterator> + 'static,
     {
-        let file = self.new_output_file(filename)?;
-        let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
-        generate_parquet(writer, sources, self.num_threads, self.parquet_compression).await
+        if self.stdout {
+            // write to stdout
+            let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
+            generate_parquet(writer, sources, self.num_threads, self.parquet_compression).await
+        } else {
+            // write to a file
+            let file = self.new_output_file(filename)?;
+            let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
+            generate_parquet(writer, sources, self.num_threads, self.parquet_compression).await
+        }
+    }
+}
+
+impl IntoSize for BufWriter<Stdout> {
+    fn into_size(self) -> Result<usize, io::Error> {
+        // we can't get the size of stdout, so just return 0
+        Ok(0)
+    }
+}
+
+impl IntoSize for BufWriter<File> {
+    fn into_size(self) -> Result<usize, io::Error> {
+        let file = self.into_inner()?;
+        let metadata = file.metadata()?;
+        Ok(metadata.len() as usize)
     }
 }
 


### PR DESCRIPTION
- Follow up to https://github.com/clflushopt/tpchgen-rs/pull/83
- Related to https://github.com/clflushopt/tpchgen-rs/issues/77

I would like to also calculate raw speed for parquet generation so it would be nice to support writing parquet to stdout as well

Also, @clflushopt  showed a great command to use `pv` to measure raw output speed which I wanted to add to the readme