### PR TITLE
Add documentation for zstd compression

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -94,7 +94,10 @@ struct Cli {
     ///
     /// Supported values: UNCOMPRESSED, ZSTD(N), SNAPPY, GZIP, LZO, BROTLI, LZ4
     ///
-    /// Using ZSTD results in the best compression, but is about 2x slower than
+    /// Note to use zstd you must supply the "compression" level (1-22)
+    /// as a number in parentheses, e.g. `ZSTD(1)` for level 1 compression.
+    ///
+    /// Using `ZSTD` results in the best compression, but is about 2x slower than
     /// UNCOMPRESSED. For example, for the lineitem table at SF=10
     ///
     ///   ZSTD(1):      1.9G  (0.52 GB/sec)


### PR DESCRIPTION
@clflushopt says in https://github.com/clflushopt/tpchgen-rs/issues/76#issuecomment-2764251375

> p.s: I think we should document how to pass ZSTD since it requires passing the level in a parenthesis format like this zstd(1) as such zstd\(1\) same goes for gzip which also requires a level.


So let's document it better!
