### PR TITLE
fix: pin local crate versions

### DIFF
--- a/tpchgen-arrow/Cargo.toml
+++ b/tpchgen-arrow/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 arrow = { version = "54.3.0", default-features = false, features = ["prettyprint"] }
 chrono = "0.4.40"
-tpchgen = { path = "../tpchgen" }
+tpchgen = { path = "../tpchgen", version = "0.1.0" }
 
 [dev-dependencies]
 arrow-csv = "54.3.0"

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -13,8 +13,8 @@ repository = { workspace = true }
 arrow = "54.3.0"
 parquet = "54.3.0"
 clap = { version = "4.5.32", features = ["derive"] }
-tpchgen = { path = "../tpchgen" }
-tpchgen-arrow = { path = "../tpchgen-arrow" }
+tpchgen = { path = "../tpchgen", version = "0.1.0"}
+tpchgen-arrow = { path = "../tpchgen-arrow", version = "0.1.0" }
 tokio = { version = "1.44.1", features = ["full"]}
 futures = "0.3.31"
 num_cpus = "1.0"


### PR DESCRIPTION
To make sure version compatibility stays within what we expect I am pinning the `tpchgen`crate versions for `tpchgen-cli` and `tpchgen-arrow`