### PR TITLE
feat: add to_unix_epoch helper to TPCHDate

### DIFF
--- a/tpchgen-arrow/src/conversions.rs
+++ b/tpchgen-arrow/src/conversions.rs
@@ -13,10 +13,24 @@ pub fn to_arrow_decimal(value: TPCHDecimal) -> i128 {
     value.into_inner() as i128
 }
 
-/// Convert a TPCH date to an Arrow Date32
+/// Convert a TPCH date to an Arrow Date32.
+///
+/// * Arrow `Date32` are days since the epoch (1970-01-01)
+/// * [`TPCHDate`]s are days since MIN_GENERATE_DATE (1992-01-01)
+///
+/// ```
+/// use chrono::NaiveDate;
+/// use tpchgen::dates::TPCHDate;
+/// let arrow_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+///  let tpch_epoch = NaiveDate::from_ymd_opt(1992, 1, 1).unwrap();
+/// // the difference between the two epochs is 8035 days
+/// let day_offset = (tpch_epoch - arrow_epoch).num_days();
+/// let day_offset: i32 = day_offset.try_into().unwrap();
+///  assert_eq!(day_offset, TPCHDate::UNIX_EPOCH_OFFSET);
+/// ```
 #[inline(always)]
 pub fn to_arrow_date32(value: TPCHDate) -> i32 {
-    value.into_inner() + TPCHDATE_TO_DATE32_OFFSET
+    value.to_unix_epoch()
 }
 
 /// Converts an iterator of TPCH decimals to an Arrow Decimal128Array
@@ -49,24 +63,6 @@ where
     }
     builder.finish()
 }
-
-/// Number of days that must be added to a TPCH date to get an Arrow `Date32` value.
-///
-/// * Arrow `Date32` are days since the epoch (1970-01-01)
-/// * [`TPCHDate`]s are days since MIN_GENERATE_DATE (1992-01-01)
-///
-/// This value is `8035` because `1992-01-01` is `8035` days after `1970-01-01`
-/// ```
-/// use chrono::NaiveDate;
-/// use tpchgen_arrow::conversions::TPCHDATE_TO_DATE32_OFFSET;
-/// let arrow_epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
-///  let tpch_epoch = NaiveDate::from_ymd_opt(1992, 1, 1).unwrap();
-/// // the difference between the two epochs is 8035 days
-/// let day_offset = (tpch_epoch - arrow_epoch).num_days();
-/// let day_offset: i32 = day_offset.try_into().unwrap();
-///  assert_eq!(day_offset, TPCHDATE_TO_DATE32_OFFSET);
-/// ```
-pub const TPCHDATE_TO_DATE32_OFFSET: i32 = 8035;
 
 // test to ensure that the conversion functions are correct
 #[cfg(test)]

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -97,8 +97,14 @@ impl Display for TPCHDate {
 }
 
 impl TPCHDate {
-    /// Number of days between TPC-H epoch and the Unix epoch (1970-01-01).
-    const UNIX_EPOCH_OFFSET: i32 = 8035;
+    /// Number of days that must be added to a TPCH date to get a Unix epoch
+    /// relative date.
+    ///
+    /// * Arrow `Date32` are days since the epoch (1970-01-01)
+    /// * [`TPCHDate`]s are days since MIN_GENERATE_DATE (1992-01-01)
+    ///
+    /// This value is `8035` because `1992-01-01` is `8035` days after `1970-01-01`
+    pub const UNIX_EPOCH_OFFSET: i32 = 8035;
 
     /// Create a new TPCHDate from a generated date
     pub fn new(generated_date: i32) -> Self {

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -131,7 +131,7 @@ impl TPCHDate {
     }
 
     /// Returns unix epoch time for this date.
-    fn to_unix_epoch(&self) -> i64 {
+    pub fn to_unix_epoch(&self) -> i64 {
         let (y, m, dy) = self.to_ymd();
         days_since_unix_epoch(1900 + y, m, dy) * 86400
     }
@@ -205,9 +205,10 @@ fn days_since_unix_epoch(year: i32, month: i32, day: i32) -> i64 {
     }
 
     // Add days from months
-    for m in 0..(month as usize - 1) {
-        days += DAYS_IN_MONTH[m];
+    for day in DAYS_IN_MONTH.iter().take(month as usize - 1) {
+        days += *day;
     }
+
     // Add leap day if needed
     if month > 2 && is_leap_year(year) {
         days += 1;

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -97,6 +97,9 @@ impl Display for TPCHDate {
 }
 
 impl TPCHDate {
+    /// Number of days between TPC-H epoch and the Unix epoch (1970-01-01).
+    const UNIX_EPOCH_OFFSET: i32 = 8035;
+
     /// Create a new TPCHDate from a generated date
     pub fn new(generated_date: i32) -> Self {
         Self {
@@ -130,10 +133,10 @@ impl TPCHDate {
         JULIAN_DATE[(date - MIN_GENERATE_DATE) as usize]
     }
 
-    /// Returns unix epoch time for this date.
-    pub fn to_unix_epoch(&self) -> i64 {
-        let (y, m, dy) = self.to_ymd();
-        days_since_unix_epoch(1900 + y, m, dy) * 86400
+    /// Returns the number of days since the Unix epoch this date
+    /// represents.
+    pub fn to_unix_epoch(&self) -> i32 {
+        self.date_index + Self::UNIX_EPOCH_OFFSET
     }
 }
 
@@ -193,33 +196,6 @@ const fn julian(date: i32) -> i32 {
     result + offset
 }
 
-/// Returns the number of days since the Unix epoch (1970-01-01).
-fn days_since_unix_epoch(year: i32, month: i32, day: i32) -> i64 {
-    // Days in each month (non-leap year)
-    const DAYS_IN_MONTH: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-    // Calculate days from year component
-    let mut days = 0i64;
-    for y in 1970..year {
-        days += if is_leap_year(y) { 366 } else { 365 };
-    }
-
-    // Add days from months
-    for day in DAYS_IN_MONTH.iter().take(month as usize - 1) {
-        days += *day;
-    }
-
-    // Add leap day if needed
-    if month > 2 && is_leap_year(year) {
-        days += 1;
-    }
-
-    // Add days from current month
-    days += day as i64 - 1;
-
-    days
-}
-
 const fn is_leap_year(year: i32) -> bool {
     year % 4 == 0 && year % 100 != 0
 }
@@ -260,18 +236,11 @@ mod test {
     fn test_date_epoch_consistency() {
         // Check that dates are actually machine some epochs.
         let date = TPCHDate::new(MIN_GENERATE_DATE + 1);
-        // 1992-01-02 00:00:00 (12:00:00 AM)
-        assert_eq!(date.to_string(), "1992-01-02");
-        assert_eq!(date.to_unix_epoch(), 694310400);
+        assert_eq!(date.to_unix_epoch(), 8036);
 
         let date = TPCHDate::new(MIN_GENERATE_DATE + 1234);
         // 1995-05-19 00:00:00 (12:00:00 AM)
         assert_eq!(date.to_string(), "1995-05-19");
-        assert_eq!(date.to_unix_epoch(), 800841600);
-
-        let date = TPCHDate::new(MIN_GENERATE_DATE + TOTAL_DATE_RANGE - 1);
-        // 1998-12-31 00:00:00 (12:00:00 AM)
-        assert_eq!(date.to_string(), "1998-12-31");
-        assert_eq!(date.to_unix_epoch(), 915062400);
+        assert_eq!(date.to_unix_epoch(), 9269);
     }
 }


### PR DESCRIPTION
Addresses a feature request by @scsmithr in #60 see [comment](https://github.com/clflushopt/tpchgen-rs/issues/60#issuecomment-2764785631).

The date conversion logic is largely mechanical **but it will compute everything relative to midnight**.