### PR TITLE
WIP: Reduce copying when generating parquet

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -20,7 +20,7 @@ use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
 use tpchgen::generators::{
-    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    CustomerGenerator, LineItemGeneratorBuilder, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
 
@@ -248,7 +248,8 @@ fn generate_lineitem(cli: &Cli) -> io::Result<()> {
     let filename = "lineitem.tbl";
     let mut writer = new_table_writer(cli, filename)?;
 
-    let generator = LineItemGenerator::new(cli.scale_factor, cli.part, cli.parts);
+    let mut generator =
+        LineItemGeneratorBuilder::new(cli.scale_factor, cli.part, cli.parts).build();
     for item in generator.iter() {
         writeln!(
             writer,

--- a/tpchgen/tests/integration_tests.rs
+++ b/tpchgen/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use tpchgen::generators::{
-    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    CustomerGenerator, LineItemGeneratorBuilder, NationGenerator, OrderGenerator, PartGenerator,
     PartSupplierGenerator, RegionGenerator, SupplierGenerator,
 };
 
@@ -196,7 +196,7 @@ fn test_orders_sf_0_001() {
 #[test]
 fn test_lineitem_sf_0_001() {
     test_generator(
-        |sf| LineItemGenerator::new(sf, 1, 1).iter(),
+        |sf| LineItemGeneratorBuilder::new(sf, 1, 1).iter(),
         "data/sf-0.001/lineitem.tbl.gz",
         0.001,
         |item| {
@@ -360,7 +360,7 @@ fn test_orders_sf_0_01() {
 #[test]
 fn test_lineitem_sf_0_01() {
     test_generator(
-        |sf| LineItemGenerator::new(sf, 1, 1).iter(),
+        |sf| LineItemGeneratorBuilder::new(sf, 1, 1).iter(),
         "data/sf-0.01/lineitem.tbl.gz",
         0.01,
         |item| {


### PR DESCRIPTION
This is an attempt to improve performance by avoiding unecessary work when creating StringViewArrays

I can't really see much of a difference performance wise, so until I can I am not going to mark this ready for revew
