### PR TITLE
refactor: Simplify DuckDB export

### DIFF
--- a/benchmarks/BENCHMARKS.md
+++ b/benchmarks/BENCHMARKS.md
@@ -79,14 +79,7 @@ LOAD tpch;
 CALL dbgen(sf = 10);
 
 -- Export each table to Parquet format
-copy customer to 'customer.parquet' (FORMAT parquet);
-copy lineitem to 'lineitem.parquet' (FORMAT parquet);
-copy nation to 'nation.parquet' (FORMAT parquet);
-copy orders to 'orders.parquet' (FORMAT parquet);
-copy part to 'part.parquet' (FORMAT parquet);
-copy partsupp to 'partsupp.parquet' (FORMAT parquet);
-copy region to 'region.parquet' (FORMAT parquet);
-copy supplier to 'supplier.parquet' (FORMAT parquet);
+EXPORT DATABASE 'tpch' (FORMAT parquet);
 ```
 
 ## `duckdb_duckdb.sh`

--- a/benchmarks/parquet_duckdb.sh
+++ b/benchmarks/parquet_duckdb.sh
@@ -18,13 +18,6 @@ for sf in $SCALE_FACTORS ; do
 INSTALL tpch;\
 LOAD tpch;\
 CALL dbgen(sf = $sf);\
-copy customer to 'out_duckdb/customer.parquet' (FORMAT parquet);\
-copy lineitem to 'out_duckdb/lineitem.parquet' (FORMAT parquet);\
-copy nation   to 'out_duckdb/nation.parquet' (FORMAT parquet);\
-copy orders   to 'out_duckdb/orders.parquet' (FORMAT parquet);\
-copy part     to 'out_duckdb/part.parquet'     (FORMAT parquet);\
-copy partsupp to 'out_duckdb/partsupp.parquet' (FORMAT parquet);\
-copy region   to 'out_duckdb/region.parquet'   (FORMAT parquet);\
-copy supplier to 'out_duckdb/supplier.parquet' (FORMAT parquet);"
+EXPORT DATABASE 'out_duckdb' (FORMAT parquet);"
 
 done


### PR DESCRIPTION
This PR simplifies the DuckDB export code. There are no noticeable performance changes, the only difference is that the export is accompanied with a `load.sql` and a (rather redundant) `schema.sql` file.

PS: Thanks for creating and publishing this project, it's **GREAT** and I'm migrating a lot of my benchmark script to use this instead of DuckDB's built-in `dbgen` function.