### PR TITLE
fix: Use lowercase for possible values of table names

### DIFF
--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -160,14 +160,14 @@ impl TypedValueParser for TableValueParser {
     ) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
         Some(Box::new(
             [
-                clap::builder::PossibleValue::new("Region").help("Region table (alias: r)"),
-                clap::builder::PossibleValue::new("Nation").help("Nation table (alias: n)"),
-                clap::builder::PossibleValue::new("Supplier").help("Supplier table (alias: s)"),
-                clap::builder::PossibleValue::new("Customer").help("Customer table (alias: c)"),
-                clap::builder::PossibleValue::new("Part").help("Part table (alias: P)"),
-                clap::builder::PossibleValue::new("PartSupp").help("PartSupp table (alias: S)"),
-                clap::builder::PossibleValue::new("Orders").help("Orders table (alias: O)"),
-                clap::builder::PossibleValue::new("LineItem").help("LineItem table (alias: L)"),
+                clap::builder::PossibleValue::new("region").help("Region table (alias: r)"),
+                clap::builder::PossibleValue::new("nation").help("Nation table (alias: n)"),
+                clap::builder::PossibleValue::new("supplier").help("Supplier table (alias: s)"),
+                clap::builder::PossibleValue::new("customer").help("Customer table (alias: c)"),
+                clap::builder::PossibleValue::new("part").help("Part table (alias: P)"),
+                clap::builder::PossibleValue::new("partsupp").help("PartSupp table (alias: S)"),
+                clap::builder::PossibleValue::new("orders").help("Orders table (alias: O)"),
+                clap::builder::PossibleValue::new("lineitem").help("LineItem table (alias: L)"),
             ]
             .into_iter(),
         ))


### PR DESCRIPTION
The help says:

```
  -T, --tables <TABLES>
          Which tables to generate (default: all)

          Possible values:
          - Region:   Region table (alias: r)
          - Nation:   Nation table (alias: n)
          - Supplier: Supplier table (alias: s)
          - Customer: Customer table (alias: c)
          - Part:     Part table (alias: P)
          - PartSupp: PartSupp table (alias: S)
          - Orders:   Orders table (alias: O)
          - LineItem: LineItem table (alias: L)
```

However, the camelcase table names are not accepted:

```
$ tpchgen-cli --tables LineItem
```
```
error: one of the values isn't valid for an argument

For more information, try '--help'.
```

Lowercase names work fine:

```
$ tpchgen-cli --tables lineitem --verbose
```
```
[2025-04-11T20:56:01Z INFO  tpchgen_cli] Verbose output enabled (ignoring RUST_LOG environment variable)
[2025-04-11T20:56:02Z INFO  tpchgen_cli] Created static distributions and text pools in 1.023608041s
[2025-04-11T20:56:02Z INFO  tpchgen_cli] Writing table lineitem (SF=1) to lineitem.tbl
[2025-04-11T20:56:02Z INFO  tpchgen_cli::statistics] Created 0.71 GB in 386.926125ms (1.83 GB/sec)
[2025-04-11T20:56:02Z INFO  tpchgen_cli] Generation complete!
```

This PR changes the list of possible values for the tables names to lowercase.