### PR TITLE
feat: fix CI and run CI for every PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
   workflow_dispatch:  # Allow manual triggering
 
 env:

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -22,7 +22,7 @@
 //!     -v, --verbose                Verbose output
 //!         --stdout                 Write output to stdout instead of files
 //!```
-//! 
+//!
 //! # Logging:
 //! Use the `-v` flag or `RUST_LOG` environment variable to control logging output.
 //!


### PR DESCRIPTION
Format issue in #127 was not caught in CI but was caught when merging. 

It looks like the github action was not run on PR. Let's fix that too

According to claude, the github action was not triggered because it [specifies `main` branch](https://github.com/clflushopt/tpchgen-rs/blob/928d57af42b3752bd7f8c211f603337611d0241f/.github/workflows/rust.yml#L6-L7) but the PR wants to merge into ` clflushopt:main`
```
kevinjqliu wants to merge 2 commits into clflushopt:main from kevinjqliu:kevinjqliu/fix-ci  
```