### PR TITLE
Fix up `tpchgen-cli`'s README

### DIFF
--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -3,6 +3,7 @@
 See the main [README.md](https://github.com/clflushopt/tpchgen-rs) for full documentation.
 
 ## Installation
+
 ### Install Using Python
 Install this tool with Python:
 ```shell

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -5,6 +5,7 @@ See the main [README.md](https://github.com/clflushopt/tpchgen-rs) for full docu
 ## Installation
 
 ### Install Using Python
+
 Install this tool with Python:
 ```shell
 pip install tpchgen-cli

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -12,6 +12,7 @@ pip install tpchgen-cli
 ```
 
 ### Install Using Rust
+
 [Install Rust](https://www.rust-lang.org/tools/install) and this tool:
 
 ```shell

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -21,6 +21,7 @@ cargo install tpchgen-cli
 ```
 
 ## CLI Usage
+
 We tried to make the `tpchgen-cli` experience as close to `dbgen` as possible for no other
 reason than maybe make it easier for you to have a drop-in replacement.
 

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -1,9 +1,27 @@
-### CLI Usage
+# TPC-H Data Generator CLI
 
+See the main [README.md](https://github.com/clflushopt/tpchgen-rs) for full documentation.
+
+## Installation
+### Install Using Python
+Install this tool with Python:
+```shell
+pip install tpchgen-cli
+```
+
+### Install Using Rust
+[Install Rust](https://www.rust-lang.org/tools/install) and this tool:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+cargo install tpchgen-cli
+```
+
+## CLI Usage
 We tried to make the `tpchgen-cli` experience as close to `dbgen` as possible for no other
 reason than maybe make it easier for you to have a drop-in replacement.
 
-```sh
+```shell
 $ tpchgen-cli -h
 TPC-H Data Generator
 
@@ -35,6 +53,6 @@ Options:
 ```
 
 For example generating a dataset with a scale factor of 1 (1GB) can be done like this:
-```sh
+```shell
 $ tpchgen-cli -s 1 --output-dir=/tmp/tpch
 ```


### PR DESCRIPTION
Closes #130

Looks like its hard to refer to the root README from the sub directory. 
As a compromise, I added the important information back to the tpchgen-cli's README. This will be shown in the crates and pypi package. 