### PR TITLE
[feat] pyproject use cargo version

### DIFF
--- a/tpchgen-cli/pyproject.toml
+++ b/tpchgen-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tpchgen-cli"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Python CLI for TPC-H data generator"
 requires-python = ">=3.8"
 


### PR DESCRIPTION
Related to #132

Use Cargo.toml's version which is `1.0.0` so we can push a brand new version to testpypi

Tested
```
(.venv) ➜  tpchgen-cli git:(kevinjqliu/pypi-use-cargo-version) maturin develop --release                     
🔗 Found bin bindings
📡 Using build options bindings from pyproject.toml
    Finished `release` profile [optimized] target(s) in 0.11s
📦 Built wheel to /var/folders/f1/3_vzsn7x1jq9hszb3z9y6f0m0000gn/T/.tmpiNV4Gq/tpchgen_cli-1.0.0-py3-none-macosx_11_0_arm64.whl
✏️ Setting installed package as editable
🛠 Installed tpchgen-cli-1.0.0
```