### PR TITLE
[feat] skip conformance test for markdown file changes 

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -3,7 +3,11 @@ name: Conformance tests
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:  # Allow manual triggering
 
 env:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,43 @@
+name: Conformance tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:  # Allow manual triggering
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Conformance tests (compare to existing implementation)
+  conformance-test:
+    name: TPC-H Conformance Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Make conformance script executable
+        run: chmod +x ./tests/conformance.sh
+
+      - name: Run Conformance Tests
+        run: ./tests/conformance.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,6 @@ jobs:
       - name: All Tests (tpchgen-cli)
         run: cargo test -p tpchgen-cli
 
-
   # documentation build
   docs:
     runs-on: ubuntu-latest
@@ -68,37 +67,3 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --no-deps --workspace
-
-
-  # Conformance tests (compare to existing  implementation)
-  conformance-test:
-    name: TPC-H Conformance Tests
-    runs-on: ubuntu-latest
-    needs: [lint, test-tests-tpchgen, docs]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Make conformance script executable
-        run: chmod +x ./tests/conformance.sh
-
-      - name: Run Conformance Tests
-        run: ./tests/conformance.sh


### PR DESCRIPTION
This PR splits the conformance test into its own action. Additionally, conformance test will be skipped for markdown file (`.md`) changes