### PR TITLE
fix: address regression in part count check

### DIFF
--- a/tpchgen-cli/src/plan.rs
+++ b/tpchgen-cli/src/plan.rs
@@ -68,7 +68,7 @@ impl GenerationPlan {
         cli_part_count: i32,
     ) -> Self {
         // parallel generation disabled if user specifies a part explicitly
-        if cli_part != -1 || cli_part_count != -1 {
+        if cli_part != 1 || cli_part_count != 1 {
             return Self {
                 part_count: cli_part_count,
                 part_list: vec![cli_part],


### PR DESCRIPTION
Addresses regression which causes an early exit leading to skipping parallel generation, specifically lines 71 the check is against `1` not `-1`.

Edit: Mistake on my end was looking at the wrong terminal :man_facepalming: 