### PR TITLE
Update Rust to 1.89

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.86.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- related to https://github.com/clflushopt/tpchgen-rs/issues/154

There is a new Rust, let's use it
