### PR TITLE
tpchgen-cli: get readme/license/authors from Cargo.toml

### DIFF
--- a/tpchgen-cli/pyproject.toml
+++ b/tpchgen-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tpchgen-cli"
-dynamic = ["version"]
+dynamic = ["version", "readme", "license", "authors"]
 description = "Python CLI for TPC-H data generator"
 requires-python = ">=3.8"
 


### PR DESCRIPTION
Context: https://github.com/clflushopt/tpchgen-rs/issues/172#issuecomment-3237947801

These need to be specified explicitly

When building wheels/sdists via PEP 621 (pyproject.toml), PyPI’s long_description comes only if the [project] table has a readme key (or you mark it as dynamic = ["readme"]).

### Testing
```
maturin build --release
twine check --strict <.wheel>
```

Or manually unzip the whl, and check the `METADATA` file