### PR TITLE
infra: add a twine check before uploading to pypi

### DIFF
--- a/.github/workflows/tpchgen-cli-publish-pypi.yml
+++ b/.github/workflows/tpchgen-cli-publish-pypi.yml
@@ -139,10 +139,18 @@ jobs:
       attestations: write # Used to generate artifact attestation
     steps:
       - uses: actions/download-artifact@v4
+
+      - name: Install twine
+        run: pip install twine
+
+      - name: Check distributions with twine
+        run: twine check --strict wheels-*/*
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: 'wheels-*/*'
+
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
`twine check --strict` would have caught the lack of README 
Context: https://github.com/clflushopt/tpchgen-rs/issues/172#issuecomment-3237947801

Example, https://github.com/PyO3/maturin-action/issues/166#issue-1650967980

### Testing
Github action run on my fork shows that `twine check` fails https://github.com/kevinjqliu/tpchgen-rs/actions/runs/17332990961
Because #182 has not been applied yet 

Tested locally, with and without fix from #182:
```
maturin sdist                                                                               
twine check --strict <.tar.gz>
```

```
maturin build --release
twine check --strict <.wheel>
```
