### PR TITLE
infra: add `continue-on-error: true` to the wheel builds

### DIFF
--- a/.github/workflows/tpchgen-cli-publish-pypi.yml
+++ b/.github/workflows/tpchgen-cli-publish-pypi.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
+    continue-on-error: true
     strategy:
       matrix:
         platform:
@@ -41,6 +42,7 @@ jobs:
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
+    continue-on-error: true
     strategy:
       matrix:
         platform:
@@ -69,6 +71,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
+    continue-on-error: true
     strategy:
       matrix:
         platform:
@@ -92,6 +95,7 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
+    continue-on-error: true
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
Context: https://github.com/clflushopt/tpchgen-rs/issues/172#issuecomment-3228025491

When any wheel build fails, continue to build the rest of the wheels and publish to pypi

Not 100% sure if we want this behavior...
Worst case scenario, only one wheel is successfully built. The version is released on pypi with 1 wheel. Since pypi artifacts are immutable, we'd have to fix the underlying issue, increase the version, and start a new release