### PR TITLE
bump to 2.0.1 to fix README in pypi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/clflushopt/tpchgen-rs"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/clflushopt/tpchgen-rs"
-version = "2.0.0"
+version = "2.0.1"
 
 [profile.release]
 strip = "debuginfo"

--- a/tpchgen-arrow/Cargo.toml
+++ b/tpchgen-arrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tpchgen-arrow"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors = ["clflushopt", "alamb"]
 description = "TPC-H data generator into Apache Arrow format"
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 
 [dependencies]
 arrow = { version = "56", default-features = false, features = ["prettyprint"] }
-tpchgen = { path = "../tpchgen", version = "2.0.0" }
+tpchgen = { path = "../tpchgen", version = "2.0.1" }
 
 [dev-dependencies]
 arrow-csv = "56"

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tpchgen-cli"
-version = "2.0.0"
+version = "2.0.1"
 authors = { workspace = true }
 description = "Blazing fast pure Rust TPC-H data generator command line tool."
 readme = "README.md"
@@ -13,8 +13,8 @@ repository = { workspace = true }
 arrow = "56"
 parquet = "56"
 clap = { version = "4.5.32", features = ["derive"] }
-tpchgen = { path = "../tpchgen", version = "2.0.0"}
-tpchgen-arrow = { path = "../tpchgen-arrow", version = "2.0.0" }
+tpchgen = { path = "../tpchgen", version = "2.0.1"}
+tpchgen-arrow = { path = "../tpchgen-arrow", version = "2.0.1" }
 tokio = { version = "1.44.1", features = ["full"]}
 futures = "0.3.31"
 num_cpus = "1.0"


### PR DESCRIPTION

### Tested locally
```
maturin build --release --out dist
maturin sdist --out dist
python -m pip install --upgrade twine
python -m twine check --strict dist/*

maturin upload \
  --repository-url https://test.pypi.org/legacy/ \
  --username __token__ \
  --password "$TESTPYPI_API_TOKEN" \
  --non-interactive \
  --skip-existing \
  dist/*
```

Uploaded to testpypi
https://test.pypi.org/project/tpchgen-cli/