### PR TITLE
infra: automatically publish to crates.io on release

### DIFF
--- a/.github/workflows/tpchgen-publish-crates.yml
+++ b/.github/workflows/tpchgen-publish-crates.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write     # Required for OIDC token exchange
     strategy:
       # Publish package one by one instead of flooding the registry
       max-parallel: 1
@@ -21,8 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Publish ${{ matrix.package }}
         working-directory: ${{ matrix.package }}
-        run: cargo publish --all-features
+        run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Closes #189

### Trusted publishing
Following https://crates.io/docs/trusted-publishing

Added to all 3 crates
- tpchgen
- tpchgen-arrow
- tpchgen-cli

<img width="642" height="794" alt="Screenshot 2025-09-08 at 11 34 38 AM" src="https://github.com/user-attachments/assets/ff3b992f-9c23-4e41-ad10-12002ab6bf83" />
