### PR TITLE
infra:  configure dependabot for cargo & github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I've added dependabot configuration for github actions and cargo dependencies since we are using a bunch of external dependencies and some of them have updates available (e.g. `actions/checkout@v4`).     