### PR TITLE
infra: macos-13 is deprecated, replace with macos-15-intel

### DIFF
--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -64,11 +64,11 @@ jobs:
             os: windows
 
           # macOS
-          - runner: macos-13
-            target: x86_64
-            os: macos
           - runner: macos-14
             target: aarch64
+            os: macos
+          - runner: macos-15-intel
+            target: x86_64
             os: macos
 
     steps:


### PR DESCRIPTION
Deprecation notice: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

Replacing with `macos-15-intel` based on guidance from
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Closes #207
