### PR TITLE
docs: add installation instructions for `uv` tool

### DIFF
--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -25,6 +25,12 @@ blog](https://datafusion.apache.org/blog/2025/04/10/fastest-tpch-generator/) to 
 pip install tpchgen-cli
 ```
 
+## Install via `uv`
+
+```shell
+uv tool install tpchgen-cli 
+```
+
 ## Install via Rust
 
 [Install Rust](https://www.rust-lang.org/tools/install) and compile


### PR DESCRIPTION
### Description

This PR adds instructions for installing tpchgen-cli using `uv` to the README.

#### Motivation

1.  **Compatibility**: Kali Linux and some modern Linux distributions (following PEP 668) restrict global `pip` installations, causing errors for users trying to install directly.
2.  **Tooling**: `uv` is a fast and modern Python package and project manager. Using `uv tool install` provides better isolation and management for CLI tools.