### PR TITLE
cli: warn when skip generation

### DIFF
--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -188,8 +188,8 @@ where
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                eprintln!(
-                    "Warning: {} already exists, skipping generation",
+                println!(
+                    "Info: {} already exists, skipping generation",
                     path.display()
                 );
                 return Ok(());
@@ -225,8 +225,8 @@ where
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                eprintln!(
-                    "Warning: {} already exists, skipping generation",
+                println!(
+                    "Info: {} already exists, skipping generation",
                     path.display()
                 );
                 return Ok(());

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -101,11 +101,11 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
         .assert()
         .success();
 
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
     assert!(
-        stderr.contains("Warning:") && stderr.contains("already exists, skipping generation"),
-        "Expected warning message not found in stderr: {}",
-        stderr
+        stdout.contains("Info:") && stdout.contains("already exists, skipping generation"),
+        "Expected info message not found in stdout: {}",
+        stdout
     );
 
     let new_metadata =
@@ -160,11 +160,11 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
         .assert()
         .success();
 
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
     assert!(
-        stderr.contains("Warning:") && stderr.contains("already exists, skipping generation"),
-        "Expected warning message not found in stderr: {}",
-        stderr
+        stdout.contains("Info:") && stdout.contains("already exists, skipping generation"),
+        "Expected info message not found in stdout: {}",
+        stdout
     );
 
     let new_metadata =


### PR DESCRIPTION
Closes #209

By default, CLI prints to stdout

Tested manually for both single file and folder 
<img width="987" height="271" alt="Screenshot 2026-01-12 at 10 02 48 AM" src="https://github.com/user-attachments/assets/d7ee7106-a776-430c-9a92-2445e0d5e478" />

As described in #209, we could also introduce a `--force` flag to overwrite the files
