### PR TITLE
cli: add `--quiet` flag, enable logging by default

### DIFF
--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -100,7 +100,7 @@ struct Cli {
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
 
-    /// Quiet mode - disable all logging output
+    /// Quiet mode - only show error-level logs
     #[arg(short, long, default_value_t = false)]
     quiet: bool,
 
@@ -176,8 +176,8 @@ impl Cli {
     async fn main(self) -> io::Result<()> {
         // Configure logging
         if self.quiet {
-            // Quiet mode: disable all logging
-            env_logger::builder().filter_level(LevelFilter::Off).init();
+            // Quiet mode: only show error-level logs
+            env_logger::builder().filter_level(LevelFilter::Error).init();
         } else if self.verbose {
             env_logger::builder().filter_level(LevelFilter::Info).init();
             info!("Verbose output enabled (ignoring RUST_LOG environment variable)");

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -100,7 +100,7 @@ struct Cli {
     #[arg(short, long, default_value_t = false)]
     verbose: bool,
 
-    /// Quiet mode - disable all stdout output
+    /// Quiet mode - disable all logging output
     #[arg(short, long, default_value_t = false)]
     quiet: bool,
 

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -97,11 +97,11 @@ struct Cli {
     ///
     /// When specified, sets the log level to `info` and ignores the `RUST_LOG`
     /// environment variable. When not specified, uses `RUST_LOG`
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, conflicts_with = "quiet")]
     verbose: bool,
 
     /// Quiet mode - only show error-level logs
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, conflicts_with = "verbose")]
     quiet: bool,
 
     /// Write the output to stdout instead of a file.

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -177,7 +177,9 @@ impl Cli {
         // Configure logging
         if self.quiet {
             // Quiet mode: only show error-level logs
-            env_logger::builder().filter_level(LevelFilter::Error).init();
+            env_logger::builder()
+                .filter_level(LevelFilter::Error)
+                .init();
         } else if self.verbose {
             env_logger::builder().filter_level(LevelFilter::Info).init();
             info!("Verbose output enabled (ignoring RUST_LOG environment variable)");

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -188,10 +188,7 @@ where
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                println!(
-                    "Info: {} already exists, skipping generation",
-                    path.display()
-                );
+                log::warn!("{} already exists, skipping generation", path.display());
                 return Ok(());
             }
             // write to a temp file and then rename to avoid partial files
@@ -225,10 +222,7 @@ where
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                println!(
-                    "Info: {} already exists, skipping generation",
-                    path.display()
-                );
+                log::warn!("{} already exists, skipping generation", path.display());
                 return Ok(());
             }
             // write to a temp file and then rename to avoid partial files


### PR DESCRIPTION
Great suggestion from @alamb to add a `--quiet` flag that suppresses all output, https://github.com/clflushopt/tpchgen-rs/pull/220#pullrequestreview-3651624336 
`--quiet` sets the log level to `ERROR` so the CLI can still display error logs 

I also took the opportunity to refactor the remaining usages of `eprintln!` and `println!`, replacing them with log statements. 

We still retain the behavior implemented in #220; the cli still warns when skip generation
<img width="998" height="243" alt="Screenshot 2026-01-13 at 2 20 35 PM" src="https://github.com/user-attachments/assets/0c27a67b-2fc9-40a0-ad95-379f9d077076" />
