### PR TITLE
feat: Track table generation with progress bars

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,10 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Check
         run: cargo check --verbose --workspace --all-targets
+      - name: Check tpchgen-cli without default features
+        run: cargo check -p tpchgen-cli --no-default-features
+      - name: Check tpchgen-cli with custom progress feature
+        run: cargo check -p tpchgen-cli --no-default-features --features progress
 
   # Tests for tpchgen
   test-tests-tpchgen:

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.31"
 num_cpus = "1.0"
 log = "0.4.26"
 env_logger = "0.11.7"
+indicatif = "0.18.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -28,7 +28,15 @@ futures = "0.3.31"
 num_cpus = "1.0"
 log = "0.4.26"
 env_logger = "0.11.7"
-indicatif = "0.18.3"
+indicatif = { version = "0.18.3", optional = true }
+
+[features]
+default = ["indicatif-progress"]
+# Enable progress callbacks for applications that want to provide their own
+# progress reporting without pulling in the default terminal progress bars.
+progress = []
+# Enable the default CLI terminal progress bars backed by `indicatif`.
+indicatif-progress = ["progress", "dep:indicatif"]
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "tpchgen-cli"
 path = "bin/main.rs"
+required-features = ["indicatif-progress"]
 
 [dependencies]
 arrow = "58"

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -72,6 +72,11 @@ for PART in `seq 2 3`; do
 done
 ```
 
+By default `tpchgen-cli` shows a per-table progress bar on stderr while data
+is generated. Pass `--no-progress` to disable it (it is also disabled
+automatically when `--quiet` is set, when `--stdout` is used, or when stderr
+is not a terminal, e.g. in CI logs).
+
 ## Performance
 
 | Scale Factor | `tpchgen-cli` | DuckDB     | DuckDB (proprietary) |

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -10,14 +10,10 @@
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
 use log::{info, LevelFilter};
-use std::io;
-#[cfg(feature = "indicatif-progress")]
-use std::io::IsTerminal;
+use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 use std::str::FromStr;
-#[cfg(feature = "indicatif-progress")]
 use std::sync::Arc;
-#[cfg(feature = "indicatif-progress")]
 use tpchgen_cli::progress::IndicatifProgress;
 use tpchgen_cli::{
     Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
@@ -138,7 +134,6 @@ impl CommonArgs {
     /// Initialize CLI logging/progress output and create a
     /// [`TpchGeneratorBuilder`] pre-configured with the common options.
     fn builder(self, format: OutputFormat) -> TpchGeneratorBuilder {
-        #[cfg(feature = "indicatif-progress")]
         let progress = self
             .should_show_progress_bars()
             .then(|| Arc::new(IndicatifProgress::new()));
@@ -160,24 +155,18 @@ impl CommonArgs {
             builder = builder.with_part(part);
         }
 
-        #[cfg(feature = "indicatif-progress")]
-        {
-            configure_logging(
-                self.verbose,
-                self.quiet,
-                progress.as_ref().map(|progress| progress.log_writer()),
-            );
-            if let Some(progress) = progress {
-                builder = builder.with_progress_tracker(progress);
-            }
+        configure_logging(
+            self.verbose,
+            self.quiet,
+            progress.as_ref().map(|progress| progress.log_writer()),
+        );
+        if let Some(progress) = progress {
+            builder = builder.with_progress_tracker(progress);
         }
-        #[cfg(not(feature = "indicatif-progress"))]
-        configure_logging(self.verbose, self.quiet, None);
 
         builder
     }
 
-    #[cfg(feature = "indicatif-progress")]
     fn should_show_progress_bars(&self) -> bool {
         // Show progress only on an interactive terminal and when no flag
         // suppresses it. `--stdout` is included so piped data isn't

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -8,7 +8,7 @@
 
 // Use the library public API
 use clap::builder::TypedValueParser;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use log::{info, LevelFilter};
 use std::io;
 use std::path::PathBuf;
@@ -120,8 +120,8 @@ struct CommonArgs {
     #[arg(long, default_value_t = false)]
     stdout: bool,
 
-    /// Show progress bars during data generation (shown by default, hidden with --quiet)
-    #[arg(short = 'P', long, default_value_t = true)]
+    /// Disable progress bars during data generation
+    #[arg(long = "no-progress", action = ArgAction::SetFalse, default_value_t = true)]
     progress: bool,
 }
 

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -11,8 +11,14 @@ use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
 use log::{info, LevelFilter};
 use std::io;
+#[cfg(feature = "indicatif-progress")]
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::str::FromStr;
+#[cfg(feature = "indicatif-progress")]
+use std::sync::Arc;
+#[cfg(feature = "indicatif-progress")]
+use tpchgen_cli::progress::IndicatifProgress;
 use tpchgen_cli::{
     Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
     DEFAULT_PARQUET_ROW_GROUP_BYTES,
@@ -120,21 +126,29 @@ struct CommonArgs {
     #[arg(long, default_value_t = false)]
     stdout: bool,
 
-    /// Disable progress bars during data generation
+    /// Disable progress bars during data generation.
+    ///
+    /// Bars are also auto-suppressed by `--quiet`, `--stdout`, or when
+    /// stderr is not a terminal.
     #[arg(long = "no-progress", action = ArgAction::SetFalse, default_value_t = true)]
-    progress: bool,
+    progress_bars_enabled: bool,
 }
 
 impl CommonArgs {
-    /// Create a [`TpchGeneratorBuilder`] pre-configured with the common options.
+    /// Initialize CLI logging/progress output and create a
+    /// [`TpchGeneratorBuilder`] pre-configured with the common options.
     fn builder(self, format: OutputFormat) -> TpchGeneratorBuilder {
+        #[cfg(feature = "indicatif-progress")]
+        let progress = self
+            .should_show_progress_bars()
+            .then(|| Arc::new(IndicatifProgress::new()));
+
         let mut builder = TpchGenerator::builder()
             .with_scale_factor(self.scale_factor)
             .with_output_dir(self.output_dir)
             .with_format(format)
             .with_num_threads(self.num_threads)
-            .with_stdout(self.stdout)
-            .with_show_progress(self.progress && !self.quiet);
+            .with_stdout(self.stdout);
 
         if let Some(tables) = self.tables {
             builder = builder.with_tables(tables);
@@ -146,7 +160,29 @@ impl CommonArgs {
             builder = builder.with_part(part);
         }
 
+        #[cfg(feature = "indicatif-progress")]
+        {
+            configure_logging(
+                self.verbose,
+                self.quiet,
+                progress.as_ref().map(|progress| progress.log_writer()),
+            );
+            if let Some(progress) = progress {
+                builder = builder.with_progress_tracker(progress);
+            }
+        }
+        #[cfg(not(feature = "indicatif-progress"))]
+        configure_logging(self.verbose, self.quiet, None);
+
         builder
+    }
+
+    #[cfg(feature = "indicatif-progress")]
+    fn should_show_progress_bars(&self) -> bool {
+        // Show progress only on an interactive terminal and when no flag
+        // suppresses it. `--stdout` is included so piped data isn't
+        // interleaved with bar redraws on shared shells.
+        self.progress_bars_enabled && !self.quiet && !self.stdout && io::stderr().is_terminal()
     }
 }
 
@@ -310,14 +346,6 @@ async fn main() -> io::Result<()> {
 impl Cli {
     /// Main function to run the generation
     async fn main(self) -> io::Result<()> {
-        let common = match &self.command {
-            Some(Commands::Tbl(args)) => &args.common,
-            Some(Commands::Csv(args)) => &args.common,
-            Some(Commands::Parquet(args)) => &args.common,
-            None => &self.args.common,
-        };
-        configure_logging(common.verbose, common.quiet);
-
         match self.command {
             Some(Commands::Tbl(args)) => args.run().await,
             Some(Commands::Csv(args)) => args.run().await,
@@ -328,21 +356,23 @@ impl Cli {
 
     async fn run(self) -> io::Result<()> {
         // Warn about --format migration to subcommands (only when explicitly provided)
-        let format = if let Some(format) = self.args.format {
+        let (format, subcommand) = if let Some(format) = self.args.format {
             let subcommand = match format {
                 OutputFormat::Parquet => "parquet",
                 OutputFormat::Csv => "csv",
                 OutputFormat::Tbl => "tbl",
             };
-            log::warn!(
-                "The --format flag will be removed in v4.0.0. Use `tpchgen-cli {subcommand}` instead."
-            );
-            format
+            (format, Some(subcommand))
         } else {
-            OutputFormat::Tbl
+            (OutputFormat::Tbl, None)
         };
 
         let mut builder = self.args.common.builder(format);
+        if let Some(subcommand) = subcommand {
+            log::warn!(
+                "The --format flag will be removed in v4.0.0. Use `tpchgen-cli {subcommand}` instead."
+            );
+        }
 
         if let Some(parquet_compression) = self.args.parquet_compression {
             if format == OutputFormat::Parquet {
@@ -399,20 +429,28 @@ impl ParquetArgs {
     }
 }
 
-fn configure_logging(verbose: bool, quiet: bool) {
+fn configure_logging(
+    verbose: bool,
+    quiet: bool,
+    log_writer: Option<Box<dyn io::Write + Send + 'static>>,
+) {
+    let mut builder = env_logger::builder();
     if quiet {
         // Quiet mode: only show error-level logs
-        env_logger::builder()
-            .filter_level(LevelFilter::Error)
-            .init();
+        builder.filter_level(LevelFilter::Error);
     } else if verbose {
-        env_logger::builder().filter_level(LevelFilter::Info).init();
-        info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
+        builder.filter_level(LevelFilter::Info);
     } else {
         // Default: show warnings and errors, but respect RUST_LOG if set
-        env_logger::builder()
-            .filter_level(LevelFilter::Warn)
-            .parse_default_env()
-            .init();
+        builder.filter_level(LevelFilter::Warn).parse_default_env();
+    }
+    if let Some(log_writer) = log_writer {
+        builder.target(env_logger::Target::Pipe(log_writer));
+    }
+
+    builder.init();
+
+    if verbose {
+        info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
     }
 }

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -119,6 +119,10 @@ struct CommonArgs {
     /// Write the output to stdout instead of a file.
     #[arg(long, default_value_t = false)]
     stdout: bool,
+
+    /// Show progress bars during generation
+    #[arg(short = 'P', long, default_value_t = false)]
+    progress: bool,
 }
 
 impl CommonArgs {
@@ -129,7 +133,8 @@ impl CommonArgs {
             .with_output_dir(self.output_dir)
             .with_format(format)
             .with_num_threads(self.num_threads)
-            .with_stdout(self.stdout);
+            .with_stdout(self.stdout)
+            .with_show_progress(self.progress);
 
         if let Some(tables) = self.tables {
             builder = builder.with_tables(tables);

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -120,8 +120,8 @@ struct CommonArgs {
     #[arg(long, default_value_t = false)]
     stdout: bool,
 
-    /// Show progress bars during generation
-    #[arg(short = 'P', long, default_value_t = false)]
+    /// Show progress bars during data generation (shown by default, hidden with --quiet)
+    #[arg(short = 'P', long, default_value_t = true)]
     progress: bool,
 }
 
@@ -134,7 +134,7 @@ impl CommonArgs {
             .with_format(format)
             .with_num_threads(self.num_threads)
             .with_stdout(self.stdout)
-            .with_show_progress(self.progress);
+            .with_show_progress(self.progress && !self.quiet);
 
         if let Some(tables) = self.tables {
             builder = builder.with_tables(tables);

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -3,7 +3,7 @@
 //! These traits and function are used to generate data in parallel and write it to a sink
 //! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
 
-use crate::progress::ProgressTracker;
+use crate::progress::{IncrementType, ProgressTracker};
 use crate::Table;
 use futures::StreamExt;
 use log::debug;
@@ -120,7 +120,7 @@ where
             captured_recycler.return_buffer(buffer);
             // Increment buffer count after each buffer/chunk is written
             if let Some(ref tracker) = captured_progress_for_buffers {
-                tracker.increment_buffer(table);
+                tracker.increment(table, IncrementType::Buffer);
             }
         }
         // No more input, flush the sink and return

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -118,7 +118,6 @@ where
         while let Some(buffer) = rx.blocking_recv() {
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
-            // Increment buffer count after each buffer/chunk is written
             if let Some(ref tracker) = captured_progress_for_buffers {
                 tracker.increment(table, IncrementType::Buffer);
             }

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -3,8 +3,7 @@
 //! These traits and function are used to generate data in parallel and write it to a sink
 //! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
 
-use crate::progress::ProgressTracker;
-use crate::Table;
+use crate::progress::TableProgress;
 use futures::StreamExt;
 use log::debug;
 use std::collections::VecDeque;
@@ -51,12 +50,38 @@ pub trait Sink: Send {
 /// I: Iterator<Item = G>
 /// S: Sink that writes buffers somewhere
 pub async fn generate_in_chunks<G, I, S>(
+    sink: S,
+    sources: I,
+    num_threads: usize,
+) -> Result<(), io::Error>
+where
+    G: Source + 'static,
+    I: Iterator<Item = G>,
+    S: Sink + 'static,
+{
+    let progress = Default::default();
+    generate_in_chunks_impl(sink, sources, num_threads, progress).await
+}
+
+pub(crate) async fn generate_in_chunks_with_progress<G, I, S>(
+    sink: S,
+    sources: I,
+    num_threads: usize,
+    progress: TableProgress,
+) -> Result<(), io::Error>
+where
+    G: Source + 'static,
+    I: Iterator<Item = G>,
+    S: Sink + 'static,
+{
+    generate_in_chunks_impl(sink, sources, num_threads, progress).await
+}
+
+async fn generate_in_chunks_impl<G, I, S>(
     mut sink: S,
     sources: I,
     num_threads: usize,
-    progress_tracker: Option<ProgressTracker>,
-    table: Table,
-    rows_per_chunk: u64,
+    progress: TableProgress,
 ) -> Result<(), io::Error>
 where
     G: Source + 'static,
@@ -69,24 +94,20 @@ where
     // use all cores to make data
     debug!("Using {num_threads} threads");
 
-    // create a channel to communicate between the generator tasks and the writer task
-    let (tx, mut rx) = tokio::sync::mpsc::channel(num_threads);
-
-    // write the header
     let Some(first) = sources.peek() else {
         return Ok(()); // no sources
     };
     let header = first.header(Vec::new());
-    tx.send(header)
-        .await
-        .expect("tx just created, it should not be closed");
 
     let sources_and_recyclers = sources.map(|generator| (generator, recycler.clone()));
+
+    // create a channel to communicate between the generator tasks and the writer task
+    let (tx, mut rx) = tokio::sync::mpsc::channel(num_threads);
 
     // convert to an async stream to run on tokio
     let mut stream = futures::stream::iter(sources_and_recyclers)
         // each generator writes to a buffer
-        .map(|(source, recycler)| async move {
+        .map(async |(source, recycler)| {
             let buffer = recycler.new_buffer(1024 * 1024 * 8);
             // do the work in a task (on a different thread)
             let mut join_set = JoinSet::new();
@@ -114,14 +135,13 @@ where
     // The writer task runs in a blocking thread to avoid blocking the async
     // runtime. It reads from the channel and writes to the sink (doing File IO)
     let captured_recycler = recycler.clone();
-    let captured_progress_for_buffers = progress_tracker.clone();
+    let captured_progress = progress.clone();
     let writer_task = tokio::task::spawn_blocking(move || {
+        sink.sink(&header)?;
         while let Some(buffer) = rx.blocking_recv() {
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
-            if let Some(ref tracker) = captured_progress_for_buffers {
-                tracker.increment(table, rows_per_chunk);
-            }
+            captured_progress.increment_output_unit();
         }
         // No more input, flush the sink and return
         sink.flush()
@@ -175,5 +195,98 @@ impl BufferRecycler {
     fn return_buffer(&self, buffer: Vec<u8>) {
         let mut buffers = self.buffers.lock().unwrap();
         buffers.push_back(buffer);
+    }
+}
+
+#[cfg(all(test, feature = "progress"))]
+mod tests {
+    use super::*;
+    use crate::progress::{ProgressTracker, RunProgress};
+    use crate::Table;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[derive(Debug)]
+    struct CountingProgress {
+        increments: AtomicU64,
+    }
+
+    impl ProgressTracker for CountingProgress {
+        fn increment(&self, _table: Table, units: u64) {
+            self.increments.fetch_add(units, Ordering::Relaxed);
+        }
+    }
+
+    struct TestSource {
+        header: &'static [u8],
+        data: &'static [u8],
+    }
+
+    impl Source for TestSource {
+        fn header(&self, mut buffer: Vec<u8>) -> Vec<u8> {
+            buffer.extend_from_slice(self.header);
+            buffer
+        }
+
+        fn create(self, mut buffer: Vec<u8>) -> Vec<u8> {
+            buffer.extend_from_slice(self.data);
+            buffer
+        }
+    }
+
+    struct CapturingSink {
+        writes: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl Sink for CapturingSink {
+        fn sink(&mut self, buffer: &[u8]) -> Result<(), io::Error> {
+            self.writes.lock().unwrap().push(buffer.to_vec());
+            Ok(())
+        }
+
+        fn flush(self) -> Result<(), io::Error> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn progress_counts_generated_chunks_not_header() {
+        let writes = Arc::new(Mutex::new(Vec::new()));
+        let tracker = Arc::new(CountingProgress {
+            increments: AtomicU64::new(0),
+        });
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = RunProgress::with_tracker(progress).for_table(Table::Region);
+
+        let sources = vec![
+            TestSource {
+                header: b"header\n",
+                data: b"row-1\n",
+            },
+            TestSource {
+                header: b"header\n",
+                data: b"row-2\n",
+            },
+        ];
+
+        generate_in_chunks_with_progress(
+            CapturingSink {
+                writes: Arc::clone(&writes),
+            },
+            sources.into_iter(),
+            1,
+            progress,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            *writes.lock().unwrap(),
+            vec![
+                b"header\n".to_vec(),
+                b"row-1\n".to_vec(),
+                b"row-2\n".to_vec()
+            ]
+        );
     }
 }

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -3,7 +3,7 @@
 //! These traits and function are used to generate data in parallel and write it to a sink
 //! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
 
-use crate::progress::{IncrementType, ProgressTracker};
+use crate::progress::ProgressTracker;
 use crate::Table;
 use futures::StreamExt;
 use log::debug;
@@ -56,6 +56,7 @@ pub async fn generate_in_chunks<G, I, S>(
     num_threads: usize,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
+    rows_per_chunk: u64,
 ) -> Result<(), io::Error>
 where
     G: Source + 'static,
@@ -119,7 +120,7 @@ where
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
             if let Some(ref tracker) = captured_progress_for_buffers {
-                tracker.increment(table, IncrementType::Buffer);
+                tracker.increment(table, rows_per_chunk);
             }
         }
         // No more input, flush the sink and return

--- a/tpchgen-cli/src/generate.rs
+++ b/tpchgen-cli/src/generate.rs
@@ -137,6 +137,7 @@ where
     let captured_recycler = recycler.clone();
     let captured_progress = progress.clone();
     let writer_task = tokio::task::spawn_blocking(move || {
+        // The header is not an output unit; only generated chunks from the channel advance progress.
         sink.sink(&header)?;
         while let Some(buffer) = rx.blocking_recv() {
             sink.sink(&buffer)?;

--- a/tpchgen-cli/src/lib.rs
+++ b/tpchgen-cli/src/lib.rs
@@ -255,7 +255,7 @@ impl Default for GeneratorConfig {
             part: None,
             stdout: false,
             csv_delimiter: ',',
-            show_progress: false,
+            show_progress: true,
         }
     }
 }
@@ -418,6 +418,7 @@ impl TpchGenerator {
 /// - Threads: number of CPUs
 /// - Parquet compression: SNAPPY
 /// - Row group size: 7MB
+/// - Show progress: true
 ///
 /// # Examples
 ///

--- a/tpchgen-cli/src/lib.rs
+++ b/tpchgen-cli/src/lib.rs
@@ -31,6 +31,9 @@ pub mod generate;
 pub mod output_plan;
 pub mod parquet;
 pub mod plan;
+#[cfg(not(feature = "progress"))]
+mod progress;
+#[cfg(feature = "progress")]
 pub mod progress;
 pub mod runner;
 pub mod statistics;
@@ -38,11 +41,15 @@ pub mod tbl;
 
 use crate::generate::Sink;
 use crate::parquet::IntoSize;
+#[cfg(feature = "progress")]
+use crate::progress::ProgressTracker;
 use crate::statistics::WriteStatistics;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::{self, BufWriter, Stdout, Write};
 use std::str::FromStr;
+#[cfg(feature = "progress")]
+use std::sync::Arc;
 
 /// Wrapper around a buffer writer that counts the number of buffers and bytes written
 pub struct WriterSink<W: Write> {
@@ -90,7 +97,7 @@ impl IntoSize for BufWriter<File> {
 ///
 /// Represents the 8 tables in the TPC-H benchmark schema.
 /// Tables are ordered by size (smallest to largest at SF=1).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Table {
     /// Nation table (25 rows)
     Nation,
@@ -237,8 +244,6 @@ pub struct GeneratorConfig {
     pub stdout: bool,
     /// CSV delimiter character (only applies to CSV format)
     pub csv_delimiter: char,
-    /// Show progress bars during generation
-    pub show_progress: bool,
 }
 
 impl Default for GeneratorConfig {
@@ -255,7 +260,6 @@ impl Default for GeneratorConfig {
             part: None,
             stdout: false,
             csv_delimiter: ',',
-            show_progress: true,
         }
     }
 }
@@ -296,6 +300,8 @@ impl Default for GeneratorConfig {
 /// ```
 pub struct TpchGenerator {
     config: GeneratorConfig,
+    #[cfg(feature = "progress")]
+    progress_tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
 impl TpchGenerator {
@@ -349,6 +355,8 @@ impl TpchGenerator {
         use tpchgen::text::TextPool;
 
         let config = self.config;
+        #[cfg(feature = "progress")]
+        let progress_tracker = self.progress_tracker;
 
         // Create output directory if it doesn't exist and we are not writing to stdout
         if !config.stdout {
@@ -396,7 +404,13 @@ impl TpchGenerator {
         info!("Created static distributions and text pools in {elapsed:?}");
 
         // Run
-        let runner = PlanRunner::new(output_plans, config.num_threads, config.show_progress);
+        let runner = PlanRunner::new(output_plans, config.num_threads);
+        #[cfg(feature = "progress")]
+        let runner = if let Some(tracker) = progress_tracker {
+            runner.with_progress_tracker(tracker)
+        } else {
+            runner
+        };
         runner.run().await?;
         info!("Generation complete!");
         Ok(())
@@ -418,7 +432,6 @@ impl TpchGenerator {
 /// - Threads: number of CPUs
 /// - Parquet compression: SNAPPY
 /// - Row group size: 7MB
-/// - Show progress: true
 ///
 /// # Examples
 ///
@@ -444,6 +457,8 @@ impl TpchGenerator {
 #[derive(Debug, Clone)]
 pub struct TpchGeneratorBuilder {
     config: GeneratorConfig,
+    #[cfg(feature = "progress")]
+    progress_tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
 impl TpchGeneratorBuilder {
@@ -459,6 +474,8 @@ impl TpchGeneratorBuilder {
     pub fn new() -> Self {
         Self {
             config: GeneratorConfig::default(),
+            #[cfg(feature = "progress")]
+            progress_tracker: None,
         }
     }
 
@@ -533,9 +550,14 @@ impl TpchGeneratorBuilder {
         self
     }
 
-    /// Show progress bars during generation
-    pub fn with_show_progress(mut self, show_progress: bool) -> Self {
-        self.config.show_progress = show_progress;
+    /// Attach a custom [`ProgressTracker`] to receive generation progress updates.
+    ///
+    /// The runner calls [`ProgressTracker::finish`] on successful completion.
+    /// Trackers that need error or panic cleanup should use `Drop` as a
+    /// fallback. See [`progress`] for the full contract and examples.
+    #[cfg(feature = "progress")]
+    pub fn with_progress_tracker(mut self, tracker: Arc<dyn ProgressTracker>) -> Self {
+        self.progress_tracker = Some(tracker);
         self
     }
 
@@ -543,6 +565,8 @@ impl TpchGeneratorBuilder {
     pub fn build(self) -> TpchGenerator {
         TpchGenerator {
             config: self.config,
+            #[cfg(feature = "progress")]
+            progress_tracker: self.progress_tracker,
         }
     }
 }
@@ -550,5 +574,63 @@ impl TpchGeneratorBuilder {
 impl Default for TpchGeneratorBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(all(test, feature = "progress"))]
+mod tests {
+    use super::*;
+    use crate::progress::ProgressTracker;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    };
+
+    #[derive(Debug, Default)]
+    struct RecordingProgress {
+        registered: Mutex<Vec<(Table, u64)>>,
+        increments: Mutex<Vec<(Table, u64)>>,
+        finishes: AtomicU64,
+    }
+
+    impl ProgressTracker for RecordingProgress {
+        fn register(&self, table: Table, total_units: u64) {
+            self.registered.lock().unwrap().push((table, total_units));
+        }
+
+        fn increment(&self, table: Table, units: u64) {
+            self.increments.lock().unwrap().push((table, units));
+        }
+
+        fn finish(&self) {
+            self.finishes.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn builder_passes_custom_progress_tracker_to_runner() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let tracker = Arc::new(RecordingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+
+        TpchGenerator::builder()
+            .with_output_dir(output_dir.path())
+            .with_tables(vec![Table::Region])
+            .with_num_threads(1)
+            .with_progress_tracker(progress)
+            .build()
+            .generate()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *tracker.registered.lock().unwrap(),
+            vec![(Table::Region, 1)]
+        );
+        assert_eq!(
+            *tracker.increments.lock().unwrap(),
+            vec![(Table::Region, 1)]
+        );
+        assert_eq!(tracker.finishes.load(Ordering::Relaxed), 1);
     }
 }

--- a/tpchgen-cli/src/lib.rs
+++ b/tpchgen-cli/src/lib.rs
@@ -31,6 +31,7 @@ pub mod generate;
 pub mod output_plan;
 pub mod parquet;
 pub mod plan;
+pub mod progress;
 pub mod runner;
 pub mod statistics;
 pub mod tbl;
@@ -89,7 +90,7 @@ impl IntoSize for BufWriter<File> {
 ///
 /// Represents the 8 tables in the TPC-H benchmark schema.
 /// Tables are ordered by size (smallest to largest at SF=1).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Table {
     /// Nation table (25 rows)
     Nation,
@@ -236,6 +237,8 @@ pub struct GeneratorConfig {
     pub stdout: bool,
     /// CSV delimiter character (only applies to CSV format)
     pub csv_delimiter: char,
+    /// Show progress bars during generation
+    pub show_progress: bool,
 }
 
 impl Default for GeneratorConfig {
@@ -252,6 +255,7 @@ impl Default for GeneratorConfig {
             part: None,
             stdout: false,
             csv_delimiter: ',',
+            show_progress: false,
         }
     }
 }
@@ -392,7 +396,7 @@ impl TpchGenerator {
         info!("Created static distributions and text pools in {elapsed:?}");
 
         // Run
-        let runner = PlanRunner::new(output_plans, config.num_threads);
+        let runner = PlanRunner::new(output_plans, config.num_threads, config.show_progress);
         runner.run().await?;
         info!("Generation complete!");
         Ok(())
@@ -525,6 +529,12 @@ impl TpchGeneratorBuilder {
     /// Set the CSV delimiter character (only applies to CSV format, default: ',')
     pub fn with_csv_delimiter(mut self, delimiter: char) -> Self {
         self.config.csv_delimiter = delimiter;
+        self
+    }
+
+    /// Show progress bars during generation
+    pub fn with_show_progress(mut self, show_progress: bool) -> Self {
+        self.config.show_progress = show_progress;
         self
     }
 

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -1,6 +1,6 @@
 //! Parquet output format
 
-use crate::progress::ProgressTracker;
+use crate::progress::{IncrementType, ProgressTracker};
 use crate::statistics::WriteStatistics;
 use crate::Table;
 use arrow::datatypes::SchemaRef;
@@ -109,7 +109,7 @@ where
             
             // Increment buffer count after each row group is written
             if let Some(ref tracker) = captured_progress {
-                tracker.increment_buffer(table);
+                tracker.increment(table, IncrementType::Buffer);
             }
         }
         let size = writer.into_inner()?.into_size()?;

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -106,7 +106,7 @@ where
             }
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
-            
+
             // Increment buffer count after each row group is written
             if let Some(ref tracker) = captured_progress {
                 tracker.increment(table, IncrementType::Buffer);

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -106,8 +106,6 @@ where
             }
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
-
-            // Increment buffer count after each row group is written
             if let Some(ref tracker) = captured_progress {
                 tracker.increment(table, IncrementType::Buffer);
             }

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -1,6 +1,6 @@
 //! Parquet output format
 
-use crate::progress::{IncrementType, ProgressTracker};
+use crate::progress::ProgressTracker;
 use crate::statistics::WriteStatistics;
 use crate::Table;
 use arrow::datatypes::SchemaRef;
@@ -36,6 +36,7 @@ pub async fn generate_parquet<W: Write + Send + IntoSize + 'static, I>(
     parquet_compression: Compression,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
+    rows_per_chunk: u64,
 ) -> Result<(), io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
@@ -107,7 +108,7 @@ where
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
             if let Some(ref tracker) = captured_progress {
-                tracker.increment(table, IncrementType::Buffer);
+                tracker.increment(table, rows_per_chunk);
             }
         }
         let size = writer.into_inner()?.into_size()?;

--- a/tpchgen-cli/src/parquet.rs
+++ b/tpchgen-cli/src/parquet.rs
@@ -1,8 +1,7 @@
 //! Parquet output format
 
-use crate::progress::ProgressTracker;
+use crate::progress::TableProgress;
 use crate::statistics::WriteStatistics;
-use crate::Table;
 use arrow::datatypes::SchemaRef;
 use futures::StreamExt;
 use log::debug;
@@ -34,9 +33,47 @@ pub async fn generate_parquet<W: Write + Send + IntoSize + 'static, I>(
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
-    progress_tracker: Option<ProgressTracker>,
-    table: Table,
-    rows_per_chunk: u64,
+) -> Result<(), io::Error>
+where
+    I: Iterator<Item: RecordBatchIterator> + 'static,
+{
+    let progress = Default::default();
+    generate_parquet_impl(
+        writer,
+        iter_iter,
+        num_threads,
+        parquet_compression,
+        progress,
+    )
+    .await
+}
+
+pub(crate) async fn generate_parquet_with_progress<W: Write + Send + IntoSize + 'static, I>(
+    writer: W,
+    iter_iter: I,
+    num_threads: usize,
+    parquet_compression: Compression,
+    progress: TableProgress,
+) -> Result<(), io::Error>
+where
+    I: Iterator<Item: RecordBatchIterator> + 'static,
+{
+    generate_parquet_impl(
+        writer,
+        iter_iter,
+        num_threads,
+        parquet_compression,
+        progress,
+    )
+    .await
+}
+
+async fn generate_parquet_impl<W: Write + Send + IntoSize + 'static, I>(
+    writer: W,
+    iter_iter: I,
+    num_threads: usize,
+    parquet_compression: Compression,
+    progress: TableProgress,
 ) -> Result<(), io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
@@ -91,25 +128,25 @@ where
         Sender<Vec<ArrowColumnChunk>>,
         Receiver<Vec<ArrowColumnChunk>>,
     ) = tokio::sync::mpsc::channel(num_threads);
-    let captured_progress = progress_tracker.clone();
+    let captured_progress = progress.clone();
     let writer_task = tokio::task::spawn_blocking(move || {
         // Create parquet writer
         let mut writer =
             SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
 
-        while let Some(chunks) = rx.blocking_recv() {
+        while let Some(column_chunks) = rx.blocking_recv() {
             // Start row group
             let mut row_group_writer = writer.next_row_group().unwrap();
 
             // Slap the chunks into the row group
-            for chunk in chunks {
-                chunk.append_to_row_group(&mut row_group_writer).unwrap();
+            for column_chunk in column_chunks {
+                column_chunk
+                    .append_to_row_group(&mut row_group_writer)
+                    .unwrap();
             }
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
-            if let Some(ref tracker) = captured_progress {
-                tracker.increment(table, rows_per_chunk);
-            }
+            captured_progress.increment_output_unit();
         }
         let size = writer.into_inner()?.into_size()?;
         statistics.increment_bytes(size);
@@ -117,10 +154,10 @@ where
     });
 
     // now, drive the input stream and send results to the writer task
-    while let Some(chunks) = row_group_stream.next().await {
+    while let Some(column_chunks) = row_group_stream.next().await {
         // send the chunks to the writer task
-        if let Err(e) = tx.send(chunks).await {
-            debug!("Error sending chunks to writer: {e}");
+        if let Err(e) = tx.send(column_chunks).await {
+            debug!("Error sending row group to writer: {e}");
             break; // stop early
         }
     }
@@ -174,4 +211,58 @@ where
         .into_iter()
         .map(|col_writer| col_writer.close().unwrap())
         .collect()
+}
+
+#[cfg(all(test, feature = "progress"))]
+mod tests {
+    use super::*;
+    use crate::progress::{ProgressTracker, RunProgress};
+    use crate::Table;
+    use std::fs::File;
+    use std::io::BufWriter;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+    use tpchgen::generators::RegionGenerator;
+    use tpchgen_arrow::RegionArrow;
+
+    #[derive(Debug)]
+    struct CountingProgress {
+        increments: AtomicU64,
+    }
+
+    impl ProgressTracker for CountingProgress {
+        fn increment(&self, _table: Table, row_groups: u64) {
+            self.increments.fetch_add(row_groups, Ordering::Relaxed);
+        }
+    }
+
+    fn region_source() -> RegionArrow {
+        RegionArrow::new(RegionGenerator::default()).with_batch_size(5)
+    }
+
+    #[tokio::test]
+    async fn progress_counts_written_row_groups() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let output_path = output_dir.path().join("progress.parquet");
+        let writer = BufWriter::new(File::create(&output_path).unwrap());
+
+        let tracker = Arc::new(CountingProgress {
+            increments: AtomicU64::new(0),
+        });
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = RunProgress::with_tracker(progress).for_table(Table::Region);
+
+        generate_parquet_with_progress(
+            writer,
+            vec![region_source(), region_source()].into_iter(),
+            1,
+            Compression::UNCOMPRESSED,
+            progress,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
+        assert!(std::fs::metadata(output_path).unwrap().len() > 0);
+    }
 }

--- a/tpchgen-cli/src/plan.rs
+++ b/tpchgen-cli/src/plan.rs
@@ -197,11 +197,6 @@ impl GenerationPlan {
     pub fn chunk_count(&self) -> usize {
         self.part_list.clone().count()
     }
-
-    /// Return the total row count
-    pub fn row_count(table: Table, scale_factor: f64) -> i64 {
-        OutputSize::row_count_for_table(table, scale_factor)
-    }
 }
 
 /// Converts the `GenerationPlan` into an iterator of (part_number, num_parts)

--- a/tpchgen-cli/src/plan.rs
+++ b/tpchgen-cli/src/plan.rs
@@ -197,6 +197,11 @@ impl GenerationPlan {
     pub fn chunk_count(&self) -> usize {
         self.part_list.clone().count()
     }
+
+    /// Return the total row count
+    pub fn row_count(table: Table, scale_factor: f64) -> i64 {
+        OutputSize::row_count_for_table(table, scale_factor)
+    }
 }
 
 /// Converts the `GenerationPlan` into an iterator of (part_number, num_parts)

--- a/tpchgen-cli/src/progress.rs
+++ b/tpchgen-cli/src/progress.rs
@@ -1,0 +1,129 @@
+//! Progress tracking for table generation
+
+use crate::Table;
+use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Tracks progress for all tables being generated
+#[derive(Clone, Debug)]
+pub struct ProgressTracker {
+    inner: Arc<ProgressTrackerInner>,
+}
+
+#[derive(Debug)]
+struct ProgressTrackerInner {
+    tables: Mutex<HashMap<Table, TableProgress>>,
+    #[allow(dead_code)] // Used via its side effects (managing progress bar display lifetime)
+    multi_progress: MultiProgress,
+}
+
+#[derive(Debug)]
+struct TableProgress {
+    parts_completed: AtomicUsize,
+    buffers_written: AtomicUsize,
+    #[allow(dead_code)] // Stored for reference, may be used in future features
+    total_parts: usize,
+    progress_bar: ProgressBar,
+}
+
+impl ProgressTracker {
+    /// Create a new progress tracker for the given tables
+    pub fn new(tables: Vec<(Table, usize)>) -> Self {
+        let multi_progress = MultiProgress::new();
+        let mut table_map = HashMap::new();
+        
+        for (table, total_parts) in tables {
+            let mut pb = multi_progress.add(ProgressBar::new(total_parts as u64));
+            pb.set_style(
+                ProgressStyle::default_bar()
+                    .template("{msg:10} [{bar:28}] Parts:{pos:>4}/{len:<4} Buffers:{prefix:>6} {percent:>3}%")
+                    .unwrap()
+                    .progress_chars("█▓░")
+            );
+            pb.set_message(format!("{}", table));
+            pb.set_prefix("0");
+            // Configure to leave the progress bar visible after finishing
+            pb = pb.with_finish(ProgressFinish::AndLeave);
+            
+            table_map.insert(table, TableProgress {
+                parts_completed: AtomicUsize::new(0),
+                buffers_written: AtomicUsize::new(0),
+                total_parts,
+                progress_bar: pb,
+            });
+        }
+        
+        Self {
+            inner: Arc::new(ProgressTrackerInner {
+                tables: Mutex::new(table_map),
+                multi_progress,
+            }),
+        }
+    }
+    
+    /// Increment the number of parts/files completed for a table
+    pub fn increment_part(&self, table: Table) {
+        let tables = self.inner.tables.lock().unwrap();
+        if let Some(progress) = tables.get(&table) {
+            let new_val = progress.parts_completed.fetch_add(1, Ordering::SeqCst) + 1;
+            progress.progress_bar.set_position(new_val as u64);
+        }
+    }
+    
+    /// Increment the number of chunks/buffers written for a table
+    pub fn increment_buffer(&self, table: Table) {
+        let tables = self.inner.tables.lock().unwrap();
+        if let Some(progress) = tables.get(&table) {
+            let new_val = progress.buffers_written.fetch_add(1, Ordering::SeqCst) + 1;
+            progress.progress_bar.set_prefix(format!("{}", new_val));
+        }
+    }
+    
+    /// Mark a table as complete (progress bar will stay visible due to ProgressFinish::AndLeave)
+    pub fn finish(&self, table: Table) {
+        let tables = self.inner.tables.lock().unwrap();
+        if let Some(progress) = tables.get(&table) {
+            progress.progress_bar.finish();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_progress_tracker_creation() {
+        let tracker = ProgressTracker::new(vec![
+            (Table::Lineitem, 10),
+            (Table::Orders, 5),
+        ]);
+        
+        // Test that we can increment without panicking
+        tracker.increment(Table::Lineitem);
+        tracker.increment(Table::Orders);
+    }
+    
+    #[test]
+    fn test_progress_tracker_increment() {
+        let tracker = ProgressTracker::new(vec![
+            (Table::Customer, 4),
+        ]);
+        
+        // Increment parts and buffers
+        for _ in 0..3 {
+            tracker.increment_part(Table::Customer);
+        }
+        for _ in 0..10 {
+            tracker.increment_buffer(Table::Customer);
+        }
+        
+        // Verify the counts
+        let tables = tracker.inner.tables.lock().unwrap();
+        let progress = tables.get(&Table::Customer).unwrap();
+        assert_eq!(progress.parts_completed.load(Ordering::SeqCst), 3);
+        assert_eq!(progress.buffers_written.load(Ordering::SeqCst), 10);
+    }
+}

--- a/tpchgen-cli/src/progress.rs
+++ b/tpchgen-cli/src/progress.rs
@@ -24,7 +24,9 @@ pub struct ProgressTracker {
 #[derive(Debug)]
 struct ProgressTrackerInner {
     tables: Mutex<HashMap<Table, TableProgress>>,
-    #[allow(dead_code)] // Used via its side effects (managing progress bar display lifetime)
+    // MultiProgress is unused but we need to it alive to
+    // manage the registered progress bars.
+    #[allow(dead_code)]
     multi_progress: MultiProgress,
 }
 

--- a/tpchgen-cli/src/progress.rs
+++ b/tpchgen-cli/src/progress.rs
@@ -1,83 +1,442 @@
-//! Progress tracking for table generation
+//! Progress tracking for table generation.
+//!
+//! # Overview
+//!
+//! [`ProgressTracker`] is a small, dyn-compatible trait that receives
+//! generation events from [`crate::runner::PlanRunner`]. The runner calls:
+//!
+//! 1. [`ProgressTracker::register`] once per table, before any worker
+//!    starts, with the total number of output units the table will produce
+//!    (chunks for TBL/CSV, row groups for Parquet).
+//! 2. [`ProgressTracker::increment`] after output units are written.
+//!    Multiple table-generation tasks may call it concurrently, so impls
+//!    must be `Send + Sync` and `increment` itself should be lightweight.
+//! 3. [`ProgressTracker::finish`] once on the success path when the
+//!    runner exits. Implementations should use `finish` for normal
+//!    success cleanup and `Drop` only as an error or panic fallback.
+//!
+//! `register` and `finish` are invoked serially by the runner and may
+//! do bookkeeping or I/O; `increment` may run concurrently while output
+//! is being written.
+//!
+//! Implementations must not panic and must not propagate I/O errors —
+//! progress reporting is best-effort and must never affect the data
+//! path.
+//!
+//! # Default implementation
+//!
+//! When the `indicatif-progress` feature is enabled (on by default), the
+//! crate provides an `IndicatifProgress` implementation, which renders
+//! one progress bar per table on stderr using the `indicatif` crate.
+//! Library users who do not want to pull in `indicatif` can enable the
+//! `progress` feature directly and supply their own [`ProgressTracker`]
+//! implementation.
+//!
+//! # Example: a custom logging tracker
+//!
+//! ```
+//! # #[cfg(feature = "progress")]
+//! # {
+//! use std::sync::atomic::{AtomicU64, Ordering};
+//! use tpchgen_cli::progress::ProgressTracker;
+//! use tpchgen_cli::Table;
+//!
+//! #[derive(Debug)]
+//! struct LoggingTracker {
+//!     written: AtomicU64,
+//! }
+//!
+//! impl ProgressTracker for LoggingTracker {
+//!     fn register(&self, table: Table, total: u64) {
+//!         eprintln!("plan: {table:?} -> {total} output units");
+//!     }
+//!     fn increment(&self, _table: Table, units: u64) {
+//!         self.written.fetch_add(units, Ordering::Relaxed);
+//!     }
+//!     fn finish(&self) {
+//!         eprintln!("done: {} output units", self.written.load(Ordering::Relaxed));
+//!     }
+//! }
+//! # }
+//! ```
 
+use crate::output_plan::OutputPlan;
 use crate::Table;
-use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+#[cfg(feature = "progress")]
+use std::collections::BTreeMap;
+#[cfg(feature = "progress")]
+use std::fmt;
+#[cfg(feature = "progress")]
+use std::sync::Arc;
 
-/// Tracks progress for all tables being generated
-#[derive(Clone, Debug)]
-pub struct ProgressTracker {
-    inner: Arc<ProgressTrackerInner>,
+/// Receives generation-progress events for one
+/// [`PlanRunner`](crate::runner::PlanRunner) invocation.
+///
+/// See the [module-level documentation](self) for the call-order
+/// contract. Trackers are passed to the runner as an
+/// [`std::sync::Arc`] and shared across concurrent generation tasks, so
+/// they must be `Send + Sync`.
+/// They must also be `Debug` so containing types can derive `Debug`.
+#[cfg(feature = "progress")]
+pub trait ProgressTracker: Send + Sync + fmt::Debug {
+    /// Pre-register a table with its total expected output-unit count.
+    ///
+    /// Called once per table before any worker starts. Implementations
+    /// that need to know totals up front (e.g. to render a progress bar
+    /// or compute an ETA) should override this; the default does
+    /// nothing.
+    fn register(&self, _table: Table, _total_units: u64) {}
+
+    /// Advance the counter for `table` by `units` output units.
+    ///
+    /// Called after generated output units are written. Multiple
+    /// table-generation tasks may call this concurrently, so implementations
+    /// should be lightweight and must never panic.
+    fn increment(&self, table: Table, units: u64);
+
+    /// Called once after the last [`Self::increment`] on the success
+    /// path. Implementations should use this for normal success cleanup
+    /// and `Drop` only as an error or panic fallback. The default does
+    /// nothing.
+    fn finish(&self) {}
 }
 
-#[derive(Debug)]
-struct ProgressTrackerInner {
-    tables: Mutex<HashMap<Table, ProgressBar>>,
-    // MultiProgress must be kept alive to manage the registered progress bars
-    _multi_progress: MultiProgress,
+/// Progress handle for one [`PlanRunner::run`](crate::runner::PlanRunner::run)
+/// invocation.
+///
+/// Owns run-level progress lifecycle: registering totals, accounting for
+/// skipped outputs, and finishing the tracker.
+#[derive(Debug, Clone, Default)]
+#[cfg(feature = "progress")]
+pub(crate) struct RunProgress {
+    tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
-impl ProgressTracker {
-    /// Create a new progress tracker for the given tables
-    pub fn new(tables: Vec<(Table, u64)>) -> Self {
-        let multi_progress = MultiProgress::new();
-        let mut table_map = HashMap::new();
-
-        for (table, total_rows) in tables {
-            let pb = multi_progress.add(ProgressBar::new(total_rows));
-            pb.set_style(
-                ProgressStyle::default_bar()
-                    .template("{msg:10} [{bar:28}]   Progress: {percent:>3}%")
-                    .unwrap()
-                    .progress_chars("█▓░"),
-            );
-            pb.set_message(format!("{}", table));
-            let pb = pb.with_finish(ProgressFinish::AndLeave);
-            table_map.insert(table, pb);
-        }
-
+#[cfg(feature = "progress")]
+impl RunProgress {
+    pub(crate) fn with_tracker(tracker: Arc<dyn ProgressTracker>) -> Self {
         Self {
-            inner: Arc::new(ProgressTrackerInner {
-                tables: Mutex::new(table_map),
-                _multi_progress: multi_progress,
-            }),
+            tracker: Some(tracker),
         }
     }
 
-    pub fn increment(&self, table: Table, rows: u64) {
-        let tables = self.inner.tables.lock().unwrap();
-        if let Some(pb) = tables.get(&table) {
-            pb.inc(rows);
+    pub(crate) fn register_totals(&self, plans: &[OutputPlan]) {
+        if let Some(tracker) = self.tracker.as_ref() {
+            let mut totals: BTreeMap<Table, u64> = BTreeMap::new();
+            for plan in plans {
+                *totals.entry(plan.table()).or_insert(0) += plan.chunk_count() as u64;
+            }
+            for (table, total) in totals {
+                tracker.register(table, total);
+            }
         }
     }
 
-    pub fn finish(&self, table: Table) {
-        let tables = self.inner.tables.lock().unwrap();
-        if let Some(pb) = tables.get(&table) {
-            pb.finish();
+    pub(crate) fn increment_for_existing(&self, plan: &OutputPlan) {
+        if let Some(tracker) = self.tracker.as_ref() {
+            tracker.increment(plan.table(), plan.chunk_count() as u64);
+        }
+    }
+
+    pub(crate) fn for_table(&self, table: Table) -> TableProgress {
+        TableProgress::for_table(self.tracker.clone(), table)
+    }
+
+    pub(crate) fn finish(self) {
+        if let Some(tracker) = self.tracker {
+            tracker.finish();
         }
     }
 }
 
-#[cfg(test)]
+/// No-op run progress handle used when progress support is disabled.
+#[derive(Debug, Clone, Default)]
+#[cfg(not(feature = "progress"))]
+pub(crate) struct RunProgress;
+
+#[cfg(not(feature = "progress"))]
+impl RunProgress {
+    pub(crate) fn register_totals(&self, _plans: &[OutputPlan]) {}
+
+    pub(crate) fn increment_for_existing(&self, _plan: &OutputPlan) {}
+
+    pub(crate) fn for_table(&self, _table: Table) -> TableProgress {
+        TableProgress
+    }
+
+    pub(crate) fn finish(self) {}
+}
+
+/// Progress handle for one table output stream.
+///
+/// Used by format writers to report each successfully written output unit
+/// without knowing whether progress tracking is enabled.
+#[derive(Clone, Default)]
+#[cfg(feature = "progress")]
+pub(crate) struct TableProgress {
+    tracker: Option<(Arc<dyn ProgressTracker>, Table)>,
+}
+
+#[cfg(feature = "progress")]
+impl TableProgress {
+    pub(crate) fn for_table(progress: Option<Arc<dyn ProgressTracker>>, table: Table) -> Self {
+        Self {
+            tracker: progress.map(|progress| (progress, table)),
+        }
+    }
+
+    pub(crate) fn increment_output_unit(&self) {
+        if let Some((progress, table)) = self.tracker.as_ref() {
+            progress.increment(*table, 1);
+        }
+    }
+}
+
+/// No-op table progress handle used when progress support is disabled.
+#[derive(Clone, Default)]
+#[cfg(not(feature = "progress"))]
+pub(crate) struct TableProgress;
+
+#[cfg(not(feature = "progress"))]
+impl TableProgress {
+    pub(crate) fn increment_output_unit(&self) {}
+}
+
+#[cfg(feature = "indicatif-progress")]
+pub use indicatif_impl::IndicatifProgress;
+
+#[cfg(feature = "indicatif-progress")]
+mod indicatif_impl {
+    use super::ProgressTracker;
+    use crate::Table;
+    use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
+    use std::collections::BTreeMap;
+    use std::io::{self, Write};
+    use std::sync::{OnceLock, RwLock};
+
+    /// Default [`ProgressTracker`] implementation backed by
+    /// [`indicatif::MultiProgress`].
+    ///
+    /// Renders one bar per table on stderr. Bars are pre-allocated in
+    /// [`ProgressTracker::register`] and are looked up by [`Table`] on
+    /// each [`ProgressTracker::increment`] call. Lookup uses a `RwLock`
+    /// read on the increment path; this is uncontended after the serial
+    /// `register` phase completes.
+    #[derive(Debug)]
+    pub struct IndicatifProgress {
+        multi: MultiProgress,
+        tables: RwLock<BTreeMap<Table, ProgressBar>>,
+    }
+
+    impl IndicatifProgress {
+        /// Construct an empty tracker. Tables are added via
+        /// [`ProgressTracker::register`].
+        pub fn new() -> Self {
+            Self {
+                multi: MultiProgress::new(),
+                tables: RwLock::new(BTreeMap::new()),
+            }
+        }
+
+        /// Return a writer that coordinates stderr log writes with progress
+        /// bar redraws.
+        pub fn log_writer(&self) -> Box<dyn io::Write + Send + 'static> {
+            Box::new(IndicatifLogWriter {
+                multi: self.multi.clone(),
+            })
+        }
+    }
+
+    impl Default for IndicatifProgress {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl ProgressTracker for IndicatifProgress {
+        fn register(&self, table: Table, total_units: u64) {
+            let Ok(mut tables) = self.tables.write() else {
+                return;
+            };
+
+            let pb = self.multi.add(ProgressBar::new(total_units));
+            pb.set_style(bar_style().clone());
+            pb.set_message(table.to_string());
+            let pb = pb.with_finish(ProgressFinish::AndLeave);
+            // Write-lock is only contended during the register phase, which
+            // happens serially before any worker task starts.
+            tables.insert(table, pb);
+        }
+
+        fn increment(&self, table: Table, units: u64) {
+            // Minimize the read-lock scope so concurrent `increment` callers
+            // don't serialize on it. Cloning the bar is a cheap `Arc` bump,
+            // and `ProgressBar::inc` is internally thread-safe.
+            let bar = {
+                let Ok(tables) = self.tables.read() else {
+                    return;
+                };
+                tables.get(&table).cloned()
+            };
+            if let Some(bar) = bar {
+                bar.inc(units);
+            }
+        }
+
+        fn finish(&self) {
+            let bars = {
+                let Ok(tables) = self.tables.read() else {
+                    return;
+                };
+                tables.values().cloned().collect::<Vec<_>>()
+            };
+            for bar in bars {
+                bar.finish_using_style();
+            }
+        }
+    }
+
+    fn bar_style() -> &'static ProgressStyle {
+        static STYLE: OnceLock<ProgressStyle> = OnceLock::new();
+        STYLE.get_or_init(|| {
+            ProgressStyle::default_bar()
+                .template("{msg:10} [{bar:28}]   Progress: {percent:>3}%")
+                .expect("static progress bar template is valid")
+                .progress_chars("█▓░")
+        })
+    }
+
+    struct IndicatifLogWriter {
+        multi: MultiProgress,
+    }
+
+    impl Write for IndicatifLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.multi.suspend(|| {
+                let mut stderr = io::stderr().lock();
+                stderr.write(buf)
+            })
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.multi.suspend(|| {
+                let mut stderr = io::stderr().lock();
+                stderr.flush()
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn registers_and_increments() {
+            let t = IndicatifProgress::new();
+            t.register(Table::Lineitem, 60);
+            t.register(Table::Orders, 15);
+            t.increment(Table::Lineitem, 1);
+            t.increment(Table::Orders, 5);
+
+            let tables = t.tables.read().unwrap();
+            assert_eq!(tables[&Table::Lineitem].position(), 1);
+            assert_eq!(tables[&Table::Orders].position(), 5);
+        }
+
+        #[test]
+        fn reaches_total() {
+            let t = IndicatifProgress::new();
+            t.register(Table::Orders, 5);
+            for _ in 0..5 {
+                t.increment(Table::Orders, 1);
+            }
+            assert_eq!(t.tables.read().unwrap()[&Table::Orders].position(), 5);
+        }
+
+        #[test]
+        fn unknown_table_is_no_op() {
+            // Incrementing a table not registered must not panic.
+            let t = IndicatifProgress::new();
+            t.register(Table::Orders, 1);
+            t.increment(Table::Lineitem, 1);
+            assert_eq!(t.tables.read().unwrap()[&Table::Orders].position(), 0);
+        }
+
+        #[test]
+        fn finish_marks_registered_bars_finished() {
+            let t = IndicatifProgress::new();
+            t.register(Table::Orders, 2);
+            t.increment(Table::Orders, 2);
+            t.finish();
+
+            assert!(t.tables.read().unwrap()[&Table::Orders].is_finished());
+        }
+    }
+}
+
+#[cfg(all(test, feature = "progress"))]
 mod tests {
     use super::*;
+    use crate::Table;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    };
 
-    #[test]
-    fn test_progress_tracker_creation() {
-        let tracker = ProgressTracker::new(vec![
-            (Table::Lineitem, 60_000_000),
-            (Table::Orders, 15_000_000),
-        ]);
-        tracker.increment(Table::Lineitem, 1_000_000);
+    /// Mock implementation that records every event. Demonstrates that
+    /// the trait is dyn-compatible and usable from external code without
+    /// pulling in `indicatif`.
+    #[derive(Debug, Default)]
+    struct MockTracker {
+        registered: Mutex<Vec<(Table, u64)>>,
+        total_increments: AtomicU64,
+        finished: AtomicU64,
+    }
+
+    impl ProgressTracker for MockTracker {
+        fn register(&self, table: Table, total_units: u64) {
+            self.registered.lock().unwrap().push((table, total_units));
+        }
+        fn increment(&self, _table: Table, units: u64) {
+            self.total_increments.fetch_add(units, Ordering::Relaxed);
+        }
+        fn finish(&self) {
+            self.finished.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     #[test]
-    fn test_progress_tracker_increment() {
-        let tracker = ProgressTracker::new(vec![(Table::Customer, 150_000)]);
-        for _ in 0..10 {
-            tracker.increment(Table::Customer, 15_000);
+    fn mock_tracker_works_through_arc_dyn() {
+        let mock = Arc::new(MockTracker::default());
+        let dynamic: Arc<dyn ProgressTracker> = mock.clone();
+        dynamic.register(Table::Lineitem, 10);
+        dynamic.register(Table::Orders, 4);
+        dynamic.increment(Table::Lineitem, 3);
+        dynamic.increment(Table::Orders, 1);
+        dynamic.finish();
+
+        assert_eq!(
+            *mock.registered.lock().unwrap(),
+            vec![(Table::Lineitem, 10), (Table::Orders, 4)]
+        );
+        assert_eq!(mock.total_increments.load(Ordering::Relaxed), 4);
+        assert_eq!(mock.finished.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn default_register_and_finish_are_noops() {
+        // An impl that only overrides `increment` should compile and run.
+        #[derive(Debug)]
+        struct Minimal(AtomicU64);
+        impl ProgressTracker for Minimal {
+            fn increment(&self, _t: Table, c: u64) {
+                self.0.fetch_add(c, Ordering::Relaxed);
+            }
         }
+        let m = Minimal(AtomicU64::new(0));
+        m.register(Table::Region, 99); // no-op default
+        m.increment(Table::Region, 7);
+        m.finish(); // no-op default
+        assert_eq!(m.0.load(Ordering::Relaxed), 7);
     }
 }

--- a/tpchgen-cli/src/progress.rs
+++ b/tpchgen-cli/src/progress.rs
@@ -3,17 +3,7 @@
 use crate::Table;
 use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-
-/// Type of progress increment
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IncrementType {
-    /// Increment the number of parts/files completed
-    Part,
-    /// Increment the number of chunks/buffers written
-    Buffer,
-}
 
 /// Tracks progress for all tables being generated
 #[derive(Clone, Debug)]
@@ -23,44 +13,28 @@ pub struct ProgressTracker {
 
 #[derive(Debug)]
 struct ProgressTrackerInner {
-    tables: Mutex<HashMap<Table, TableProgress>>,
+    tables: Mutex<HashMap<Table, ProgressBar>>,
     // MultiProgress must be kept alive to manage the registered progress bars
     _multi_progress: MultiProgress,
 }
 
-#[derive(Debug)]
-struct TableProgress {
-    parts_completed: AtomicUsize,
-    buffers_written: AtomicUsize,
-    progress_bar: ProgressBar,
-}
-
 impl ProgressTracker {
     /// Create a new progress tracker for the given tables
-    pub fn new(tables: Vec<(Table, usize)>) -> Self {
+    pub fn new(tables: Vec<(Table, u64)>) -> Self {
         let multi_progress = MultiProgress::new();
         let mut table_map = HashMap::new();
 
-        for (table, total_parts) in tables {
-            let mut pb = multi_progress.add(ProgressBar::new(total_parts as u64));
+        for (table, total_rows) in tables {
+            let pb = multi_progress.add(ProgressBar::new(total_rows));
             pb.set_style(
                 ProgressStyle::default_bar()
-                    .template("{msg:10} [{bar:28}] Parts:{pos:>4}/{len:<4} Buffers:{prefix:>6} {percent:>3}%")
+                    .template("{msg:10} [{bar:28}]   Progress: {percent:>3}%")
                     .unwrap()
-                    .progress_chars("█▓░")
+                    .progress_chars("█▓░"),
             );
             pb.set_message(format!("{}", table));
-            pb.set_prefix("0");
-            pb = pb.with_finish(ProgressFinish::AndLeave);
-
-            table_map.insert(
-                table,
-                TableProgress {
-                    parts_completed: AtomicUsize::new(0),
-                    buffers_written: AtomicUsize::new(0),
-                    progress_bar: pb,
-                },
-            );
+            let pb = pb.with_finish(ProgressFinish::AndLeave);
+            table_map.insert(table, pb);
         }
 
         Self {
@@ -71,26 +45,17 @@ impl ProgressTracker {
         }
     }
 
-    pub fn increment(&self, table: Table, increment_type: IncrementType) {
+    pub fn increment(&self, table: Table, rows: u64) {
         let tables = self.inner.tables.lock().unwrap();
-        if let Some(progress) = tables.get(&table) {
-            match increment_type {
-                IncrementType::Part => {
-                    let new_val = progress.parts_completed.fetch_add(1, Ordering::SeqCst) + 1;
-                    progress.progress_bar.set_position(new_val as u64);
-                }
-                IncrementType::Buffer => {
-                    let new_val = progress.buffers_written.fetch_add(1, Ordering::SeqCst) + 1;
-                    progress.progress_bar.set_prefix(format!("{}", new_val));
-                }
-            }
+        if let Some(pb) = tables.get(&table) {
+            pb.inc(rows);
         }
     }
 
     pub fn finish(&self, table: Table) {
         let tables = self.inner.tables.lock().unwrap();
-        if let Some(progress) = tables.get(&table) {
-            progress.progress_bar.finish();
+        if let Some(pb) = tables.get(&table) {
+            pb.finish();
         }
     }
 }
@@ -101,26 +66,18 @@ mod tests {
 
     #[test]
     fn test_progress_tracker_creation() {
-        let tracker = ProgressTracker::new(vec![(Table::Lineitem, 10), (Table::Orders, 5)]);
-
-        tracker.increment(Table::Lineitem, IncrementType::Part);
-        tracker.increment(Table::Orders, IncrementType::Buffer);
+        let tracker = ProgressTracker::new(vec![
+            (Table::Lineitem, 60_000_000),
+            (Table::Orders, 15_000_000),
+        ]);
+        tracker.increment(Table::Lineitem, 1_000_000);
     }
 
     #[test]
     fn test_progress_tracker_increment() {
-        let tracker = ProgressTracker::new(vec![(Table::Customer, 4)]);
-
-        for _ in 0..3 {
-            tracker.increment(Table::Customer, IncrementType::Part);
-        }
+        let tracker = ProgressTracker::new(vec![(Table::Customer, 150_000)]);
         for _ in 0..10 {
-            tracker.increment(Table::Customer, IncrementType::Buffer);
+            tracker.increment(Table::Customer, 15_000);
         }
-
-        let tables = tracker.inner.tables.lock().unwrap();
-        let progress = tables.get(&Table::Customer).unwrap();
-        assert_eq!(progress.parts_completed.load(Ordering::SeqCst), 3);
-        assert_eq!(progress.buffers_written.load(Ordering::SeqCst), 10);
     }
 }

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -34,7 +34,6 @@ impl PlanRunner {
     /// Create a new [`PlanRunner`] with the given plans and number of threads.
     pub fn new(plans: Vec<OutputPlan>, num_threads: usize, show_progress: bool) -> Self {
         let progress_tracker = if show_progress {
-            // Group plans by table and count the number of files (parts) per table
             use std::collections::HashMap;
             let mut table_file_count: HashMap<Table, usize> = HashMap::new();
             for plan in &plans {
@@ -202,7 +201,6 @@ async fn run_plan(
         Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await?,
     };
 
-    // Increment part counter after this file/plan is complete
     if !was_skipped {
         if let Some(ref tracker) = progress_tracker {
             tracker.increment(table, IncrementType::Part);

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -4,7 +4,7 @@ use crate::csv::*;
 use crate::generate::{generate_in_chunks, Source};
 use crate::output_plan::{OutputLocation, OutputPlan};
 use crate::parquet::generate_parquet;
-use crate::progress::ProgressTracker;
+use crate::progress::{IncrementType, ProgressTracker};
 use crate::tbl::*;
 use crate::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::{OutputFormat, Table, WriterSink};
@@ -34,7 +34,7 @@ impl PlanRunner {
     /// Create a new [`PlanRunner`] with the given plans and number of threads.
     pub fn new(plans: Vec<OutputPlan>, num_threads: usize, show_progress: bool) -> Self {
         let progress_tracker = if show_progress {
-            // Group plans by table and count the number of files (plans) per table
+            // Group plans by table and count the number of files (parts) per table
             use std::collections::HashMap;
             let mut table_file_count: HashMap<Table, usize> = HashMap::new();
             for plan in &plans {
@@ -200,7 +200,7 @@ async fn run_plan(plan: OutputPlan, num_threads: usize, progress_tracker: Option
     
     // Increment part counter after this file/plan is complete
     if let Some(ref tracker) = progress_tracker {
-        tracker.increment_part(table);
+        tracker.increment(table, IncrementType::Part);
     }
     
     result

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -99,7 +99,7 @@ impl PlanRunner {
 ///
 /// [`GenerationPlan`]: crate::plan::GenerationPlan
 struct WorkerQueue {
-    join_set: JoinSet<io::Result<usize>>,
+    join_set: JoinSet<io::Result<(usize, bool)>>,
     /// Current number of threads available to commit
     available_threads: usize,
     progress_tracker: Option<ProgressTracker>,
@@ -134,13 +134,15 @@ impl WorkerQueue {
                         "Internal Error No more tasks to wait for, but had no threads",
                     ));
                 };
-                self.available_threads += task_result(result)?;
+                let (threads, _skipped) = task_result(result)?;
+                self.available_threads += threads;
                 continue; // look for threads again
             }
 
             // Check for any other jobs done so we can reuse their threads
             if let Some(result) = self.join_set.try_join_next() {
-                self.available_threads += task_result(result)?;
+                let (threads, _skipped) = task_result(result)?;
+                self.available_threads += threads;
                 continue;
             }
 
@@ -170,7 +172,7 @@ impl WorkerQueue {
     pub async fn join_all(mut self) -> io::Result<()> {
         debug!("Waiting for tasks to finish...");
         while let Some(result) = self.join_set.join_next().await {
-            task_result(result)?;
+            let _ = task_result(result)?;
         }
         debug!("Tasks finished.");
         Ok(())
@@ -187,25 +189,27 @@ async fn run_plan(
     plan: OutputPlan,
     num_threads: usize,
     progress_tracker: Option<ProgressTracker>,
-) -> io::Result<usize> {
+) -> io::Result<(usize, bool)> {
     let table = plan.table();
-    let result = match table {
-        Table::Nation => run_nation_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Region => run_region_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Part => run_part_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Supplier => run_supplier_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Partsupp => run_partsupp_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Customer => run_customer_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Orders => run_orders_plan(plan, num_threads, progress_tracker.clone()).await,
-        Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await,
+    let (num_threads, was_skipped) = match table {
+        Table::Nation => run_nation_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Region => run_region_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Part => run_part_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Supplier => run_supplier_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Partsupp => run_partsupp_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Customer => run_customer_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Orders => run_orders_plan(plan, num_threads, progress_tracker.clone()).await?,
+        Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await?,
     };
 
     // Increment part counter after this file/plan is complete
-    if let Some(ref tracker) = progress_tracker {
-        tracker.increment(table, IncrementType::Part);
+    if !was_skipped {
+        if let Some(ref tracker) = progress_tracker {
+            tracker.increment(table, IncrementType::Part);
+        }
     }
 
-    result
+    Ok((num_threads, was_skipped))
 }
 
 /// Writes a CSV/TSV output from the sources
@@ -215,7 +219,7 @@ async fn write_file<I>(
     sources: I,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
-) -> Result<(), io::Error>
+) -> Result<bool, io::Error>
 where
     I: Iterator<Item: Source> + 'static,
 {
@@ -224,13 +228,17 @@ where
     match plan.output_location() {
         OutputLocation::Stdout => {
             let sink = WriterSink::new(io::stdout());
-            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await
+            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await?;
+            Ok(false)
         }
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                log::warn!("{} already exists, skipping generation", path.display());
-                return Ok(());
+                log::info!("{} already exists, skipping generation", path.display());
+                if let Some(ref tracker) = progress_tracker {
+                    tracker.increment(table, IncrementType::Part);
+                }
+                return Ok(true);
             }
             // write to a temp file and then rename to avoid partial files
             let temp_path = path.with_extension("inprogress");
@@ -245,7 +253,7 @@ where
                     "Failed to rename {temp_path:?} to {path:?} file: {e}"
                 ))
             })?;
-            Ok(())
+            Ok(false)
         }
     }
 }
@@ -257,7 +265,7 @@ async fn write_parquet<I>(
     sources: I,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
-) -> Result<(), io::Error>
+) -> Result<bool, io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
@@ -272,13 +280,17 @@ where
                 progress_tracker,
                 table,
             )
-            .await
+            .await?;
+            Ok(false)
         }
         OutputLocation::File(path) => {
             // if the output already exists, skip running
             if path.exists() {
-                log::warn!("{} already exists, skipping generation", path.display());
-                return Ok(());
+                log::info!("{} already exists, skipping generation", path.display());
+                if let Some(ref tracker) = progress_tracker {
+                    tracker.increment(table, IncrementType::Part);
+                }
+                return Ok(true);
             }
             // write to a temp file and then rename to avoid partial files
             let temp_path = path.with_extension("inprogress");
@@ -301,7 +313,7 @@ where
                     "Failed to rename {temp_path:?} to {path:?} file: {e}"
                 ))
             })?;
-            Ok(())
+            Ok(false)
         }
     }
 }
@@ -320,7 +332,7 @@ macro_rules! define_run {
             plan: OutputPlan,
             num_threads: usize,
             _progress_tracker: Option<ProgressTracker>,
-        ) -> io::Result<usize> {
+        ) -> io::Result<(usize, bool)> {
             use crate::GenerationPlan;
             let scale_factor = plan.scale_factor();
             info!("Writing {plan} using {num_threads} threads");
@@ -369,7 +381,7 @@ macro_rules! define_run {
 
             // Dispatch to the appropriate output format
             let table = plan.table();
-            match plan.output_format() {
+            let was_skipped = match plan.output_format() {
                 OutputFormat::Tbl => {
                     let gens = tbl_sources(plan.generation_plan(), scale_factor);
                     write_file(plan, num_threads, gens, _progress_tracker.clone(), table).await?
@@ -385,7 +397,7 @@ macro_rules! define_run {
                     write_parquet(plan, num_threads, gens, _progress_tracker.clone(), table).await?
                 }
             };
-            Ok(num_threads)
+            Ok((num_threads, was_skipped))
         }
     };
 }

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -40,9 +40,7 @@ impl PlanRunner {
             for plan in &plans {
                 *table_file_count.entry(plan.table()).or_insert(0) += 1;
             }
-            let table_parts: Vec<(Table, usize)> = table_file_count
-                .into_iter()
-                .collect();
+            let table_parts: Vec<(Table, usize)> = table_file_count.into_iter().collect();
             Some(ProgressTracker::new(table_parts))
         } else {
             None
@@ -185,7 +183,11 @@ fn task_result<T>(result: Result<io::Result<T>, JoinError>) -> io::Result<T> {
 }
 
 /// Run a single [`OutputPlan`]
-async fn run_plan(plan: OutputPlan, num_threads: usize, progress_tracker: Option<ProgressTracker>) -> io::Result<usize> {
+async fn run_plan(
+    plan: OutputPlan,
+    num_threads: usize,
+    progress_tracker: Option<ProgressTracker>,
+) -> io::Result<usize> {
     let table = plan.table();
     let result = match table {
         Table::Nation => run_nation_plan(plan, num_threads, progress_tracker.clone()).await,
@@ -197,17 +199,23 @@ async fn run_plan(plan: OutputPlan, num_threads: usize, progress_tracker: Option
         Table::Orders => run_orders_plan(plan, num_threads, progress_tracker.clone()).await,
         Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await,
     };
-    
+
     // Increment part counter after this file/plan is complete
     if let Some(ref tracker) = progress_tracker {
         tracker.increment(table, IncrementType::Part);
     }
-    
+
     result
 }
 
 /// Writes a CSV/TSV output from the sources
-async fn write_file<I>(plan: OutputPlan, num_threads: usize, sources: I, progress_tracker: Option<ProgressTracker>, table: Table) -> Result<(), io::Error>
+async fn write_file<I>(
+    plan: OutputPlan,
+    num_threads: usize,
+    sources: I,
+    progress_tracker: Option<ProgressTracker>,
+    table: Table,
+) -> Result<(), io::Error>
 where
     I: Iterator<Item: Source> + 'static,
 {
@@ -243,14 +251,28 @@ where
 }
 
 /// Generates an output parquet file from the sources
-async fn write_parquet<I>(plan: OutputPlan, num_threads: usize, sources: I, progress_tracker: Option<ProgressTracker>, table: Table) -> Result<(), io::Error>
+async fn write_parquet<I>(
+    plan: OutputPlan,
+    num_threads: usize,
+    sources: I,
+    progress_tracker: Option<ProgressTracker>,
+    table: Table,
+) -> Result<(), io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
-            generate_parquet(writer, sources, num_threads, plan.parquet_compression(), progress_tracker, table).await
+            generate_parquet(
+                writer,
+                sources,
+                num_threads,
+                plan.parquet_compression(),
+                progress_tracker,
+                table,
+            )
+            .await
         }
         OutputLocation::File(path) => {
             // if the output already exists, skip running
@@ -264,7 +286,15 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
-            generate_parquet(writer, sources, num_threads, plan.parquet_compression(), progress_tracker, table).await?;
+            generate_parquet(
+                writer,
+                sources,
+                num_threads,
+                plan.parquet_compression(),
+                progress_tracker,
+                table,
+            )
+            .await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
@@ -286,7 +316,11 @@ where
 /// $PARQUET_SOURCE: The [`RecordBatchIterator`] type to use for Parquet format
 macro_rules! define_run {
     ($FUN_NAME:ident, $GENERATOR:ident, $TBL_SOURCE:ty, $CSV_SOURCE:ty, $PARQUET_SOURCE:ty) => {
-        async fn $FUN_NAME(plan: OutputPlan, num_threads: usize, _progress_tracker: Option<ProgressTracker>) -> io::Result<usize> {
+        async fn $FUN_NAME(
+            plan: OutputPlan,
+            num_threads: usize,
+            _progress_tracker: Option<ProgressTracker>,
+        ) -> io::Result<usize> {
             use crate::GenerationPlan;
             let scale_factor = plan.scale_factor();
             info!("Writing {plan} using {num_threads} threads");

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -1,18 +1,20 @@
 //! [`PlanRunner`] for running [`OutputPlan`]s.
 
 use crate::csv::*;
-use crate::generate::{generate_in_chunks, Source};
+use crate::generate::generate_in_chunks_with_progress;
+use crate::generate::Source;
 use crate::output_plan::{OutputLocation, OutputPlan};
-use crate::parquet::generate_parquet;
-use crate::plan::GenerationPlan;
+use crate::parquet::generate_parquet_with_progress;
+#[cfg(feature = "progress")]
 use crate::progress::ProgressTracker;
+use crate::progress::RunProgress;
 use crate::tbl::*;
 use crate::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::{OutputFormat, Table, WriterSink};
 use log::{debug, info};
-use std::collections::HashMap;
 use std::io;
 use std::io::BufWriter;
+#[cfg(feature = "progress")]
 use std::sync::Arc;
 use tokio::task::{JoinError, JoinSet};
 use tpchgen::generators::{
@@ -30,43 +32,31 @@ use tpchgen_arrow::{
 pub struct PlanRunner {
     plans: Vec<OutputPlan>,
     num_threads: usize,
-    progress_tracker: Option<ProgressTracker>,
-    rows_per_chunk: Arc<HashMap<Table, u64>>,
+    progress: RunProgress,
 }
 
 impl PlanRunner {
     /// Create a new [`PlanRunner`] with the given plans and number of threads.
-    pub fn new(plans: Vec<OutputPlan>, num_threads: usize, show_progress: bool) -> Self {
-        let mut table_total_rows: HashMap<Table, u64> = HashMap::new();
-        let mut table_total_chunks: HashMap<Table, u64> = HashMap::new();
-        for plan in &plans {
-            table_total_rows.entry(plan.table()).or_insert_with(|| {
-                GenerationPlan::row_count(plan.table(), plan.scale_factor()) as u64
-            });
-            *table_total_chunks.entry(plan.table()).or_insert(0) += plan.chunk_count() as u64;
-        }
-
-        let rows_per_chunk: HashMap<Table, u64> = table_total_rows
-            .iter()
-            .map(|(table, total_rows)| {
-                let total_chunks = *table_total_chunks.get(table).unwrap_or(&1);
-                (*table, total_rows / total_chunks.max(1))
-            })
-            .collect();
-
-        let progress_tracker = if show_progress {
-            let table_progress: Vec<(Table, u64)> = table_total_rows.into_iter().collect();
-            Some(ProgressTracker::new(table_progress))
-        } else {
-            None
-        };
-
+    /// Progress reporting is disabled by default.
+    pub fn new(plans: Vec<OutputPlan>, num_threads: usize) -> Self {
         Self {
             plans,
             num_threads,
-            progress_tracker,
-            rows_per_chunk: Arc::new(rows_per_chunk),
+            progress: RunProgress::default(),
         }
+    }
+
+    /// Attach a [`ProgressTracker`].
+    ///
+    /// The runner pre-registers each table's output-unit total with the
+    /// tracker before scheduling, calls [`ProgressTracker::increment`]
+    /// after output units are written, and calls [`ProgressTracker::finish`]
+    /// once on the success path. Implementations needing cleanup on the
+    /// error or panic path should use `Drop` as a fallback.
+    #[cfg(feature = "progress")]
+    pub fn with_progress_tracker(mut self, tracker: Arc<dyn ProgressTracker>) -> Self {
+        self.progress = RunProgress::with_tracker(tracker);
+        self
     }
 
     /// Run all the plans in the runner.
@@ -79,8 +69,7 @@ impl PlanRunner {
         let Self {
             mut plans,
             num_threads,
-            progress_tracker,
-            rows_per_chunk,
+            progress,
         } = self;
 
         // Sort the plans by the number of parts so the largest are first
@@ -90,12 +79,18 @@ impl PlanRunner {
             a_cnt.cmp(&b_cnt)
         });
 
+        // Pre-register per-table output-unit totals so trackers can size their
+        // bars before the first `increment`.
+        progress.register_totals(&plans);
+
         // Do the actual work in parallel, using a worker queue
-        let mut worker_queue = WorkerQueue::new(num_threads, progress_tracker, rows_per_chunk);
+        let mut worker_queue = WorkerQueue::new(num_threads, progress.clone());
         while let Some(plan) = plans.pop() {
             worker_queue.schedule_plan(plan).await?;
         }
-        worker_queue.join_all().await
+        worker_queue.join_all().await?;
+        progress.finish();
+        Ok(())
     }
 }
 
@@ -116,25 +111,19 @@ impl PlanRunner {
 ///
 /// [`GenerationPlan`]: crate::plan::GenerationPlan
 struct WorkerQueue {
-    join_set: JoinSet<io::Result<(usize, bool)>>,
+    join_set: JoinSet<io::Result<usize>>,
     /// Current number of threads available to commit
     available_threads: usize,
-    progress_tracker: Option<ProgressTracker>,
-    rows_per_chunk: Arc<HashMap<Table, u64>>,
+    progress: RunProgress,
 }
 
 impl WorkerQueue {
-    pub fn new(
-        max_threads: usize,
-        progress_tracker: Option<ProgressTracker>,
-        rows_per_chunk: Arc<HashMap<Table, u64>>,
-    ) -> Self {
+    pub fn new(max_threads: usize, progress: RunProgress) -> Self {
         assert!(max_threads > 0);
         Self {
             join_set: JoinSet::new(),
             available_threads: max_threads,
-            progress_tracker,
-            rows_per_chunk,
+            progress,
         }
     }
 
@@ -157,15 +146,13 @@ impl WorkerQueue {
                         "Internal Error No more tasks to wait for, but had no threads",
                     ));
                 };
-                let (threads, _skipped) = task_result(result)?;
-                self.available_threads += threads;
+                self.available_threads += task_result(result)?;
                 continue; // look for threads again
             }
 
             // Check for any other jobs done so we can reuse their threads
             if let Some(result) = self.join_set.try_join_next() {
-                let (threads, _skipped) = task_result(result)?;
-                self.available_threads += threads;
+                self.available_threads += task_result(result)?;
                 continue;
             }
 
@@ -183,11 +170,9 @@ impl WorkerQueue {
             // run the plan in a separate task, which returns the number of threads it used
             debug!("Spawning plan {plan} with {num_plan_threads} threads");
 
-            let progress_tracker = self.progress_tracker.clone();
-            let rows_per_chunk = Arc::clone(&self.rows_per_chunk);
-            self.join_set.spawn(async move {
-                run_plan(plan, num_plan_threads, progress_tracker, rows_per_chunk).await
-            });
+            let progress = self.progress.clone();
+            self.join_set
+                .spawn(async move { run_plan(plan, num_plan_threads, progress).await });
             self.available_threads -= num_plan_threads;
             return Ok(());
         }
@@ -197,7 +182,7 @@ impl WorkerQueue {
     pub async fn join_all(mut self) -> io::Result<()> {
         debug!("Waiting for tasks to finish...");
         while let Some(result) = self.join_set.join_next().await {
-            let _ = task_result(result)?;
+            task_result(result)?;
         }
         debug!("Tasks finished.");
         Ok(())
@@ -213,39 +198,30 @@ fn task_result<T>(result: Result<io::Result<T>, JoinError>) -> io::Result<T> {
 async fn run_plan(
     plan: OutputPlan,
     num_threads: usize,
-    progress_tracker: Option<ProgressTracker>,
-    rows_per_chunk: Arc<HashMap<Table, u64>>,
-) -> io::Result<(usize, bool)> {
-    let table = plan.table();
-    let chunk_rows = *rows_per_chunk.get(&table).unwrap_or(&0);
-    let (num_threads, was_skipped) = match table {
-        Table::Nation => {
-            run_nation_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Region => {
-            run_region_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Part => {
-            run_part_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Supplier => {
-            run_supplier_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Partsupp => {
-            run_partsupp_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Customer => {
-            run_customer_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Orders => {
-            run_orders_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-        Table::Lineitem => {
-            run_lineitem_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
-        }
-    };
+    progress: RunProgress,
+) -> io::Result<usize> {
+    match plan.table() {
+        Table::Nation => run_nation_plan(plan, num_threads, progress).await,
+        Table::Region => run_region_plan(plan, num_threads, progress).await,
+        Table::Part => run_part_plan(plan, num_threads, progress).await,
+        Table::Supplier => run_supplier_plan(plan, num_threads, progress).await,
+        Table::Partsupp => run_partsupp_plan(plan, num_threads, progress).await,
+        Table::Customer => run_customer_plan(plan, num_threads, progress).await,
+        Table::Orders => run_orders_plan(plan, num_threads, progress).await,
+        Table::Lineitem => run_lineitem_plan(plan, num_threads, progress).await,
+    }
+}
 
-    Ok((num_threads, was_skipped))
+/// If `path` already exists, log a warning, advance progress by the full
+/// output-unit count for this plan, and return `true` so the caller can skip
+/// generation. Returns `false` otherwise.
+fn maybe_skip_existing(path: &std::path::Path, plan: &OutputPlan, progress: &RunProgress) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    log::warn!("{} already exists, skipping generation", path.display());
+    progress.increment_for_existing(plan);
+    true
 }
 
 /// Writes a CSV/TSV output from the sources
@@ -253,37 +229,23 @@ async fn write_file<I>(
     plan: OutputPlan,
     num_threads: usize,
     sources: I,
-    progress_tracker: Option<ProgressTracker>,
-    table: Table,
-    rows_per_chunk: u64,
-) -> Result<bool, io::Error>
+    progress: RunProgress,
+) -> Result<(), io::Error>
 where
     I: Iterator<Item: Source> + 'static,
 {
+    let table = plan.table();
+    let table_progress = progress.for_table(table);
     // Since generate_in_chunks already buffers, there is no need to buffer
     // again (aka don't use BufWriter here)
     match plan.output_location() {
         OutputLocation::Stdout => {
             let sink = WriterSink::new(io::stdout());
-            generate_in_chunks(
-                sink,
-                sources,
-                num_threads,
-                progress_tracker,
-                table,
-                rows_per_chunk,
-            )
-            .await?;
-            Ok(false)
+            generate_in_chunks_with_progress(sink, sources, num_threads, table_progress).await
         }
         OutputLocation::File(path) => {
-            // if the output already exists, skip running
-            if path.exists() {
-                log::info!("{} already exists, skipping generation", path.display());
-                if let Some(ref tracker) = progress_tracker {
-                    tracker.increment(table, rows_per_chunk * plan.chunk_count() as u64);
-                }
-                return Ok(true);
+            if maybe_skip_existing(path, &plan, &progress) {
+                return Ok(());
             }
             // write to a temp file and then rename to avoid partial files
             let temp_path = path.with_extension("inprogress");
@@ -291,22 +253,14 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let sink = WriterSink::new(file);
-            generate_in_chunks(
-                sink,
-                sources,
-                num_threads,
-                progress_tracker,
-                table,
-                rows_per_chunk,
-            )
-            .await?;
+            generate_in_chunks_with_progress(sink, sources, num_threads, table_progress).await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
                     "Failed to rename {temp_path:?} to {path:?} file: {e}"
                 ))
             })?;
-            Ok(false)
+            Ok(())
         }
     }
 }
@@ -316,36 +270,28 @@ async fn write_parquet<I>(
     plan: OutputPlan,
     num_threads: usize,
     sources: I,
-    progress_tracker: Option<ProgressTracker>,
-    table: Table,
-    rows_per_chunk: u64,
-) -> Result<bool, io::Error>
+    progress: RunProgress,
+) -> Result<(), io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
+    let table = plan.table();
+    let table_progress = progress.for_table(table);
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
-            generate_parquet(
+            generate_parquet_with_progress(
                 writer,
                 sources,
                 num_threads,
                 plan.parquet_compression(),
-                progress_tracker,
-                table,
-                rows_per_chunk,
+                table_progress,
             )
-            .await?;
-            Ok(false)
+            .await
         }
         OutputLocation::File(path) => {
-            // if the output already exists, skip running
-            if path.exists() {
-                log::info!("{} already exists, skipping generation", path.display());
-                if let Some(ref tracker) = progress_tracker {
-                    tracker.increment(table, rows_per_chunk * plan.chunk_count() as u64);
-                }
-                return Ok(true);
+            if maybe_skip_existing(path, &plan, &progress) {
+                return Ok(());
             }
             // write to a temp file and then rename to avoid partial files
             let temp_path = path.with_extension("inprogress");
@@ -353,14 +299,12 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
-            generate_parquet(
+            generate_parquet_with_progress(
                 writer,
                 sources,
                 num_threads,
                 plan.parquet_compression(),
-                progress_tracker,
-                table,
-                rows_per_chunk,
+                table_progress,
             )
             .await?;
             // rename the temp file to the final path
@@ -369,7 +313,7 @@ where
                     "Failed to rename {temp_path:?} to {path:?} file: {e}"
                 ))
             })?;
-            Ok(false)
+            Ok(())
         }
     }
 }
@@ -387,9 +331,8 @@ macro_rules! define_run {
         async fn $FUN_NAME(
             plan: OutputPlan,
             num_threads: usize,
-            _progress_tracker: Option<ProgressTracker>,
-            rows_per_chunk: u64,
-        ) -> io::Result<(usize, bool)> {
+            progress: RunProgress,
+        ) -> io::Result<usize> {
             use crate::GenerationPlan;
             let scale_factor = plan.scale_factor();
             info!("Writing {plan} using {num_threads} threads");
@@ -437,47 +380,22 @@ macro_rules! define_run {
             }
 
             // Dispatch to the appropriate output format
-            let table = plan.table();
-            let was_skipped = match plan.output_format() {
+            match plan.output_format() {
                 OutputFormat::Tbl => {
                     let gens = tbl_sources(plan.generation_plan(), scale_factor);
-                    write_file(
-                        plan,
-                        num_threads,
-                        gens,
-                        _progress_tracker.clone(),
-                        table,
-                        rows_per_chunk,
-                    )
-                    .await?
+                    write_file(plan, num_threads, gens, progress).await?
                 }
                 OutputFormat::Csv => {
                     let delimiter = plan.csv_delimiter();
                     let gens = csv_sources(plan.generation_plan(), scale_factor, delimiter);
-                    write_file(
-                        plan,
-                        num_threads,
-                        gens,
-                        _progress_tracker.clone(),
-                        table,
-                        rows_per_chunk,
-                    )
-                    .await?
+                    write_file(plan, num_threads, gens, progress).await?
                 }
                 OutputFormat::Parquet => {
                     let gens = parquet_sources(plan.generation_plan(), scale_factor);
-                    write_parquet(
-                        plan,
-                        num_threads,
-                        gens,
-                        _progress_tracker.clone(),
-                        table,
-                        rows_per_chunk,
-                    )
-                    .await?
+                    write_parquet(plan, num_threads, gens, progress).await?
                 }
             };
-            Ok((num_threads, was_skipped))
+            Ok(num_threads)
         }
     };
 }
@@ -544,3 +462,62 @@ define_run!(
     OrderCsvSource,
     OrderArrow
 );
+
+#[cfg(all(test, feature = "progress"))]
+mod tests {
+    use super::*;
+    use crate::progress::ProgressTracker;
+    use crate::{Compression, GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+
+    #[derive(Debug)]
+    struct CountingProgress {
+        increments: AtomicU64,
+    }
+
+    impl ProgressTracker for CountingProgress {
+        fn increment(&self, _table: Table, units: u64) {
+            self.increments.fetch_add(units, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn skip_existing_advances_progress_by_full_plan() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let output_path = output_dir.path().join("lineitem.tbl");
+        std::fs::write(&output_path, b"already here").unwrap();
+
+        let generation_plan = GenerationPlan::try_new(
+            Table::Lineitem,
+            OutputFormat::Tbl,
+            1.0,
+            Some(1),
+            Some(4),
+            DEFAULT_PARQUET_ROW_GROUP_BYTES,
+        )
+        .unwrap();
+        let plan = OutputPlan::new(
+            Table::Lineitem,
+            1.0,
+            OutputFormat::Tbl,
+            Compression::SNAPPY,
+            OutputLocation::File(output_path.clone()),
+            generation_plan,
+            ',',
+        );
+        let expected_units = plan.chunk_count() as u64;
+        assert!(expected_units > 1);
+
+        let tracker = Arc::new(CountingProgress {
+            increments: AtomicU64::new(0),
+        });
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = RunProgress::with_tracker(progress);
+
+        assert!(maybe_skip_existing(&output_path, &plan, &progress));
+        assert_eq!(tracker.increments.load(Ordering::Relaxed), expected_units);
+    }
+}

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -4,13 +4,16 @@ use crate::csv::*;
 use crate::generate::{generate_in_chunks, Source};
 use crate::output_plan::{OutputLocation, OutputPlan};
 use crate::parquet::generate_parquet;
-use crate::progress::{IncrementType, ProgressTracker};
+use crate::plan::GenerationPlan;
+use crate::progress::ProgressTracker;
 use crate::tbl::*;
 use crate::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::{OutputFormat, Table, WriterSink};
 use log::{debug, info};
+use std::collections::HashMap;
 use std::io;
 use std::io::BufWriter;
+use std::sync::Arc;
 use tokio::task::{JoinError, JoinSet};
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
@@ -28,19 +31,32 @@ pub struct PlanRunner {
     plans: Vec<OutputPlan>,
     num_threads: usize,
     progress_tracker: Option<ProgressTracker>,
+    rows_per_chunk: Arc<HashMap<Table, u64>>,
 }
 
 impl PlanRunner {
     /// Create a new [`PlanRunner`] with the given plans and number of threads.
     pub fn new(plans: Vec<OutputPlan>, num_threads: usize, show_progress: bool) -> Self {
+        let mut table_total_rows: HashMap<Table, u64> = HashMap::new();
+        let mut table_total_chunks: HashMap<Table, u64> = HashMap::new();
+        for plan in &plans {
+            table_total_rows.entry(plan.table()).or_insert_with(|| {
+                GenerationPlan::row_count(plan.table(), plan.scale_factor()) as u64
+            });
+            *table_total_chunks.entry(plan.table()).or_insert(0) += plan.chunk_count() as u64;
+        }
+
+        let rows_per_chunk: HashMap<Table, u64> = table_total_rows
+            .iter()
+            .map(|(table, total_rows)| {
+                let total_chunks = *table_total_chunks.get(table).unwrap_or(&1);
+                (*table, total_rows / total_chunks.max(1))
+            })
+            .collect();
+
         let progress_tracker = if show_progress {
-            use std::collections::HashMap;
-            let mut table_file_count: HashMap<Table, usize> = HashMap::new();
-            for plan in &plans {
-                *table_file_count.entry(plan.table()).or_insert(0) += 1;
-            }
-            let table_parts: Vec<(Table, usize)> = table_file_count.into_iter().collect();
-            Some(ProgressTracker::new(table_parts))
+            let table_progress: Vec<(Table, u64)> = table_total_rows.into_iter().collect();
+            Some(ProgressTracker::new(table_progress))
         } else {
             None
         };
@@ -49,6 +65,7 @@ impl PlanRunner {
             plans,
             num_threads,
             progress_tracker,
+            rows_per_chunk: Arc::new(rows_per_chunk),
         }
     }
 
@@ -63,6 +80,7 @@ impl PlanRunner {
             mut plans,
             num_threads,
             progress_tracker,
+            rows_per_chunk,
         } = self;
 
         // Sort the plans by the number of parts so the largest are first
@@ -73,7 +91,7 @@ impl PlanRunner {
         });
 
         // Do the actual work in parallel, using a worker queue
-        let mut worker_queue = WorkerQueue::new(num_threads, progress_tracker);
+        let mut worker_queue = WorkerQueue::new(num_threads, progress_tracker, rows_per_chunk);
         while let Some(plan) = plans.pop() {
             worker_queue.schedule_plan(plan).await?;
         }
@@ -102,15 +120,21 @@ struct WorkerQueue {
     /// Current number of threads available to commit
     available_threads: usize,
     progress_tracker: Option<ProgressTracker>,
+    rows_per_chunk: Arc<HashMap<Table, u64>>,
 }
 
 impl WorkerQueue {
-    pub fn new(max_threads: usize, progress_tracker: Option<ProgressTracker>) -> Self {
+    pub fn new(
+        max_threads: usize,
+        progress_tracker: Option<ProgressTracker>,
+        rows_per_chunk: Arc<HashMap<Table, u64>>,
+    ) -> Self {
         assert!(max_threads > 0);
         Self {
             join_set: JoinSet::new(),
             available_threads: max_threads,
             progress_tracker,
+            rows_per_chunk,
         }
     }
 
@@ -160,8 +184,10 @@ impl WorkerQueue {
             debug!("Spawning plan {plan} with {num_plan_threads} threads");
 
             let progress_tracker = self.progress_tracker.clone();
-            self.join_set
-                .spawn(async move { run_plan(plan, num_plan_threads, progress_tracker).await });
+            let rows_per_chunk = Arc::clone(&self.rows_per_chunk);
+            self.join_set.spawn(async move {
+                run_plan(plan, num_plan_threads, progress_tracker, rows_per_chunk).await
+            });
             self.available_threads -= num_plan_threads;
             return Ok(());
         }
@@ -188,24 +214,36 @@ async fn run_plan(
     plan: OutputPlan,
     num_threads: usize,
     progress_tracker: Option<ProgressTracker>,
+    rows_per_chunk: Arc<HashMap<Table, u64>>,
 ) -> io::Result<(usize, bool)> {
     let table = plan.table();
+    let chunk_rows = *rows_per_chunk.get(&table).unwrap_or(&0);
     let (num_threads, was_skipped) = match table {
-        Table::Nation => run_nation_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Region => run_region_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Part => run_part_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Supplier => run_supplier_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Partsupp => run_partsupp_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Customer => run_customer_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Orders => run_orders_plan(plan, num_threads, progress_tracker.clone()).await?,
-        Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await?,
-    };
-
-    if !was_skipped {
-        if let Some(ref tracker) = progress_tracker {
-            tracker.increment(table, IncrementType::Part);
+        Table::Nation => {
+            run_nation_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
         }
-    }
+        Table::Region => {
+            run_region_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Part => {
+            run_part_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Supplier => {
+            run_supplier_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Partsupp => {
+            run_partsupp_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Customer => {
+            run_customer_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Orders => {
+            run_orders_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+        Table::Lineitem => {
+            run_lineitem_plan(plan, num_threads, progress_tracker.clone(), chunk_rows).await?
+        }
+    };
 
     Ok((num_threads, was_skipped))
 }
@@ -217,6 +255,7 @@ async fn write_file<I>(
     sources: I,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
+    rows_per_chunk: u64,
 ) -> Result<bool, io::Error>
 where
     I: Iterator<Item: Source> + 'static,
@@ -226,7 +265,15 @@ where
     match plan.output_location() {
         OutputLocation::Stdout => {
             let sink = WriterSink::new(io::stdout());
-            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await?;
+            generate_in_chunks(
+                sink,
+                sources,
+                num_threads,
+                progress_tracker,
+                table,
+                rows_per_chunk,
+            )
+            .await?;
             Ok(false)
         }
         OutputLocation::File(path) => {
@@ -234,7 +281,7 @@ where
             if path.exists() {
                 log::info!("{} already exists, skipping generation", path.display());
                 if let Some(ref tracker) = progress_tracker {
-                    tracker.increment(table, IncrementType::Part);
+                    tracker.increment(table, rows_per_chunk * plan.chunk_count() as u64);
                 }
                 return Ok(true);
             }
@@ -244,7 +291,15 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let sink = WriterSink::new(file);
-            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await?;
+            generate_in_chunks(
+                sink,
+                sources,
+                num_threads,
+                progress_tracker,
+                table,
+                rows_per_chunk,
+            )
+            .await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
@@ -263,6 +318,7 @@ async fn write_parquet<I>(
     sources: I,
     progress_tracker: Option<ProgressTracker>,
     table: Table,
+    rows_per_chunk: u64,
 ) -> Result<bool, io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
@@ -277,6 +333,7 @@ where
                 plan.parquet_compression(),
                 progress_tracker,
                 table,
+                rows_per_chunk,
             )
             .await?;
             Ok(false)
@@ -286,7 +343,7 @@ where
             if path.exists() {
                 log::info!("{} already exists, skipping generation", path.display());
                 if let Some(ref tracker) = progress_tracker {
-                    tracker.increment(table, IncrementType::Part);
+                    tracker.increment(table, rows_per_chunk * plan.chunk_count() as u64);
                 }
                 return Ok(true);
             }
@@ -303,6 +360,7 @@ where
                 plan.parquet_compression(),
                 progress_tracker,
                 table,
+                rows_per_chunk,
             )
             .await?;
             // rename the temp file to the final path
@@ -330,6 +388,7 @@ macro_rules! define_run {
             plan: OutputPlan,
             num_threads: usize,
             _progress_tracker: Option<ProgressTracker>,
+            rows_per_chunk: u64,
         ) -> io::Result<(usize, bool)> {
             use crate::GenerationPlan;
             let scale_factor = plan.scale_factor();
@@ -382,17 +441,40 @@ macro_rules! define_run {
             let was_skipped = match plan.output_format() {
                 OutputFormat::Tbl => {
                     let gens = tbl_sources(plan.generation_plan(), scale_factor);
-                    write_file(plan, num_threads, gens, _progress_tracker.clone(), table).await?
+                    write_file(
+                        plan,
+                        num_threads,
+                        gens,
+                        _progress_tracker.clone(),
+                        table,
+                        rows_per_chunk,
+                    )
+                    .await?
                 }
                 OutputFormat::Csv => {
                     let delimiter = plan.csv_delimiter();
                     let gens = csv_sources(plan.generation_plan(), scale_factor, delimiter);
-                    write_file(plan, num_threads, gens).await?
-                    write_file(plan, num_threads, gens, _progress_tracker.clone(), table).await?
+                    write_file(
+                        plan,
+                        num_threads,
+                        gens,
+                        _progress_tracker.clone(),
+                        table,
+                        rows_per_chunk,
+                    )
+                    .await?
                 }
                 OutputFormat::Parquet => {
                     let gens = parquet_sources(plan.generation_plan(), scale_factor);
-                    write_parquet(plan, num_threads, gens, _progress_tracker.clone(), table).await?
+                    write_parquet(
+                        plan,
+                        num_threads,
+                        gens,
+                        _progress_tracker.clone(),
+                        table,
+                        rows_per_chunk,
+                    )
+                    .await?
                 }
             };
             Ok((num_threads, was_skipped))

--- a/tpchgen-cli/src/runner.rs
+++ b/tpchgen-cli/src/runner.rs
@@ -4,6 +4,7 @@ use crate::csv::*;
 use crate::generate::{generate_in_chunks, Source};
 use crate::output_plan::{OutputLocation, OutputPlan};
 use crate::parquet::generate_parquet;
+use crate::progress::ProgressTracker;
 use crate::tbl::*;
 use crate::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::{OutputFormat, Table, WriterSink};
@@ -26,12 +27,32 @@ use tpchgen_arrow::{
 pub struct PlanRunner {
     plans: Vec<OutputPlan>,
     num_threads: usize,
+    progress_tracker: Option<ProgressTracker>,
 }
 
 impl PlanRunner {
     /// Create a new [`PlanRunner`] with the given plans and number of threads.
-    pub fn new(plans: Vec<OutputPlan>, num_threads: usize) -> Self {
-        Self { plans, num_threads }
+    pub fn new(plans: Vec<OutputPlan>, num_threads: usize, show_progress: bool) -> Self {
+        let progress_tracker = if show_progress {
+            // Group plans by table and count the number of files (plans) per table
+            use std::collections::HashMap;
+            let mut table_file_count: HashMap<Table, usize> = HashMap::new();
+            for plan in &plans {
+                *table_file_count.entry(plan.table()).or_insert(0) += 1;
+            }
+            let table_parts: Vec<(Table, usize)> = table_file_count
+                .into_iter()
+                .collect();
+            Some(ProgressTracker::new(table_parts))
+        } else {
+            None
+        };
+
+        Self {
+            plans,
+            num_threads,
+            progress_tracker,
+        }
     }
 
     /// Run all the plans in the runner.
@@ -44,6 +65,7 @@ impl PlanRunner {
         let Self {
             mut plans,
             num_threads,
+            progress_tracker,
         } = self;
 
         // Sort the plans by the number of parts so the largest are first
@@ -54,7 +76,7 @@ impl PlanRunner {
         });
 
         // Do the actual work in parallel, using a worker queue
-        let mut worker_queue = WorkerQueue::new(num_threads);
+        let mut worker_queue = WorkerQueue::new(num_threads, progress_tracker);
         while let Some(plan) = plans.pop() {
             worker_queue.schedule_plan(plan).await?;
         }
@@ -82,14 +104,16 @@ struct WorkerQueue {
     join_set: JoinSet<io::Result<usize>>,
     /// Current number of threads available to commit
     available_threads: usize,
+    progress_tracker: Option<ProgressTracker>,
 }
 
 impl WorkerQueue {
-    pub fn new(max_threads: usize) -> Self {
+    pub fn new(max_threads: usize, progress_tracker: Option<ProgressTracker>) -> Self {
         assert!(max_threads > 0);
         Self {
             join_set: JoinSet::new(),
             available_threads: max_threads,
+            progress_tracker,
         }
     }
 
@@ -136,8 +160,9 @@ impl WorkerQueue {
             // run the plan in a separate task, which returns the number of threads it used
             debug!("Spawning plan {plan} with {num_plan_threads} threads");
 
+            let progress_tracker = self.progress_tracker.clone();
             self.join_set
-                .spawn(async move { run_plan(plan, num_plan_threads).await });
+                .spawn(async move { run_plan(plan, num_plan_threads, progress_tracker).await });
             self.available_threads -= num_plan_threads;
             return Ok(());
         }
@@ -160,21 +185,29 @@ fn task_result<T>(result: Result<io::Result<T>, JoinError>) -> io::Result<T> {
 }
 
 /// Run a single [`OutputPlan`]
-async fn run_plan(plan: OutputPlan, num_threads: usize) -> io::Result<usize> {
-    match plan.table() {
-        Table::Nation => run_nation_plan(plan, num_threads).await,
-        Table::Region => run_region_plan(plan, num_threads).await,
-        Table::Part => run_part_plan(plan, num_threads).await,
-        Table::Supplier => run_supplier_plan(plan, num_threads).await,
-        Table::Partsupp => run_partsupp_plan(plan, num_threads).await,
-        Table::Customer => run_customer_plan(plan, num_threads).await,
-        Table::Orders => run_orders_plan(plan, num_threads).await,
-        Table::Lineitem => run_lineitem_plan(plan, num_threads).await,
+async fn run_plan(plan: OutputPlan, num_threads: usize, progress_tracker: Option<ProgressTracker>) -> io::Result<usize> {
+    let table = plan.table();
+    let result = match table {
+        Table::Nation => run_nation_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Region => run_region_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Part => run_part_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Supplier => run_supplier_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Partsupp => run_partsupp_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Customer => run_customer_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Orders => run_orders_plan(plan, num_threads, progress_tracker.clone()).await,
+        Table::Lineitem => run_lineitem_plan(plan, num_threads, progress_tracker.clone()).await,
+    };
+    
+    // Increment part counter after this file/plan is complete
+    if let Some(ref tracker) = progress_tracker {
+        tracker.increment_part(table);
     }
+    
+    result
 }
 
 /// Writes a CSV/TSV output from the sources
-async fn write_file<I>(plan: OutputPlan, num_threads: usize, sources: I) -> Result<(), io::Error>
+async fn write_file<I>(plan: OutputPlan, num_threads: usize, sources: I, progress_tracker: Option<ProgressTracker>, table: Table) -> Result<(), io::Error>
 where
     I: Iterator<Item: Source> + 'static,
 {
@@ -183,7 +216,7 @@ where
     match plan.output_location() {
         OutputLocation::Stdout => {
             let sink = WriterSink::new(io::stdout());
-            generate_in_chunks(sink, sources, num_threads).await
+            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await
         }
         OutputLocation::File(path) => {
             // if the output already exists, skip running
@@ -197,7 +230,7 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let sink = WriterSink::new(file);
-            generate_in_chunks(sink, sources, num_threads).await?;
+            generate_in_chunks(sink, sources, num_threads, progress_tracker, table).await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
@@ -210,14 +243,14 @@ where
 }
 
 /// Generates an output parquet file from the sources
-async fn write_parquet<I>(plan: OutputPlan, num_threads: usize, sources: I) -> Result<(), io::Error>
+async fn write_parquet<I>(plan: OutputPlan, num_threads: usize, sources: I, progress_tracker: Option<ProgressTracker>, table: Table) -> Result<(), io::Error>
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
-            generate_parquet(writer, sources, num_threads, plan.parquet_compression()).await
+            generate_parquet(writer, sources, num_threads, plan.parquet_compression(), progress_tracker, table).await
         }
         OutputLocation::File(path) => {
             // if the output already exists, skip running
@@ -231,7 +264,7 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
-            generate_parquet(writer, sources, num_threads, plan.parquet_compression()).await?;
+            generate_parquet(writer, sources, num_threads, plan.parquet_compression(), progress_tracker, table).await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
@@ -253,7 +286,7 @@ where
 /// $PARQUET_SOURCE: The [`RecordBatchIterator`] type to use for Parquet format
 macro_rules! define_run {
     ($FUN_NAME:ident, $GENERATOR:ident, $TBL_SOURCE:ty, $CSV_SOURCE:ty, $PARQUET_SOURCE:ty) => {
-        async fn $FUN_NAME(plan: OutputPlan, num_threads: usize) -> io::Result<usize> {
+        async fn $FUN_NAME(plan: OutputPlan, num_threads: usize, _progress_tracker: Option<ProgressTracker>) -> io::Result<usize> {
             use crate::GenerationPlan;
             let scale_factor = plan.scale_factor();
             info!("Writing {plan} using {num_threads} threads");
@@ -301,19 +334,21 @@ macro_rules! define_run {
             }
 
             // Dispatch to the appropriate output format
+            let table = plan.table();
             match plan.output_format() {
                 OutputFormat::Tbl => {
                     let gens = tbl_sources(plan.generation_plan(), scale_factor);
-                    write_file(plan, num_threads, gens).await?
+                    write_file(plan, num_threads, gens, _progress_tracker.clone(), table).await?
                 }
                 OutputFormat::Csv => {
                     let delimiter = plan.csv_delimiter();
                     let gens = csv_sources(plan.generation_plan(), scale_factor, delimiter);
                     write_file(plan, num_threads, gens).await?
+                    write_file(plan, num_threads, gens, _progress_tracker.clone(), table).await?
                 }
                 OutputFormat::Parquet => {
                     let gens = parquet_sources(plan.generation_plan(), scale_factor);
-                    write_parquet(plan, num_threads, gens).await?
+                    write_parquet(plan, num_threads, gens, _progress_tracker.clone(), table).await?
                 }
             };
             Ok(num_threads)

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -95,13 +95,14 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
         .arg("part")
         .arg("--output-dir")
         .arg(temp_dir.path())
+        .arg("--verbose")
         .assert()
         .success();
 
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(
         stderr.contains("already exists, skipping generation"),
-        "Expected warning message not found in stderr: {}",
+        "Expected skip message not found in stderr: {}",
         stderr
     );
 
@@ -150,13 +151,14 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
         .arg("part")
         .arg("--output-dir")
         .arg(temp_dir.path())
+        .arg("--verbose")
         .assert()
         .success();
 
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(
         stderr.contains("already exists, skipping generation"),
-        "Expected warning message not found in stderr: {}",
+        "Expected skip message not found in stderr: {}",
         stderr
     );
 

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -95,14 +95,13 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
         .arg("part")
         .arg("--output-dir")
         .arg(temp_dir.path())
-        .arg("--verbose")
         .assert()
         .success();
 
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(
         stderr.contains("already exists, skipping generation"),
-        "Expected skip message not found in stderr: {}",
+        "Expected warning message not found in stderr: {}",
         stderr
     );
 
@@ -151,14 +150,13 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
         .arg("part")
         .arg("--output-dir")
         .arg(temp_dir.path())
-        .arg("--verbose")
         .assert()
         .success();
 
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(
         stderr.contains("already exists, skipping generation"),
-        "Expected skip message not found in stderr: {}",
+        "Expected warning message not found in stderr: {}",
         stderr
     );
 
@@ -643,6 +641,59 @@ async fn test_quiet_flag_suppresses_warnings() {
         "Expected no warning messages in stderr with --quiet flag, but found: {}",
         stderr
     );
+}
+
+/// Test that --no-progress is accepted and produces no progress bar output.
+/// Note: in `assert_cmd`-driven tests stderr is not a TTY so progress is also
+/// auto-disabled; this test mainly locks in the flag's existence and verifies
+/// no progress glyphs leak into the output.
+#[test]
+fn test_tpchgen_cli_no_progress_flag() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+    let output = cargo_bin_cmd!("tpchgen-cli")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("region")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--no-progress")
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    for glyph in ["█", "▓", "░", "Progress:"] {
+        assert!(
+            !stderr.contains(glyph),
+            "Expected no progress bar glyph {glyph:?} in stderr, but found: {stderr}"
+        );
+    }
+}
+
+/// Test that the progress bar is auto-suppressed when stderr is not a TTY
+/// (as is the case under `assert_cmd`, CI logs, and pipe redirection),
+/// even without passing `--no-progress`. This locks in the contract that
+/// CI logs are never polluted with progress glyphs by default.
+#[test]
+fn test_tpchgen_cli_progress_auto_disabled_on_non_tty() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+    let output = cargo_bin_cmd!("tpchgen-cli")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("region")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    for glyph in ["█", "▓", "░", "Progress:"] {
+        assert!(
+            !stderr.contains(glyph),
+            "Expected progress to be auto-disabled on non-TTY stderr, but found {glyph:?} in: {stderr}"
+        );
+    }
 }
 
 fn read_gzipped_file_to_string<P: AsRef<Path>>(path: P) -> Result<String, std::io::Error> {


### PR DESCRIPTION
Closes #216

Adds progress reporting for table generation, including default CLI progress bars and an optional library progress hook.

## Design

Generation reports progress through a shared, thread-safe `ProgressTracker`. The CLI default implementation, `IndicatifProgress`, uses `indicatif` with one progress bar per `Table`, coordinated by `MultiProgress`.

The library-facing API stays small:

- `ProgressTracker` is the public hook for custom progress sinks.
- `RunProgress` tracks run-level totals, skipped files, and finish behavior.
- `TableProgress` is passed to writers and advances progress for completed output units.

Progress is advanced only after output is successfully written. Since generation parallelism is across tables, each table writer still emits its chunks or row groups in order, so each table bar moves forward one output unit at a time.

Progress units are format-specific:

- TBL/CSV counts written data chunks, excluding headers.
- Parquet counts written row groups.
- Skipped existing files advance by their planned output-unit count.

## CLI Behavior

Progress bars are enabled by default only when stderr is an interactive terminal. They are suppressed by `--no-progress`, `--quiet`, `--stdout`, or non-TTY stderr, keeping CI logs and piped output clean.

Library users can enable the lightweight `progress` feature and provide their own `ProgressTracker` without depending on the default terminal progress implementation.

https://github.com/user-attachments/assets/ca7c0370-47e8-489a-aa85-29b4a673c7d7
