### PR TITLE
feat: Add parquet subcommand with format-specific argument validation

### DIFF
--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -120,15 +120,6 @@ struct TopLevelArgs {
     #[arg(short, long, default_value = "tbl")]
     format: OutputFormat,
 
-    /// CSV delimiter character (default: ',')
-    ///
-    /// Specifies the delimiter character to use when generating CSV files.
-    ///
-    /// Supports escape sequences: \t (tab), \n (newline), \r (carriage return), \\ (backslash)
-    /// Common delimiters: ',' (comma), '|' (pipe), '\t' (tab), ';' (semicolon)
-    #[arg(long, default_value = ",", value_parser = parse_delimiter)]
-    delimiter: char,
-
     /// Parquet block compression format (deprecated: use 'parquet' subcommand instead)
     #[arg(short = 'c', long)]
     #[deprecated]
@@ -138,6 +129,15 @@ struct TopLevelArgs {
     #[arg(long)]
     #[deprecated]
     parquet_row_group_bytes: Option<i64>,
+
+    /// CSV delimiter character (default: ',')
+    ///
+    /// Specifies the delimiter character to use when generating CSV files.
+    ///
+    /// Supports escape sequences: \t (tab), \n (newline), \r (carriage return), \\ (backslash)
+    /// Common delimiters: ',' (comma), '|' (pipe), '\t' (tab), ';' (semicolon)
+    #[arg(long, default_value = ",", value_parser = parse_delimiter)]
+    delimiter: char,
 }
 
 #[derive(clap::Args)]

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -248,6 +248,7 @@ async fn main() -> io::Result<()> {
 }
 
 impl Cli {
+    /// Main function to run the generation
     async fn main(self) -> io::Result<()> {
         match self.command {
             Some(Commands::Parquet(args)) => args.run().await,
@@ -273,6 +274,7 @@ impl Cli {
 
         configure_logging(verbose, quiet);
 
+        // Warn if parquet specific options are set but not generating parquet
         if format == OutputFormat::Parquet {
             eprintln!(
                 "Warning: Use 'tpchgen-cli parquet' subcommand instead of '--format=parquet' for better validation and control"
@@ -295,6 +297,7 @@ impl Cli {
             );
         }
 
+        // Validate delimiter usage
         if format == OutputFormat::Tbl && delimiter != ',' {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -302,10 +305,12 @@ impl Cli {
             ));
         }
 
+        // Warn if delimiter is set but not generating CSV
         if delimiter != ',' && format != OutputFormat::Csv {
             log::warn!("Delimiter option set but not generating CSV files");
         }
 
+        // Build the generator using the library API
         let mut builder = TpchGenerator::builder()
             .with_scale_factor(scale_factor)
             .with_output_dir(output_dir)
@@ -361,6 +366,7 @@ impl ParquetArgs {
 
 fn configure_logging(verbose: bool, quiet: bool) {
     if quiet {
+        // Quiet mode: only show error-level logs
         env_logger::builder()
             .filter_level(LevelFilter::Error)
             .init();
@@ -368,6 +374,7 @@ fn configure_logging(verbose: bool, quiet: bool) {
         env_logger::builder().filter_level(LevelFilter::Info).init();
         info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
     } else {
+        // Default: show warnings and errors, but respect RUST_LOG if set
         env_logger::builder()
             .filter_level(LevelFilter::Warn)
             .parse_default_env()

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -38,6 +38,10 @@ Examples
 
 tpchgen-cli tbl -s 1 --output-dir=/tmp/tpch
 
+# Or without subcommand (defaults to TBL format):
+
+tpchgen-cli -s 1 --output-dir=/tmp/tpch
+
 # Generate the lineitem table at scale factor 100 in 10 Apache Parquet files to
 # /tmp/tpch/lineitem
 

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -66,6 +66,7 @@ struct Cli {
 
 #[derive(clap::Subcommand)]
 enum Commands {
+    /// Generate Apache Parquet output with Parquet-specific options
     Parquet(ParquetArgs),
 }
 

--- a/tpchgen-cli/bin/main.rs
+++ b/tpchgen-cli/bin/main.rs
@@ -121,12 +121,12 @@ struct TopLevelArgs {
     format: OutputFormat,
 
     /// Parquet block compression format (deprecated: use 'parquet' subcommand instead)
-    #[arg(short = 'c', long)]
+    #[arg(short = 'c', long, hide = true)]
     #[deprecated]
     parquet_compression: Option<Compression>,
 
     /// Target row group size in bytes (deprecated: use 'parquet' subcommand instead)
-    #[arg(long)]
+    #[arg(long, hide = true)]
     #[deprecated]
     parquet_row_group_bytes: Option<i64>,
 
@@ -276,25 +276,24 @@ impl Cli {
 
         // Warn if parquet specific options are set but not generating parquet
         if format == OutputFormat::Parquet {
-            eprintln!(
+            log::warn!(
                 "Warning: Use 'tpchgen-cli parquet' subcommand instead of '--format=parquet' for better validation and control"
             );
         }
 
-        if self.args.parquet_compression.is_some() && format != OutputFormat::Parquet {
-            log::warn!("Parquet compression option set but not generating Parquet files");
-        } else if self.args.parquet_compression.is_some() {
-            eprintln!(
-                "Warning: The --parquet-compression flag is deprecated. Use 'tpchgen-cli parquet --compression=...' instead"
-            );
+        if self.args.parquet_compression.is_some() {
+            if format == OutputFormat::Parquet {
+                log::warn!("The --parquet-compression flag is deprecated. Use 'tpchgen-cli parquet --compression=...' instead");
+            } else {
+                log::warn!("Parquet compression option set but not generating Parquet files");
+            }
         }
-
-        if self.args.parquet_row_group_bytes.is_some() && format != OutputFormat::Parquet {
-            log::warn!("Parquet row group size option set but not generating Parquet files");
-        } else if self.args.parquet_row_group_bytes.is_some() {
-            eprintln!(
-                "Warning: The --parquet-row-group-bytes flag is deprecated. Use 'tpchgen-cli parquet --row-group-bytes=...' instead"
-            );
+        if self.args.parquet_row_group_bytes.is_some() {
+            if format == OutputFormat::Parquet {
+                log::warn!("The --parquet-row-group-bytes flag is deprecated. Use 'tpchgen-cli parquet --row-group-bytes=...' instead");
+            } else {
+                log::warn!("Parquet row group size option set but not generating Parquet files");
+            }
         }
 
         // Validate delimiter usage
@@ -306,8 +305,8 @@ impl Cli {
         }
 
         // Warn if delimiter is set but not generating CSV
-        if delimiter != ',' && format != OutputFormat::Csv {
-            log::warn!("Delimiter option set but not generating CSV files");
+        if format != OutputFormat::Csv && delimiter != ',' {
+            log::warn!("Warning: Delimiter option set but not generating CSV");
         }
 
         // Build the generator using the library API

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -18,7 +18,6 @@ fn test_tpchgen_cli_tbl_scale_factor_0_001() {
     // Run the tpchgen-cli command
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -76,7 +75,6 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
     // First run - create the file
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -94,7 +92,6 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
     // file to not be overwritten and a warning to be logged
     let output = Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -190,7 +187,6 @@ fn test_tpchgen_cli_quiet_flag() {
     // First run - create the file
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -208,7 +204,6 @@ fn test_tpchgen_cli_quiet_flag() {
     // Expect the file to not be overwritten and NO warning even though warnings show by default
     let output = Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -252,7 +247,6 @@ fn test_tpchgen_cli_parts() {
     let output_dir = temp_dir.path().to_path_buf();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -284,7 +278,6 @@ fn test_tpchgen_cli_parts_explicit() {
             // output goes into `output_dir/orders/orders.{part}.tbl`
             Command::cargo_bin("tpchgen-cli")
                 .expect("Binary not found")
-                .arg("tbl")
                 .arg("--scale-factor")
                 .arg("0.001")
                 .arg("--output-dir")
@@ -315,7 +308,6 @@ fn test_tpchgen_cli_parts_all_tables() {
     let output_dir = temp_dir.path().to_path_buf();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -540,7 +532,6 @@ fn test_tpchgen_cli_part_no_parts() {
     // CLI Error test --part and but not --parts
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -559,7 +550,6 @@ fn test_tpchgen_cli_too_many_parts() {
     // This should fail because --part is 42 which is more than the --parts 10
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -579,7 +569,6 @@ fn test_tpchgen_cli_zero_part() {
 
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -598,7 +587,6 @@ fn test_tpchgen_cli_zero_part_zero_parts() {
 
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -18,6 +18,7 @@ fn test_tpchgen_cli_tbl_scale_factor_0_001() {
     // Run the tpchgen-cli command
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -75,6 +76,7 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
     // First run - create the file
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -92,6 +94,7 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
     // file to not be overwritten and a warning to be logged
     let output = Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -130,12 +133,11 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
     // First run - create the file
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("parquet")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
         .arg("part")
-        .arg("--format")
-        .arg("parquet")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .assert()
@@ -149,12 +151,11 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
     // file to not be overwritten and a warning to be logged
     let output = Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("parquet")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
         .arg("part")
-        .arg("--format")
-        .arg("parquet")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .assert()
@@ -189,6 +190,7 @@ fn test_tpchgen_cli_quiet_flag() {
     // First run - create the file
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -206,6 +208,7 @@ fn test_tpchgen_cli_quiet_flag() {
     // Expect the file to not be overwritten and NO warning even though warnings show by default
     let output = Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--tables")
@@ -249,6 +252,7 @@ fn test_tpchgen_cli_parts() {
     let output_dir = temp_dir.path().to_path_buf();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -280,6 +284,7 @@ fn test_tpchgen_cli_parts_explicit() {
             // output goes into `output_dir/orders/orders.{part}.tbl`
             Command::cargo_bin("tpchgen-cli")
                 .expect("Binary not found")
+                .arg("tbl")
                 .arg("--scale-factor")
                 .arg("0.001")
                 .arg("--output-dir")
@@ -310,6 +315,7 @@ fn test_tpchgen_cli_parts_all_tables() {
     let output_dir = temp_dir.path().to_path_buf();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -362,7 +368,6 @@ async fn test_write_parquet_orders() {
     let output_path = output_dir.path().join("orders.parquet");
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("--format")
         .arg("parquet")
         .arg("--tables")
         .arg("orders")
@@ -408,7 +413,6 @@ async fn test_write_parquet_row_group_size_default() {
     let output_dir = tempdir().unwrap();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("--format")
         .arg("parquet")
         .arg("--scale-factor")
         .arg("1")
@@ -476,13 +480,12 @@ async fn test_write_parquet_row_group_size_20mb() {
     let output_dir = tempdir().unwrap();
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
-        .arg("--format")
         .arg("parquet")
         .arg("--scale-factor")
         .arg("1")
         .arg("--output-dir")
         .arg(output_dir.path())
-        .arg("--parquet-row-group-bytes")
+        .arg("--row-group-bytes")
         .arg("20000000") // 20 MB
         .assert()
         .success();
@@ -537,6 +540,7 @@ fn test_tpchgen_cli_part_no_parts() {
     // CLI Error test --part and but not --parts
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -555,6 +559,7 @@ fn test_tpchgen_cli_too_many_parts() {
     // This should fail because --part is 42 which is more than the --parts 10
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -574,6 +579,7 @@ fn test_tpchgen_cli_zero_part() {
 
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -592,6 +598,7 @@ fn test_tpchgen_cli_zero_part_zero_parts() {
 
     Command::cargo_bin("tpchgen-cli")
         .expect("Binary not found")
+        .arg("tbl")
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")


### PR DESCRIPTION
Adds a `parquet` subcommand so parquet-specific flags (`--compression`, `--row-group-bytes`) are only accepted when generating Parquet output, replacing the error-prone `--format=parquet` + `--parquet-*` flags pattern.

## Changes
- Add `parquet` subcommand with dedicated `ParquetArgs` (compression, row-group-bytes)
- Extract shared options into `CommonArgs` (scale-factor, output-dir, tables, parts, etc.)
- Deprecate top-level `--parquet-compression` and `--parquet-row-group-bytes` with migration warnings
- Warn on `--format=parquet` usage, directing users to the subcommand
- Rename `--parquet-compression` → `--compression` and `--parquet-row-group-bytes` → `--row-group-bytes` under the subcommand
- Extract `configure_logging()` helper
- Update CLI integration tests and help examples

## Migration
```sh
# Before
tpchgen-cli -s 100 --format=parquet --parquet-compression snappy --parquet-row-group-bytes=100000000 --output-dir /tmp/tpch

# After
tpchgen-cli parquet -s 100 --compression snappy --row-group-bytes=100000000 --output-dir /tmp/tpch
```

TBL/CSV generation via top-level flags is unchanged.

Closes #173
