### PR TITLE
Bump Arrow and Parquet to 59.0.0

### DIFF
--- a/tpchgen-arrow/Cargo.toml
+++ b/tpchgen-arrow/Cargo.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-arrow = { version = "58", default-features = false, features = ["prettyprint"] }
+arrow = { version = "59", default-features = false, features = ["prettyprint"] }
 tpchgen = { path = "../tpchgen", version = "2.0.2" }
 
 [dev-dependencies]
-arrow-csv = "58"
+arrow-csv = "59"
 chrono = "0.4.39"

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -18,8 +18,8 @@ name = "tpchgen-cli"
 path = "bin/main.rs"
 
 [dependencies]
-arrow = "58"
-parquet = "58"
+arrow = "59"
+parquet = "59"
 clap = { version = "4.5.32", features = ["derive"] }
 tpchgen = { path = "../tpchgen", version = "2.0.2" }
 tpchgen-arrow = { path = "../tpchgen-arrow", version = "2.0.2" }

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -406,7 +406,7 @@ async fn test_write_parquet_row_group_size_default() {
         vec![
             RowGroups {
                 table: "customer",
-                row_group_bytes: vec![6523694, 6509728, 6508417, 6518582],
+                row_group_bytes: vec![6522719, 6507058, 6507800, 6515798],
             },
             RowGroups {
                 table: "lineitem",
@@ -427,19 +427,19 @@ async fn test_write_parquet_row_group_size_default() {
             RowGroups {
                 table: "orders",
                 row_group_bytes: vec![
-                    7842293, 7842276, 7847651, 7844507, 7849468, 7847495, 7838699, 7841044,
-                    7840487, 7839166, 7841356, 7839460, 7843712, 7834117, 7840051, 7838256,
+                    7842293, 7841931, 7847396, 7844507, 7849243, 7847495, 7838444, 7841044,
+                    7840217, 7837271, 7841056, 7839265, 7843712, 7834117, 7839886, 7838091,
                 ],
             },
             RowGroups {
                 table: "part",
-                row_group_bytes: vec![7013437, 7014324],
+                row_group_bytes: vec![7012918, 7014223],
             },
             RowGroups {
                 table: "partsupp",
                 row_group_bytes: vec![
-                    7294343, 7277020, 7291816, 7287548, 7285532, 7292484, 7279927, 7300829,
-                    7284682, 7291052, 7286819, 7297626, 7292903, 7295373, 7290239, 7279755,
+                    7292900, 7275703, 7290373, 7286175, 7284159, 7291041, 7278512, 7298320,
+                    7283253, 7289609, 7285376, 7295104, 7290407, 7293930, 7287756, 7278354,
                 ],
             },
             RowGroups {
@@ -474,7 +474,7 @@ async fn test_write_parquet_row_group_size_20mb() {
         vec![
             RowGroups {
                 table: "customer",
-                row_group_bytes: vec![12848012, 12841373],
+                row_group_bytes: vec![12844748, 12838467],
             },
             RowGroups {
                 table: "lineitem",
@@ -490,15 +490,15 @@ async fn test_write_parquet_row_group_size_20mb() {
             },
             RowGroups {
                 table: "orders",
-                row_group_bytes: vec![19815261, 19819775, 19810468, 19806802, 19802354, 19795478],
+                row_group_bytes: vec![19815261, 19819445, 19810193, 19806532, 19802204, 19795267],
             },
             RowGroups {
                 table: "part",
-                row_group_bytes: vec![13920228],
+                row_group_bytes: vec![13919709],
             },
             RowGroups {
                 table: "partsupp",
-                row_group_bytes: vec![18979513, 18992386, 18975044, 18978110, 18996633, 18983782],
+                row_group_bytes: vec![18978072, 18990959, 18973658, 18976682, 18995233, 18981274],
             },
             RowGroups {
                 table: "region",


### PR DESCRIPTION
## Summary

This bumps the Arrow and Parquet dependencies from 58 to 59.

The only test updates are the Parquet row-group byte-size snapshots. Those numbers come from Parquet's physical metadata, and Parquet 59 changed the writer's page batching for variable-width columns in [apache/arrow-rs#9972](https://github.com/apache/arrow-rs/pull/9972). That shifts a few encoded byte totals for string/comment columns, but the generated data still round-trips correctly.

## Validation

- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo test -p tpchgen-cli --test cli_integration`
- `cargo test --workspace`
- `cargo clippy -p tpchgen-arrow -p tpchgen-cli --all-targets -- -D warnings`
- `git diff --check`

## Benchmark

I also reran the lineitem Parquet benchmark shape from the previous Arrow bump with `hyperfine`, using the current `parquet` subcommand and fresh output dirs. I ran it twice with the command order reversed, so the result is less sensitive to ordering/warmup noise. To reproduce locally, build the two release binaries and point these variables at them:

```text
TPCHGEN_58=/path/to/tpchgen-cli-58.3.0
TPCHGEN_59=/path/to/tpchgen-cli-59.0.0
OUT=/tmp/tpchgen-bench-out

hyperfine --runs 5 \
  --prepare "rm -rf $OUT/sf100-p10-58 $OUT/sf100-p10-59" \
  "$TPCHGEN_58 parquet --scale-factor=100 --tables=lineitem --parts=10 --output-dir $OUT/sf100-p10-58" \
  "$TPCHGEN_59 parquet --scale-factor=100 --tables=lineitem --parts=10 --output-dir $OUT/sf100-p10-59"

hyperfine --runs 5 \
  --prepare "rm -rf $OUT/sf100-p10-59-rev $OUT/sf100-p10-58-rev" \
  "$TPCHGEN_59 parquet --scale-factor=100 --tables=lineitem --parts=10 --output-dir $OUT/sf100-p10-59-rev" \
  "$TPCHGEN_58 parquet --scale-factor=100 --tables=lineitem --parts=10 --output-dir $OUT/sf100-p10-58-rev"
```

The baseline binary resolved Arrow/Parquet to 58.3.0, and the upgraded binary resolved them to 59.0.0.

```text
58 first:
  58.3.0: 32.109 s +/- 0.354 s  [range: 31.702 s ... 32.521 s]
  59.0.0: 33.235 s +/- 0.315 s  [range: 32.832 s ... 33.613 s]
  Summary: 58.3.0 ran 1.04 +/- 0.02x faster

59 first:
  59.0.0: 32.675 s +/- 0.325 s  [range: 32.348 s ... 33.176 s]
  58.3.0: 33.085 s +/- 0.283 s  [range: 32.805 s ... 33.557 s]
  Summary: 59.0.0 ran 1.01 +/- 0.01x faster
```

So I would read this as no material performance change on my loaded machine.
Combined across both orderings,
* `58.3.0` averaged `32.597s`
* `59.0.0` averaged `32.955s`

Output size was effectively unchanged too:
* `27,146,187,982` bytes for `58.3.0`
* `27,146,169,702` bytes for `59.0.0`
