### PR TITLE
Add tpcdsgen-arrow README

### DIFF
--- a/tpcdsgen-arrow/README.md
+++ b/tpcdsgen-arrow/README.md
@@ -1,0 +1,25 @@
+# TPC-DS Data Generator in Arrow format
+
+Generate TPC-DS data directly into [Apache Arrow] format using the [tpcdsgen] and [arrow] crate.
+
+[Apache Arrow]: https://arrow.apache.org/
+[tpcdsgen]: https://crates.io/crates/tpcdsgen
+[arrow]: https://crates.io/crates/arrow
+
+# Example usage:
+
+See [docs.rs page](https://docs.rs/tpcdsgen-arrow/latest/tpcdsgen_arrow/)
+
+# Testing:
+
+This crate ensures correct results using two methods.
+
+1. Basic functional tests are in Rust doc tests in the source code (`cargo test -p tpcdsgen-arrow --doc`)
+2. The `reparse` integration test ensures that the Arrow generators
+   produce the same results as parsing the original DAT format (`cargo test -p tpcdsgen-arrow --test reparse`)
+
+# Contributing:
+
+Please see [CONTRIBUTING.md] for more information on how to contribute to this project.
+
+[CONTRIBUTING.md]: https://github.com/clflushopt/tpchgen-rs/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- Add `tpcdsgen-arrow/README.md` so [`tpcdsgen-arrow/Cargo.toml`'s `readme = "README.md"](https://github.com/clflushopt/tpchgen-rs/blob/af151bc22e68c2472b64a7c118964cd4d6912147/tpchgen-arrow/Cargo.toml#L8)` metadata resolves correctly.
- Mirror the existing [`tpchgen-arrow` README](https://github.com/clflushopt/tpchgen-rs/blob/af151bc22e68c2472b64a7c118964cd4d6912147/tpchgen-arrow/README.md) structure for example usage, testing, and contributing.

Closes https://github.com/clflushopt/tpchgen-rs/issues/281

## Validation
- `cargo package -p tpcdsgen-arrow --allow-dirty --list --offline` includes `README.md`
- `cargo metadata --no-deps --format-version 1 --offline` reports `readme = "README.md"` for `tpcdsgen-arrow`
- `cargo test -p tpcdsgen-arrow --doc --offline`
- `cargo test -p tpcdsgen-arrow --test reparse --offline`
