### PR TITLE
fix(tpcds): use `i32`/ `Date32` for  call_center columns

### DIFF
--- a/tpcdsgen-arrow/src/tables/call_center.rs
+++ b/tpcdsgen-arrow/src/tables/call_center.rs
@@ -1,8 +1,9 @@
 use crate::conversions::{
-    address_columns, decimal_to_i128, is_null, opt, sk_opt, string_view_array_from_opt_iter,
+    address_columns, decimal_to_i128, is_null, julian_to_date32, opt, sk_opt,
+    string_view_array_from_opt_iter,
 };
 use crate::{RecordBatchIterator, RowIter, DEFAULT_BATCH_SIZE};
-use arrow::array::{Decimal128Array, Int32Array, Int64Array, RecordBatch};
+use arrow::array::{Date32Array, Decimal128Array, Int32Array, Int64Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use std::sync::{Arc, LazyLock};
 use tpcdsgen::config::{Session, Table};
@@ -53,10 +54,10 @@ impl Iterator for CallCenterArrow {
 
         let mut cc_sk: Vec<Option<i64>> = Vec::with_capacity(rows.len());
         let mut cc_id: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut cc_rec_start: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut cc_rec_end: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut cc_closed_date: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut cc_open_date: Vec<Option<String>> = Vec::with_capacity(rows.len());
+        let mut cc_rec_start: Vec<Option<i32>> = Vec::with_capacity(rows.len());
+        let mut cc_rec_end: Vec<Option<i32>> = Vec::with_capacity(rows.len());
+        let mut cc_closed_date: Vec<Option<i64>> = Vec::with_capacity(rows.len());
+        let mut cc_open_date: Vec<Option<i64>> = Vec::with_capacity(rows.len());
         let mut cc_name: Vec<Option<String>> = Vec::with_capacity(rows.len());
         let mut cc_class: Vec<Option<String>> = Vec::with_capacity(rows.len());
         let mut cc_employees: Vec<Option<i32>> = Vec::with_capacity(rows.len());
@@ -79,20 +80,18 @@ impl Iterator for CallCenterArrow {
             let nbm = r.get_null_bit_map();
             cc_sk.push(sk_opt(nbm, 0, r.get_cc_call_center_sk()));
             cc_id.push(opt(nbm, 1, r.get_cc_call_center_id().to_owned()));
-            cc_rec_start.push(opt(nbm, 2, r.get_cc_rec_start_date_id().to_owned()));
-            let rec_end = r.get_cc_rec_end_date_id();
-            cc_rec_end.push(if is_null(nbm, 3) || rec_end.is_empty() {
+            cc_rec_start.push(if is_null(nbm, 2) {
                 None
             } else {
-                Some(rec_end.to_owned())
+                julian_to_date32(r.get_cc_rec_start_date_id())
             });
-            let closed = r.get_cc_closed_date_id();
-            cc_closed_date.push(if is_null(nbm, 4) || closed.is_empty() {
+            cc_rec_end.push(if is_null(nbm, 3) {
                 None
             } else {
-                Some(closed.to_owned())
+                julian_to_date32(r.get_cc_rec_end_date_id())
             });
-            cc_open_date.push(opt(nbm, 5, r.get_cc_open_date_id().to_owned()));
+            cc_closed_date.push(sk_opt(nbm, 4, r.get_cc_closed_date_id()));
+            cc_open_date.push(sk_opt(nbm, 5, r.get_cc_open_date_id()));
             cc_name.push(opt(nbm, 6, r.get_cc_name().to_owned()));
             cc_class.push(opt(nbm, 7, r.get_cc_class().to_owned()));
             cc_employees.push(opt(nbm, 8, r.get_cc_employees()));
@@ -136,18 +135,10 @@ impl Iterator for CallCenterArrow {
                     Arc::new(string_view_array_from_opt_iter(
                         cc_id.iter().map(|s| s.as_deref()),
                     )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        cc_rec_start.iter().map(|s| s.as_deref()),
-                    )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        cc_rec_end.iter().map(|s| s.as_deref()),
-                    )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        cc_closed_date.iter().map(|s| s.as_deref()),
-                    )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        cc_open_date.iter().map(|s| s.as_deref()),
-                    )),
+                    Arc::new(Date32Array::from(cc_rec_start)),
+                    Arc::new(Date32Array::from(cc_rec_end)),
+                    Arc::new(Int64Array::from(cc_closed_date)),
+                    Arc::new(Int64Array::from(cc_open_date)),
                     Arc::new(string_view_array_from_opt_iter(
                         cc_name.iter().map(|s| s.as_deref()),
                     )),
@@ -204,10 +195,10 @@ fn make_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("cc_call_center_sk", DataType::Int64, true),
         Field::new("cc_call_center_id", DataType::Utf8View, true),
-        Field::new("cc_rec_start_date", DataType::Utf8View, true),
-        Field::new("cc_rec_end_date", DataType::Utf8View, true),
-        Field::new("cc_closed_date_sk", DataType::Utf8View, true),
-        Field::new("cc_open_date_sk", DataType::Utf8View, true),
+        Field::new("cc_rec_start_date", DataType::Date32, true),
+        Field::new("cc_rec_end_date", DataType::Date32, true),
+        Field::new("cc_closed_date_sk", DataType::Int64, true),
+        Field::new("cc_open_date_sk", DataType::Int64, true),
         Field::new("cc_name", DataType::Utf8View, true),
         Field::new("cc_class", DataType::Utf8View, true),
         Field::new("cc_employees", DataType::Int32, true),

--- a/tpcdsgen/src/row/tables/call_center_row.rs
+++ b/tpcdsgen/src/row/tables/call_center_row.rs
@@ -1,5 +1,5 @@
 use crate::row::TableRow;
-use crate::types::{Address, Decimal};
+use crate::types::{Address, Date, Decimal};
 
 /// Call Center row data structure (CallCenterRow)
 /// Contains all fields for the CALL_CENTER table in TPC-DS
@@ -8,12 +8,15 @@ pub struct CallCenterRow {
     // Primary key
     cc_call_center_sk: i64,
 
-    // Business key and versioning
+    // Business key and versioning.
+    //
+    // Record dates are stored as Julian day numbers. Open/closed dates are
+    // DATE_DIM surrogate keys. They are formatted only when writing .dat output.
     cc_call_center_id: String,
-    cc_rec_start_date_id: String,
-    cc_rec_end_date_id: String,
-    cc_closed_date_id: String,
-    cc_open_date_id: String,
+    cc_rec_start_date_id: i64,
+    cc_rec_end_date_id: i64,
+    cc_closed_date_id: i64,
+    cc_open_date_id: i64,
 
     // Call center information
     cc_name: String,
@@ -60,20 +63,20 @@ impl CallCenterRow {
         &self.cc_call_center_id
     }
 
-    pub fn get_cc_rec_start_date_id(&self) -> &str {
-        &self.cc_rec_start_date_id
+    pub fn get_cc_rec_start_date_id(&self) -> i64 {
+        self.cc_rec_start_date_id
     }
 
-    pub fn get_cc_rec_end_date_id(&self) -> &str {
-        &self.cc_rec_end_date_id
+    pub fn get_cc_rec_end_date_id(&self) -> i64 {
+        self.cc_rec_end_date_id
     }
 
-    pub fn get_cc_closed_date_id(&self) -> &str {
-        &self.cc_closed_date_id
+    pub fn get_cc_closed_date_id(&self) -> i64 {
+        self.cc_closed_date_id
     }
 
-    pub fn get_cc_open_date_id(&self) -> &str {
-        &self.cc_open_date_id
+    pub fn get_cc_open_date_id(&self) -> i64 {
+        self.cc_open_date_id
     }
 
     pub fn get_cc_name(&self) -> &str {
@@ -166,6 +169,24 @@ impl CallCenterRow {
             value.to_string()
         }
     }
+
+    /// Format a Julian day number as a .dat date string, handling nulls.
+    fn format_date(&self, julian_days: i64, column_position: i32) -> String {
+        if self.is_null(column_position) || julian_days < 0 {
+            String::new()
+        } else {
+            Date::from_julian_days(julian_days as i32).to_string()
+        }
+    }
+
+    /// Format a DATE_DIM surrogate key, handling nulls.
+    fn format_key(&self, value: i64, column_position: i32) -> String {
+        if self.is_null(column_position) || value < 0 {
+            String::new()
+        } else {
+            value.to_string()
+        }
+    }
 }
 
 impl TableRow for CallCenterRow {
@@ -174,10 +195,10 @@ impl TableRow for CallCenterRow {
         vec![
             self.format_numeric(self.cc_call_center_sk, 0),
             self.format_value(&self.cc_call_center_id, 1),
-            self.format_value(&self.cc_rec_start_date_id, 2),
-            self.format_value(&self.cc_rec_end_date_id, 3),
-            self.format_value(&self.cc_closed_date_id, 4),
-            self.format_value(&self.cc_open_date_id, 5),
+            self.format_date(self.cc_rec_start_date_id, 2),
+            self.format_date(self.cc_rec_end_date_id, 3),
+            self.format_key(self.cc_closed_date_id, 4),
+            self.format_key(self.cc_open_date_id, 5),
             self.format_value(&self.cc_name, 6),
             self.format_value(&self.cc_class, 7),
             self.format_numeric(self.cc_employees, 8),
@@ -213,10 +234,10 @@ impl TableRow for CallCenterRow {
 pub struct CallCenterRowBuilder {
     cc_call_center_sk: Option<i64>,
     cc_call_center_id: Option<String>,
-    cc_rec_start_date_id: Option<String>,
-    cc_rec_end_date_id: Option<String>,
-    cc_closed_date_id: Option<String>,
-    cc_open_date_id: Option<String>,
+    cc_rec_start_date_id: Option<i64>,
+    cc_rec_end_date_id: Option<i64>,
+    cc_closed_date_id: Option<i64>,
+    cc_open_date_id: Option<i64>,
     cc_name: Option<String>,
     cc_class: Option<String>,
     cc_employees: Option<i32>,
@@ -252,22 +273,22 @@ impl CallCenterRowBuilder {
         self
     }
 
-    pub fn set_cc_rec_start_date_id(mut self, value: String) -> Self {
+    pub fn set_cc_rec_start_date_id(mut self, value: i64) -> Self {
         self.cc_rec_start_date_id = Some(value);
         self
     }
 
-    pub fn set_cc_rec_end_date_id(mut self, value: String) -> Self {
+    pub fn set_cc_rec_end_date_id(mut self, value: i64) -> Self {
         self.cc_rec_end_date_id = Some(value);
         self
     }
 
-    pub fn set_cc_closed_date_id(mut self, value: String) -> Self {
+    pub fn set_cc_closed_date_id(mut self, value: i64) -> Self {
         self.cc_closed_date_id = Some(value);
         self
     }
 
-    pub fn set_cc_open_date_id(mut self, value: String) -> Self {
+    pub fn set_cc_open_date_id(mut self, value: i64) -> Self {
         self.cc_open_date_id = Some(value);
         self
     }
@@ -362,10 +383,10 @@ impl CallCenterRowBuilder {
         CallCenterRow {
             cc_call_center_sk: self.cc_call_center_sk.unwrap_or(0),
             cc_call_center_id: self.cc_call_center_id.unwrap_or_default(),
-            cc_rec_start_date_id: self.cc_rec_start_date_id.unwrap_or_default(),
-            cc_rec_end_date_id: self.cc_rec_end_date_id.unwrap_or_default(),
-            cc_closed_date_id: self.cc_closed_date_id.unwrap_or_default(), // Default empty for null
-            cc_open_date_id: self.cc_open_date_id.unwrap_or_default(),
+            cc_rec_start_date_id: self.cc_rec_start_date_id.unwrap_or(-1),
+            cc_rec_end_date_id: self.cc_rec_end_date_id.unwrap_or(-1),
+            cc_closed_date_id: self.cc_closed_date_id.unwrap_or(-1),
+            cc_open_date_id: self.cc_open_date_id.unwrap_or(-1),
             cc_name: self.cc_name.unwrap_or_default(),
             cc_class: self.cc_class.unwrap_or_default(),
             cc_employees: self.cc_employees.unwrap_or(0),
@@ -412,10 +433,10 @@ mod tests {
         let row = CallCenterRow::builder()
             .set_cc_call_center_sk(1)
             .set_cc_call_center_id("AAAAAAAABAAAAAAA".to_string())
-            .set_cc_rec_start_date_id(2450815.to_string())
-            .set_cc_rec_end_date_id(2451179.to_string())
-            .set_cc_closed_date_id((-1).to_string())
-            .set_cc_open_date_id(2450816.to_string())
+            .set_cc_rec_start_date_id(2450815)
+            .set_cc_rec_end_date_id(2451179)
+            .set_cc_closed_date_id(-1)
+            .set_cc_open_date_id(2450816)
             .set_cc_name("NY Metro".to_string())
             .set_cc_class("large".to_string())
             .set_cc_employees(2)

--- a/tpcdsgen/src/row/tables/call_center_row.rs
+++ b/tpcdsgen/src/row/tables/call_center_row.rs
@@ -10,8 +10,7 @@ pub struct CallCenterRow {
 
     // Business key and versioning.
     //
-    // Record dates are stored as Julian day numbers. Open/closed dates are
-    // DATE_DIM surrogate keys. They are formatted only when writing .dat output.
+    // Open/closed dates are DATE_DIM surrogate keys.
     cc_call_center_id: String,
     cc_rec_start_date_id: i64,
     cc_rec_end_date_id: i64,

--- a/tpcdsgen/src/row/tables/call_center_row_generator.rs
+++ b/tpcdsgen/src/row/tables/call_center_row_generator.rs
@@ -64,12 +64,6 @@ impl CallCenterRowGenerator {
         // the start and end dates are the version information for the row.
         let scd_key: SlowlyChangingDimensionKey = compute_scd_key(Table::CallCenter, row_number);
 
-        let end_date_str = if scd_key.get_end_date() == -1 {
-            String::new() // Empty string for null end dates
-        } else {
-            Date::julian_to_date_string(scd_key.get_end_date())
-        };
-
         let scaling = session.get_scaling();
         let is_new_business_key = scd_key.is_new_business_key();
 
@@ -80,8 +74,7 @@ impl CallCenterRowGenerator {
                 .get_random_number_stream(&CallCenterGeneratorColumn::CcOpenDateId);
             let open_date_random =
                 RandomValueGenerator::generate_uniform_random_int(-365, 0, open_date_stream);
-            let open_date_julian = JULIAN_DATE_START - open_date_random as i64;
-            let open_date_id = open_date_julian.to_string();
+            let open_date_id = JULIAN_DATE_START - open_date_random as i64;
 
             let number_of_call_centers =
                 CallCenterDistributions::get_number_of_call_centers().unwrap_or(12);
@@ -109,7 +102,7 @@ impl CallCenterRowGenerator {
             // Use values from previous row - DO NOT consume random streams!
             if let Some(ref prev_row) = self.previous_row {
                 (
-                    prev_row.get_cc_open_date_id().to_string(),
+                    prev_row.get_cc_open_date_id(),
                     prev_row.get_cc_name().to_string(),
                     prev_row.get_cc_address().clone(),
                 )
@@ -376,9 +369,9 @@ impl CallCenterRowGenerator {
             .set_null_bit_map(0)
             .set_cc_call_center_sk(row_number)
             .set_cc_call_center_id(scd_key.get_business_key().to_string())
-            .set_cc_rec_start_date_id(Date::julian_to_date_string(scd_key.get_start_date()))
-            .set_cc_rec_end_date_id(end_date_str)
-            .set_cc_closed_date_id(String::new())
+            .set_cc_rec_start_date_id(scd_key.get_start_date())
+            .set_cc_rec_end_date_id(scd_key.get_end_date())
+            .set_cc_closed_date_id(-1)
             .set_cc_open_date_id(cc_open_date_id)
             .set_cc_name(cc_name)
             .set_cc_class(cc_class.to_string())


### PR DESCRIPTION
- Closes #292

While reviewing the TPC-DS Arrow schemas, `call_center` was  inconsistent with the other slowly changing dimension tables.

This updates the Arrow representation for `call_center` so record date fields use `Date32` and date surrogate key fields use `Int64`, matching the pattern used by tables such as `store`, `web_site`, and `item`.

