### PR TITLE
fix(tpcds): use `i32` / `Date32` / `Time32` for dbgen_version create date 

### DIFF
--- a/tpcdsgen-arrow/src/tables/dbgen_version.rs
+++ b/tpcdsgen-arrow/src/tables/dbgen_version.rs
@@ -1,7 +1,7 @@
-use crate::conversions::{opt, string_view_array_from_opt_iter};
+use crate::conversions::{date_to_date32, opt, string_view_array_from_opt_iter};
 use crate::{RecordBatchIterator, RowIter, DEFAULT_BATCH_SIZE};
-use arrow::array::RecordBatch;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::array::{Date32Array, RecordBatch, Time32SecondArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use std::sync::{Arc, LazyLock};
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen::row::{DbgenVersionRowGenerator, GeneratedRow};
@@ -50,15 +50,15 @@ impl Iterator for DbgenVersionArrow {
         }
 
         let mut version: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut create_date: Vec<Option<String>> = Vec::with_capacity(rows.len());
-        let mut create_time: Vec<Option<String>> = Vec::with_capacity(rows.len());
+        let mut create_date: Vec<Option<i32>> = Vec::with_capacity(rows.len());
+        let mut create_time: Vec<Option<i32>> = Vec::with_capacity(rows.len());
         let mut cmdline: Vec<Option<String>> = Vec::with_capacity(rows.len());
 
         for r in &rows {
             let nbm = r.null_bit_map();
             version.push(opt(nbm, 0, r.get_dv_version().to_owned()));
-            create_date.push(opt(nbm, 1, r.get_dv_create_date().to_owned()));
-            create_time.push(opt(nbm, 2, r.get_dv_create_time().to_owned()));
+            create_date.push(opt(nbm, 1, date_to_date32(r.get_dv_create_date())));
+            create_time.push(opt(nbm, 2, r.get_dv_create_time()));
             cmdline.push(opt(nbm, 3, r.get_dv_cmdline_args().to_owned()));
         }
 
@@ -69,12 +69,8 @@ impl Iterator for DbgenVersionArrow {
                     Arc::new(string_view_array_from_opt_iter(
                         version.iter().map(|s| s.as_deref()),
                     )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        create_date.iter().map(|s| s.as_deref()),
-                    )),
-                    Arc::new(string_view_array_from_opt_iter(
-                        create_time.iter().map(|s| s.as_deref()),
-                    )),
+                    Arc::new(Date32Array::from(create_date)),
+                    Arc::new(Time32SecondArray::from(create_time)),
                     Arc::new(string_view_array_from_opt_iter(
                         cmdline.iter().map(|s| s.as_deref()),
                     )),
@@ -90,8 +86,8 @@ static SCHEMA: LazyLock<SchemaRef> = LazyLock::new(make_schema);
 fn make_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("dv_version", DataType::Utf8View, true),
-        Field::new("dv_create_date", DataType::Utf8View, true),
-        Field::new("dv_create_time", DataType::Utf8View, true),
+        Field::new("dv_create_date", DataType::Date32, true),
+        Field::new("dv_create_time", DataType::Time32(TimeUnit::Second), true),
         Field::new("dv_cmdline_args", DataType::Utf8View, true),
     ]))
 }

--- a/tpcdsgen/src/row/tables/dbgen_version_row.rs
+++ b/tpcdsgen/src/row/tables/dbgen_version_row.rs
@@ -13,14 +13,15 @@
  */
 
 use crate::row::TableRow;
+use crate::types::Date;
 
 /// DbgenVersion table row
 #[derive(Debug, Clone)]
 pub struct DbgenVersionRow {
     null_bit_map: i64,
     dv_version: String,
-    dv_create_date: String,
-    dv_create_time: String,
+    dv_create_date: Date,
+    dv_create_time: i32,
     dv_cmdline_args: String,
 }
 
@@ -28,8 +29,8 @@ impl DbgenVersionRow {
     pub fn new(
         null_bit_map: i64,
         dv_version: String,
-        dv_create_date: String,
-        dv_create_time: String,
+        dv_create_date: Date,
+        dv_create_time: i32,
         dv_cmdline_args: String,
     ) -> Self {
         DbgenVersionRow {
@@ -63,12 +64,12 @@ impl DbgenVersionRow {
         &self.dv_version
     }
 
-    pub fn get_dv_create_date(&self) -> &str {
+    pub fn get_dv_create_date(&self) -> &Date {
         &self.dv_create_date
     }
 
-    pub fn get_dv_create_time(&self) -> &str {
-        &self.dv_create_time
+    pub fn get_dv_create_time(&self) -> i32 {
+        self.dv_create_time
     }
 
     pub fn get_dv_cmdline_args(&self) -> &str {
@@ -81,9 +82,16 @@ impl TableRow for DbgenVersionRow {
         // Column positions match Java DbgenVersionGeneratorColumn (476-479)
         vec![
             self.get_string_or_null(&self.dv_version, 0),
-            self.get_string_or_null(&self.dv_create_date, 1),
-            self.get_string_or_null(&self.dv_create_time, 2),
+            self.get_string_or_null(self.dv_create_date, 1),
+            self.get_string_or_null(format_time(self.dv_create_time), 2),
             self.get_string_or_null(&self.dv_cmdline_args, 3),
         ]
     }
+}
+
+fn format_time(seconds_since_midnight: i32) -> String {
+    let hour = seconds_since_midnight / 3600;
+    let minute = (seconds_since_midnight / 60) % 60;
+    let second = seconds_since_midnight % 60;
+    format!("{hour:02}:{minute:02}:{second:02}")
 }

--- a/tpcdsgen/src/row/tables/dbgen_version_row_generator.rs
+++ b/tpcdsgen/src/row/tables/dbgen_version_row_generator.rs
@@ -16,7 +16,8 @@ use crate::config::Session;
 use crate::error::Result;
 use crate::row::{AbstractRowGenerator, DbgenVersionRow, RowGenerator, RowGeneratorResult};
 use crate::table::Table;
-use chrono::Local;
+use crate::types::Date;
+use chrono::{Datelike, Local, Timelike};
 
 /// Row generator for the DBGEN_VERSION table (DbgenVersionRowGenerator)
 pub struct DbgenVersionRowGenerator {
@@ -49,11 +50,10 @@ impl DbgenVersionRowGenerator {
         // Get current date and time
         let now = Local::now();
 
-        // Format date as "yyyy-MM-dd" (Java SimpleDateFormat equivalent)
-        let create_date = now.format("%Y-%m-%d").to_string();
+        let create_date = Date::new(now.year(), now.month() as i32, now.day() as i32);
 
-        // Format time as "HH:mm:ss" (Java SimpleDateFormat equivalent)
-        let create_time = now.format("%H:%M:%S").to_string();
+        let create_time =
+            (now.hour() as i32 * 3600) + (now.minute() as i32 * 60) + now.second() as i32;
 
         // Get command line arguments from session
         let cmdline_args = session.get_command_line_arguments();


### PR DESCRIPTION
While working on #294, we also found that `dbgen_version.dv_create_date` and `dbgen_version.dv_create_time` were still stored as strings and exposed from `tpcdsgen-arrow` as `Utf8View`.

This keeps the generated `.dat` output unchanged, but carries `dv_create_date` as the typed TPC-DS `Date` and `dv_create_time` as seconds since midnight in the row model. The Arrow representation now exposes them as `Date32` and `Time32(Second)`.