### PR TITLE
Run clippy on all targets and features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run cargo-fmt
         run: cargo fmt --all -- --check
       - name: Run cargo-clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Check
         run: cargo check --verbose --workspace --all-targets
       - name: Check tpchgen-cli without default features

--- a/tpcdsgen/src/distribution/calendar_distribution.rs
+++ b/tpcdsgen/src/distribution/calendar_distribution.rs
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn test_calendar_distribution_loading() {
         let dist = CalendarDistribution::get_instance();
-        assert!(dist.days_of_year.len() > 0);
+        assert!(!dist.days_of_year.is_empty());
         assert_eq!(dist.quarters.len(), dist.days_of_year.len());
         assert_eq!(dist.holiday_flags.len(), dist.days_of_year.len());
     }
@@ -232,7 +232,7 @@ mod tests {
 
         // Day should be in valid range [1, 366]
         assert!(
-            day >= 1 && day <= 366,
+            (1..=366).contains(&day),
             "Day {} should be in range [1, 366]",
             day
         );
@@ -271,7 +271,7 @@ mod tests {
                 .unwrap();
 
         // Both should be valid
-        assert!(day_uniform >= 1 && day_uniform <= 366);
-        assert!(day_sales >= 1 && day_sales <= 366);
+        assert!((1..=366).contains(&day_uniform));
+        assert!((1..=366).contains(&day_sales));
     }
 }

--- a/tpcdsgen/src/distribution/hours_distribution.rs
+++ b/tpcdsgen/src/distribution/hours_distribution.rs
@@ -209,7 +209,7 @@ mod tests {
 
         // Hour should be in valid range [0, 23]
         assert!(
-            hour >= 0 && hour <= 23,
+            (0..=23).contains(&hour),
             "Hour {} should be in range [0, 23]",
             hour
         );
@@ -244,8 +244,8 @@ mod tests {
             HoursDistribution::pick_random_hour(HoursWeights::CatalogAndWeb, &mut stream).unwrap();
 
         // All should be valid
-        assert!(hour_uniform >= 0 && hour_uniform <= 23);
-        assert!(hour_store >= 0 && hour_store <= 23);
-        assert!(hour_catalog >= 0 && hour_catalog <= 23);
+        assert!((0..=23).contains(&hour_uniform));
+        assert!((0..=23).contains(&hour_store));
+        assert!((0..=23).contains(&hour_catalog));
     }
 }

--- a/tpcdsgen/src/join_key_utils.rs
+++ b/tpcdsgen/src/join_key_utils.rs
@@ -399,7 +399,7 @@ mod tests {
 
         // Time keys should be in range [0, 86400) seconds in a day
         assert!(
-            result >= 0 && result < 86400,
+            (0..86400).contains(&result),
             "Time key should be valid seconds in day"
         );
     }

--- a/tpcdsgen/src/random/generator.rs
+++ b/tpcdsgen/src/random/generator.rs
@@ -351,14 +351,14 @@ mod tests {
     fn test_uniform_random_int() {
         let mut stream = RandomNumberStreamImpl::new(1).unwrap();
         let result = RandomValueGenerator::generate_uniform_random_int(1, 10, &mut stream);
-        assert!(result >= 1 && result <= 10);
+        assert!((1..=10).contains(&result));
     }
 
     #[test]
     fn test_uniform_random_key() {
         let mut stream = RandomNumberStreamImpl::new(1).unwrap();
         let result = RandomValueGenerator::generate_uniform_random_key(100, 200, &mut stream);
-        assert!(result >= 100 && result <= 200);
+        assert!((100..=200).contains(&result));
     }
 
     #[test]

--- a/tpcdsgen/src/random/stream.rs
+++ b/tpcdsgen/src/random/stream.rs
@@ -148,7 +148,7 @@ mod tests {
         let random_double = stream.next_random_double();
 
         // Should be between 0 and 1
-        assert!(random_double >= 0.0 && random_double <= 1.0);
+        assert!((0.0..=1.0).contains(&random_double));
     }
 
     #[test]

--- a/tpcdsgen/src/row/tables/web_site_row_generator.rs
+++ b/tpcdsgen/src/row/tables/web_site_row_generator.rs
@@ -380,8 +380,6 @@ mod tests {
     #[test]
     fn test_web_site_row_generator_creation() {
         let _generator = WebSiteRowGenerator::new();
-        // Should not panic
-        assert!(true);
     }
 
     #[test]

--- a/tpcdsgen/src/scaling_info.rs
+++ b/tpcdsgen/src/scaling_info.rs
@@ -308,6 +308,6 @@ mod tests {
 
         // Test interpolation
         let result_5 = scaling_info.get_row_count_for_scale(5.0).unwrap();
-        assert!(result_5 >= 3 && result_5 <= 12);
+        assert!((3..=12).contains(&result_5));
     }
 }

--- a/tpcdsgen/src/table.rs
+++ b/tpcdsgen/src/table.rs
@@ -893,8 +893,7 @@ mod tests {
         assert_eq!(first_col.get_name(), "cc_call_center_sk");
         assert_eq!(first_col.get_position(), 0);
 
-        // Convert column table to our table type for comparison
-        let column_table: Table = first_col.get_table().into();
+        let column_table: Table = first_col.get_table();
         assert_eq!(column_table, Table::CallCenter);
     }
 
@@ -907,8 +906,7 @@ mod tests {
         let first_gen_col = table.get_generator_column_by_index(0).unwrap();
         assert_eq!(first_gen_col.get_global_column_number(), 1);
 
-        // Convert generator column table to our table type for comparison
-        let gen_column_table: Table = first_gen_col.get_table().into();
+        let gen_column_table: Table = first_gen_col.get_table();
         assert_eq!(gen_column_table, Table::CallCenter);
     }
 
@@ -953,8 +951,8 @@ mod tests {
     #[test]
     fn test_table_conversions() {
         let table = Table::CallCenter;
-        let column_table: crate::column::Table = table.into();
-        let back_to_table: Table = column_table.into();
+        let column_table: crate::column::Table = table;
+        let back_to_table: Table = column_table;
         assert_eq!(table, back_to_table);
     }
 

--- a/tpcdsgen/src/types/address.rs
+++ b/tpcdsgen/src/types/address.rs
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn test_city_hash() {
         let hash = Address::compute_city_hash("TESTCITY");
-        assert!(hash >= 0 && hash < 10000);
+        assert!((0..10000).contains(&hash));
     }
 
     #[test]


### PR DESCRIPTION
I was running clippy locally and noticed a few failures which I wanted to fix.

This PR updates CI to run clippy across the full workspace with `--all-targets` and `--all-features`, so test code is checked as well.

It also fixes the new clippy errors in the `tpcdsgen` tests