### PR TITLE
Make progress tracker API always available

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Check
         run: cargo check --verbose --workspace --all-targets
       - name: Check tpchgen-cli without default features
-        run: cargo check -p tpchgen-cli --no-default-features
-      - name: Check tpchgen-cli with custom progress feature
-        run: cargo check -p tpchgen-cli --no-default-features --features progress
+        run: cargo check -p tpchgen-cli --all-targets --no-default-features
+      - name: Check tpcgen-cli without default features
+        run: cargo check -p tpcgen-cli --all-targets --no-default-features
 
   # Tests for tpchgen
   test-tests-tpchgen:

--- a/tpcgen-cli/Cargo.toml
+++ b/tpcgen-cli/Cargo.toml
@@ -33,11 +33,8 @@ tpchgen-arrow = { path = "../tpchgen-arrow", version = "3.0.0" }
 
 [features]
 default = ["indicatif-progress"]
-# Enable progress callbacks for applications that want to provide their own
-# progress reporting without pulling in the default terminal progress bars.
-progress = []
 # Enable the default CLI terminal progress bars backed by `indicatif`.
-indicatif-progress = ["progress", "dep:indicatif"]
+indicatif-progress = ["dep:indicatif"]
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tpcgen-cli/src/tpch_cli.rs
+++ b/tpcgen-cli/src/tpch_cli.rs
@@ -8,9 +8,6 @@ pub mod generate;
 pub mod output_plan;
 pub mod parquet;
 pub mod plan;
-#[cfg(not(feature = "progress"))]
-mod progress;
-#[cfg(feature = "progress")]
 pub mod progress;
 pub mod runner;
 pub mod statistics;

--- a/tpcgen-cli/src/tpch_cli/generate.rs
+++ b/tpcgen-cli/src/tpch_cli/generate.rs
@@ -199,7 +199,7 @@ impl BufferRecycler {
     }
 }
 
-#[cfg(all(test, feature = "progress"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::tpch_cli::progress::{ProgressTracker, RunProgress};

--- a/tpcgen-cli/src/tpch_cli/generate.rs
+++ b/tpcgen-cli/src/tpch_cli/generate.rs
@@ -59,25 +59,10 @@ where
     I: Iterator<Item = G>,
     S: Sink + 'static,
 {
-    let progress = Default::default();
-    generate_in_chunks_impl(sink, sources, num_threads, progress).await
+    generate_in_chunks_with_progress(sink, sources, num_threads, TableProgress::default()).await
 }
 
 pub(crate) async fn generate_in_chunks_with_progress<G, I, S>(
-    sink: S,
-    sources: I,
-    num_threads: usize,
-    progress: TableProgress,
-) -> Result<(), io::Error>
-where
-    G: Source + 'static,
-    I: Iterator<Item = G>,
-    S: Sink + 'static,
-{
-    generate_in_chunks_impl(sink, sources, num_threads, progress).await
-}
-
-async fn generate_in_chunks_impl<G, I, S>(
     mut sink: S,
     sources: I,
     num_threads: usize,
@@ -135,14 +120,13 @@ where
     // The writer task runs in a blocking thread to avoid blocking the async
     // runtime. It reads from the channel and writes to the sink (doing File IO)
     let captured_recycler = recycler.clone();
-    let captured_progress = progress.clone();
     let writer_task = tokio::task::spawn_blocking(move || {
         // The header is not an output unit; only generated chunks from the channel advance progress.
         sink.sink(&header)?;
         while let Some(buffer) = rx.blocking_recv() {
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
-            captured_progress.increment_output_unit();
+            progress.increment_output_unit();
         }
         // No more input, flush the sink and return
         sink.flush()

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -2,7 +2,6 @@ use super::generate::Sink;
 use super::output_plan::OutputPlanGenerator;
 use super::parquet::IntoSize;
 use super::plan::DEFAULT_PARQUET_ROW_GROUP_BYTES;
-#[cfg(feature = "progress")]
 use super::progress::ProgressTracker;
 use super::runner::PlanRunner;
 use super::statistics::WriteStatistics;
@@ -13,7 +12,6 @@ use std::fs::File;
 use std::io;
 use std::io::{BufWriter, Stdout, Write};
 use std::str::FromStr;
-#[cfg(feature = "progress")]
 use std::sync::Arc;
 use std::time::Instant;
 use tpchgen::distribution::Distributions;
@@ -226,7 +224,6 @@ impl Default for GeneratorConfig {
 /// Use the builder pattern via [`TpchGenerator::builder()`] to configure and create instances.
 pub struct TpchGenerator {
     config: GeneratorConfig,
-    #[cfg(feature = "progress")]
     progress_tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
@@ -239,7 +236,6 @@ impl TpchGenerator {
     /// Generate TPC-H data with the configured settings.
     pub async fn generate(self) -> io::Result<()> {
         let config = self.config;
-        #[cfg(feature = "progress")]
         let progress_tracker = self.progress_tracker;
 
         // Create output directory if it doesn't exist and we are not writing to stdout
@@ -288,7 +284,6 @@ impl TpchGenerator {
         info!("Created static distributions and text pools in {elapsed:?}");
 
         let runner = PlanRunner::new(output_plans, config.num_threads);
-        #[cfg(feature = "progress")]
         let runner = if let Some(tracker) = progress_tracker {
             runner.with_progress_tracker(tracker)
         } else {
@@ -304,7 +299,6 @@ impl TpchGenerator {
 #[derive(Debug, Clone)]
 pub struct TpchGeneratorBuilder {
     config: GeneratorConfig,
-    #[cfg(feature = "progress")]
     progress_tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
@@ -313,7 +307,6 @@ impl TpchGeneratorBuilder {
     pub fn new() -> Self {
         Self {
             config: GeneratorConfig::default(),
-            #[cfg(feature = "progress")]
             progress_tracker: None,
         }
     }
@@ -394,7 +387,6 @@ impl TpchGeneratorBuilder {
     /// The runner calls [`ProgressTracker::finish`] on successful completion.
     /// Trackers that need error or panic cleanup should use `Drop` as a
     /// fallback. See [`crate::tpch_cli::progress`] for the full contract and examples.
-    #[cfg(feature = "progress")]
     pub fn with_progress_tracker(mut self, tracker: Arc<dyn ProgressTracker>) -> Self {
         self.progress_tracker = Some(tracker);
         self
@@ -404,7 +396,6 @@ impl TpchGeneratorBuilder {
     pub fn build(self) -> TpchGenerator {
         TpchGenerator {
             config: self.config,
-            #[cfg(feature = "progress")]
             progress_tracker: self.progress_tracker,
         }
     }
@@ -416,7 +407,7 @@ impl Default for TpchGeneratorBuilder {
     }
 }
 
-#[cfg(all(test, feature = "progress"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::tpch_cli::progress::ProgressTracker;

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -37,38 +37,17 @@ pub async fn generate_parquet<W: Write + Send + IntoSize + 'static, I>(
 where
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
-    let progress = Default::default();
-    generate_parquet_impl(
+    generate_parquet_with_progress(
         writer,
         iter_iter,
         num_threads,
         parquet_compression,
-        progress,
+        TableProgress::default(),
     )
     .await
 }
 
 pub(crate) async fn generate_parquet_with_progress<W: Write + Send + IntoSize + 'static, I>(
-    writer: W,
-    iter_iter: I,
-    num_threads: usize,
-    parquet_compression: Compression,
-    progress: TableProgress,
-) -> Result<(), io::Error>
-where
-    I: Iterator<Item: RecordBatchIterator> + 'static,
-{
-    generate_parquet_impl(
-        writer,
-        iter_iter,
-        num_threads,
-        parquet_compression,
-        progress,
-    )
-    .await
-}
-
-async fn generate_parquet_impl<W: Write + Send + IntoSize + 'static, I>(
     writer: W,
     iter_iter: I,
     num_threads: usize,
@@ -128,7 +107,6 @@ where
         Sender<Vec<ArrowColumnChunk>>,
         Receiver<Vec<ArrowColumnChunk>>,
     ) = tokio::sync::mpsc::channel(num_threads);
-    let captured_progress = progress.clone();
     let writer_task = tokio::task::spawn_blocking(move || {
         // Create parquet writer
         let mut writer =
@@ -146,7 +124,7 @@ where
             }
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
-            captured_progress.increment_output_unit();
+            progress.increment_output_unit();
         }
         let size = writer.into_inner()?.into_size()?;
         statistics.increment_bytes(size);

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -213,7 +213,7 @@ where
         .collect()
 }
 
-#[cfg(all(test, feature = "progress"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::tpch_cli::progress::{ProgressTracker, RunProgress};

--- a/tpcgen-cli/src/tpch_cli/progress.rs
+++ b/tpcgen-cli/src/tpch_cli/progress.rs
@@ -28,15 +28,14 @@
 //! When the `indicatif-progress` feature is enabled (on by default), the
 //! crate provides an `IndicatifProgress` implementation, which renders
 //! one progress bar per table on stderr using the `indicatif` crate.
-//! Library users who do not want to pull in `indicatif` can enable the
-//! `progress` feature directly and supply their own [`ProgressTracker`]
-//! implementation.
+//! Library users who do not want to pull in `indicatif` can disable default
+//! features and still supply their own [`ProgressTracker`] implementation.
+//! Without `indicatif-progress` and without a custom tracker, progress
+//! reporting is a no-op.
 //!
 //! # Example: a custom logging tracker
 //!
 //! ```
-//! # #[cfg(feature = "progress")]
-//! # {
 //! use std::sync::atomic::{AtomicU64, Ordering};
 //! use tpcgen_cli::tpch_cli::progress::ProgressTracker;
 //! use tpcgen_cli::tpch_cli::Table;
@@ -57,16 +56,12 @@
 //!         eprintln!("done: {} output units", self.written.load(Ordering::Relaxed));
 //!     }
 //! }
-//! # }
 //! ```
 
 use crate::tpch_cli::output_plan::OutputPlan;
 use crate::tpch_cli::Table;
-#[cfg(feature = "progress")]
 use std::collections::BTreeMap;
-#[cfg(feature = "progress")]
 use std::fmt;
-#[cfg(feature = "progress")]
 use std::sync::Arc;
 
 /// Receives generation-progress events for one
@@ -77,7 +72,6 @@ use std::sync::Arc;
 /// [`std::sync::Arc`] and shared across concurrent generation tasks, so
 /// they must be `Send + Sync`.
 /// They must also be `Debug` so containing types can derive `Debug`.
-#[cfg(feature = "progress")]
 pub trait ProgressTracker: Send + Sync + fmt::Debug {
     /// Pre-register a table with its total expected output-unit count.
     ///
@@ -107,12 +101,10 @@ pub trait ProgressTracker: Send + Sync + fmt::Debug {
 /// Owns run-level progress lifecycle: registering totals, accounting for
 /// skipped outputs, and finishing the tracker.
 #[derive(Debug, Clone, Default)]
-#[cfg(feature = "progress")]
 pub(crate) struct RunProgress {
     tracker: Option<Arc<dyn ProgressTracker>>,
 }
 
-#[cfg(feature = "progress")]
 impl RunProgress {
     pub(crate) fn with_tracker(tracker: Arc<dyn ProgressTracker>) -> Self {
         Self {
@@ -149,35 +141,15 @@ impl RunProgress {
     }
 }
 
-/// No-op run progress handle used when progress support is disabled.
-#[derive(Debug, Clone, Default)]
-#[cfg(not(feature = "progress"))]
-pub(crate) struct RunProgress;
-
-#[cfg(not(feature = "progress"))]
-impl RunProgress {
-    pub(crate) fn register_totals(&self, _plans: &[OutputPlan]) {}
-
-    pub(crate) fn increment_for_existing(&self, _plan: &OutputPlan) {}
-
-    pub(crate) fn for_table(&self, _table: Table) -> TableProgress {
-        TableProgress
-    }
-
-    pub(crate) fn finish(self) {}
-}
-
 /// Progress handle for one table output stream.
 ///
 /// Used by format writers to report each successfully written output unit
 /// without knowing whether progress tracking is enabled.
 #[derive(Clone, Default)]
-#[cfg(feature = "progress")]
 pub(crate) struct TableProgress {
     tracker: Option<(Arc<dyn ProgressTracker>, Table)>,
 }
 
-#[cfg(feature = "progress")]
 impl TableProgress {
     pub(crate) fn for_table(progress: Option<Arc<dyn ProgressTracker>>, table: Table) -> Self {
         Self {
@@ -190,16 +162,6 @@ impl TableProgress {
             progress.increment(*table, 1);
         }
     }
-}
-
-/// No-op table progress handle used when progress support is disabled.
-#[derive(Clone, Default)]
-#[cfg(not(feature = "progress"))]
-pub(crate) struct TableProgress;
-
-#[cfg(not(feature = "progress"))]
-impl TableProgress {
-    pub(crate) fn increment_output_unit(&self) {}
 }
 
 #[cfg(feature = "indicatif-progress")]
@@ -374,7 +336,7 @@ mod indicatif_impl {
     }
 }
 
-#[cfg(all(test, feature = "progress"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::tpch_cli::Table;

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -5,7 +5,6 @@ use crate::tpch_cli::generate::generate_in_chunks_with_progress;
 use crate::tpch_cli::generate::Source;
 use crate::tpch_cli::output_plan::{OutputLocation, OutputPlan};
 use crate::tpch_cli::parquet::generate_parquet_with_progress;
-#[cfg(feature = "progress")]
 use crate::tpch_cli::progress::ProgressTracker;
 use crate::tpch_cli::progress::RunProgress;
 use crate::tpch_cli::tbl::*;
@@ -14,7 +13,6 @@ use crate::tpch_cli::{OutputFormat, Table, WriterSink};
 use log::{debug, info};
 use std::io;
 use std::io::BufWriter;
-#[cfg(feature = "progress")]
 use std::sync::Arc;
 use tokio::task::{JoinError, JoinSet};
 use tpchgen::generators::{
@@ -53,7 +51,6 @@ impl PlanRunner {
     /// after output units are written, and calls [`ProgressTracker::finish`]
     /// once on the success path. Implementations needing cleanup on the
     /// error or panic path should use `Drop` as a fallback.
-    #[cfg(feature = "progress")]
     pub fn with_progress_tracker(mut self, tracker: Arc<dyn ProgressTracker>) -> Self {
         self.progress = RunProgress::with_tracker(tracker);
         self
@@ -463,7 +460,7 @@ define_run!(
     OrderArrow
 );
 
-#[cfg(all(test, feature = "progress"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::tpch_cli::progress::ProgressTracker;

--- a/tpchgen-cli/Cargo.toml
+++ b/tpchgen-cli/Cargo.toml
@@ -12,7 +12,6 @@ repository = { workspace = true }
 [[bin]]
 name = "tpchgen-cli"
 path = "bin/tpchgen_cli.rs"
-required-features = ["indicatif-progress"]
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }
@@ -21,11 +20,8 @@ tokio = { version = "1.44.1", features = ["full"] }
 
 [features]
 default = ["indicatif-progress"]
-# Enable progress callbacks for applications that want to provide their own
-# progress reporting without pulling in the default terminal progress bars.
-progress = ["tpcgen-cli/progress"]
 # Enable the default CLI terminal progress bars backed by `indicatif`.
-indicatif-progress = ["progress", "tpcgen-cli/indicatif-progress"]
+indicatif-progress = ["tpcgen-cli/indicatif-progress"]
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
- Closes #298

- Remove the `progress` feature and always include the progress reporting API / traits
- When `indicatif-progress` is NOT enabled then there will be a stub progress reporting implementation that doesn't do anything
- When `indicatif-progress` is enabled then there will be a progress reporting implementation that uses `indicatif` to report progress

Overall improves the code quality of Progress tracker implementation (https://github.com/clflushopt/tpchgen-rs/commit/5f652feebc46fa788a8a2f0ea76813f69de74797)
Note that removing `progress` is a breaking change (since it was released as part of v3.0.0), but i think its fine to do so