### PR TITLE
Add all new crates to the publishing workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,5 +1,5 @@
 
-name: tpchgen-publish-crates.yml
+name: publish-crates.yml
 
 on:
   release:
@@ -20,7 +20,10 @@ jobs:
         # Order here is sensitive, as it will be used to determine the order of publishing
         package:
           - "tpchgen"
+          - "tpcdsgen"
           - "tpchgen-arrow"
+          - "tpcdsgen-arrow"
+          - "tpcgen-cli"
           - "tpchgen-cli"
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Part of #287

Add new crates: `tpcdsgen` / `tpcdsgen-arrow` / `tpcgen-cli`
Rename the workflow to `publish-crates.yml`

Note the rename requires us to change the settings in crates.io to update the workflow name, for existing crates:
- https://crates.io/crates/tpchgen
- https://crates.io/crates/tpchgen-arrow
- https://crates.io/crates/tpchgen-cli

I'll do that once this PR merges