### PR TITLE
[tpcgen-cli]: Integrate tpcds dat status output and logging

### DIFF
--- a/tpcgen-cli/src/lib.rs
+++ b/tpcgen-cli/src/lib.rs
@@ -1,3 +1,4 @@
 //! This library contains both the TPCH and TPCDS command line clients.
+mod logging;
 pub mod tpcds_cli;
 pub mod tpch_cli;

--- a/tpcgen-cli/src/logging.rs
+++ b/tpcgen-cli/src/logging.rs
@@ -1,0 +1,28 @@
+use log::{info, LevelFilter};
+use std::io;
+
+pub(crate) fn configure_logging(
+    verbose: bool,
+    quiet: bool,
+    log_writer: Option<Box<dyn io::Write + Send + 'static>>,
+) {
+    let mut builder = env_logger::builder();
+    if quiet {
+        // Quiet mode: only show error-level logs
+        builder.filter_level(LevelFilter::Error);
+    } else if verbose {
+        builder.filter_level(LevelFilter::Info);
+    } else {
+        // Default: show warnings and errors, but respect RUST_LOG if set
+        builder.filter_level(LevelFilter::Warn).parse_default_env();
+    }
+    if let Some(log_writer) = log_writer {
+        builder.target(env_logger::Target::Pipe(log_writer));
+    }
+
+    builder.init();
+
+    if verbose {
+        info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
+    }
+}

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -1,4 +1,5 @@
 //! TPC-DS data generation CLI with a dbgen compatible API.
+use crate::logging::configure_logging;
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
 use std::fmt;
@@ -159,7 +160,7 @@ impl ParquetArgs {
 
 impl CommonArgs {
     fn run_dat(self) -> Result<()> {
-        let _ = self.progress_bars_enabled;
+        configure_logging(self.verbose, self.quiet, None);
         std::fs::create_dir_all(&self.output_dir)?;
         let output_options = dat::OutputOptions::new(self.output_dir.clone())?;
         if let Some(tables) = &self.tables {

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -21,6 +21,7 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use log::info;
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen::error::InvalidOptionError;
 use tpcdsgen::output::CompatWriter;
@@ -97,9 +98,9 @@ impl OutputOptions {
 
 /// Generate TPC-DS data in DAT format.
 pub fn generate(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    println!("TPC-DS Data Generator (Rust)");
-    println!("Scale factor: {}", session.get_scaling().get_scale());
-    println!(
+    info!("TPC-DS Data Generator (Rust)");
+    info!("Scale factor: {}", session.get_scaling().get_scale());
+    info!(
         "Output directory: {}",
         output_options.target_directory.display()
     );
@@ -116,7 +117,7 @@ pub fn generate(session: &Session, output_options: &OutputOptions) -> Result<()>
     }
 
     let elapsed = start.elapsed();
-    println!("\nCompleted in {:.2}s", elapsed.as_secs_f64());
+    info!("Completed in {:.2}s", elapsed.as_secs_f64());
 
     Ok(())
 }
@@ -227,8 +228,7 @@ fn generate_simple<G: RowGeneratorFactory>(
     let file = create_output_file(&path, output_options)?;
     let mut writer = CompatWriter::new(BufWriter::new(file), session.get_compat_mode());
 
-    print!("Generating {}... ", table.get_name());
-    std::io::stdout().flush()?;
+    info!("Generating {}...", table.get_name());
 
     for row_number in 1..=row_count {
         let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
@@ -241,7 +241,12 @@ fn generate_simple<G: RowGeneratorFactory>(
     }
 
     writer.flush()?;
-    println!("{} rows -> {}", row_count, path.display());
+    info!(
+        "Generated {}: {} rows -> {}",
+        table.get_name(),
+        row_count,
+        path.display()
+    );
 
     Ok(())
 }
@@ -264,8 +269,7 @@ fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Re
         compat_mode,
     );
 
-    print!("Generating store_sales + store_returns... ");
-    std::io::stdout().flush()?;
+    info!("Generating store_sales + store_returns...");
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -294,8 +298,8 @@ fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Re
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
+    info!(
+        "Generated store_sales + store_returns: {} sales, {} returns -> {}, {}",
         sales_count,
         returns_count,
         sales_path.display(),
@@ -323,8 +327,7 @@ fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> 
         compat_mode,
     );
 
-    print!("Generating catalog_sales + catalog_returns... ");
-    std::io::stdout().flush()?;
+    info!("Generating catalog_sales + catalog_returns...");
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -353,8 +356,8 @@ fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> 
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
+    info!(
+        "Generated catalog_sales + catalog_returns: {} sales, {} returns -> {}, {}",
         sales_count,
         returns_count,
         sales_path.display(),
@@ -382,8 +385,7 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
         compat_mode,
     );
 
-    print!("Generating web_sales + web_returns... ");
-    std::io::stdout().flush()?;
+    info!("Generating web_sales + web_returns...");
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
@@ -412,8 +414,8 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
     sales_writer.flush()?;
     returns_writer.flush()?;
 
-    println!(
-        "{} sales, {} returns -> {}, {}",
+    info!(
+        "Generated web_sales + web_returns: {} sales, {} returns -> {}, {}",
         sales_count,
         returns_count,
         sales_path.display(),
@@ -440,8 +442,7 @@ fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Resu
         session.get_compat_mode(),
     );
 
-    print!("Generating inventory... ");
-    std::io::stdout().flush()?;
+    info!("Generating inventory...");
 
     for row_number in 1..=num_rows {
         let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
@@ -454,7 +455,11 @@ fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Resu
     }
 
     writer.flush()?;
-    println!("{} rows -> {}", num_rows, path.display());
+    info!(
+        "Generated inventory: {} rows -> {}",
+        num_rows,
+        path.display()
+    );
 
     Ok(())
 }

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -4,9 +4,9 @@ use super::{
     Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
     DEFAULT_PARQUET_ROW_GROUP_BYTES,
 };
+use crate::logging::configure_logging;
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
-use log::{info, LevelFilter};
 use std::io;
 #[cfg(feature = "indicatif-progress")]
 use std::io::IsTerminal;
@@ -410,31 +410,5 @@ impl ParquetArgs {
             .build()
             .generate()
             .await
-    }
-}
-
-fn configure_logging(
-    verbose: bool,
-    quiet: bool,
-    log_writer: Option<Box<dyn io::Write + Send + 'static>>,
-) {
-    let mut builder = env_logger::builder();
-    if quiet {
-        // Quiet mode: only show error-level logs
-        builder.filter_level(LevelFilter::Error);
-    } else if verbose {
-        builder.filter_level(LevelFilter::Info);
-    } else {
-        // Default: show warnings and errors, but respect RUST_LOG if set
-        builder.filter_level(LevelFilter::Warn).parse_default_env();
-    }
-    if let Some(log_writer) = log_writer {
-        builder.target(env_logger::Target::Pipe(log_writer));
-    }
-
-    builder.init();
-
-    if verbose {
-        info!("Verbose output enabled (ignoring RUST_LOG environment variable)");
     }
 }

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -2,6 +2,80 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use std::fs;
 use tempfile::tempdir;
 
+/// Test that TPC-DS DAT generation is quiet unless logging is explicitly enabled.
+#[test]
+fn test_tpcgen_cli_tpcds_dat_is_quiet_by_default() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("dat")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .env_remove("RUST_LOG")
+        .assert()
+        .success();
+
+    assert!(
+        assert.get_output().stdout.is_empty(),
+        "Expected TPC-DS DAT generation to write no stdout by default, got: {}",
+        String::from_utf8_lossy(&assert.get_output().stdout)
+    );
+    assert!(
+        assert.get_output().stderr.is_empty(),
+        "Expected TPC-DS DAT generation to write no stderr by default, got: {}",
+        String::from_utf8_lossy(&assert.get_output().stderr)
+    );
+}
+
+/// Test that TPC-DS DAT verbose mode enables status logging on stderr.
+#[test]
+fn test_tpcgen_cli_tpcds_dat_verbose_enables_status_logging() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("dat")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("-v")
+        .env("RUST_LOG", "warn")
+        .assert()
+        .success();
+
+    assert!(
+        assert.get_output().stdout.is_empty(),
+        "Expected verbose TPC-DS DAT logging to use stderr, got stdout: {}",
+        String::from_utf8_lossy(&assert.get_output().stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Verbose output enabled (ignoring RUST_LOG environment variable)"),
+        "Expected verbose mode setup log, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("TPC-DS Data Generator (Rust)"),
+        "Expected TPC-DS generator status log, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Generating reason..."),
+        "Expected TPC-DS table start log, got stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Generated reason: 1 rows ->"),
+        "Expected TPC-DS table completion log, got stderr: {stderr}"
+    );
+}
+
 /// Test multiple TPC-DS table selection and the default DAT command form.
 #[test]
 fn test_tpcgen_cli_tpcds_dat_multiple_table_selection_command_forms() {


### PR DESCRIPTION
## Summary

This consolidates debug logging for tpch/tpcds generators (the `-v` command to enable them)

Example new behavior
```shell
# No output
cargo run --release --bin tpcgen-cli -- tpcds dat -s 0.01
    Finished `release` profile [optimized] target(s) in 0.16s
     Running `target/release/tpcgen-cli tpcds dat -s 0.01`
```

With -v argument (logging)
```shell
cargo run --release --bin tpcgen-cli -- tpcds dat -v -s 0.01
    Finished `release` profile [optimized] target(s) in 0.07s
     Running `target/release/tpcgen-cli tpcds dat -v -s 0.01`
[2026-07-04T11:06:59Z INFO  tpcgen_cli::logging] Verbose output enabled (ignoring RUST_LOG environment variable)
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] TPC-DS Data Generator (Rust)
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Scale factor: 0.01
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Output directory: .
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Generating call_center...
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Generated call_center: 2 rows -> ./call_center.dat
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Generating catalog_page...
[2026-07-04T11:06:59Z INFO  tpcgen_cli::tpcds_cli::dat] Generated catalog_page: 11718 rows -> ./catalog_page.dat
...
[2026-07-04T11:07:02Z INFO  tpcgen_cli::tpcds_cli::dat] Generating web_site...
[2026-07-04T11:07:02Z INFO  tpcgen_cli::tpcds_cli::dat] Generated web_site: 2 rows -> ./web_site.dat
[2026-07-04T11:07:02Z INFO  tpcgen_cli::tpcds_cli::dat] Generating dbgen_version...
[2026-07-04T11:07:02Z INFO  tpcgen_cli::tpcds_cli::dat] Generated dbgen_version: 1 rows -> ./dbgen_version.dat
[2026-07-04T11:07:02Z INFO  tpcgen_cli::tpcds_cli::dat] Completed in 2.91s
andrewlamb@Andrews-MacBook-Pro-3:~/Software/tpchgen-rs$
```


Previously this would have printed to stdout
>
> ```text
> cargo run --bin tpcgen-cli -- tpcds dat -s 0.01
>    Compiling tpcgen-cli v0.1.0 (/Users/andrewlamb/Software/tpchgen-rs/tpcgen-cli)
>     Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.34s
>      Running `target/debug/tpcgen-cli tpcds dat -s 0.01`
> TPC-DS Data Generator (Rust)
> Scale factor: 0.01
> Output directory: .
> Generating call_center... 2 rows -> ./call_center.dat
> Generating catalog_page... 11718 rows -> ./catalog_page.dat
> Generating catalog_sales + catalog_returns... ^C
> ```
