### PR TITLE
[tpcgen-cli]: support TPC-DS CSV generation

### DIFF
--- a/tpcgen-cli/Cargo.toml
+++ b/tpcgen-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "bin/tpcgen_cli.rs"
 
 [dependencies]
 arrow = "59"
+arrow-csv = { workspace = true }
 clap = { version = "4.5.32", features = ["derive"] }
 env_logger = "0.11.7"
 futures = "0.3.31"

--- a/tpcgen-cli/README.md
+++ b/tpcgen-cli/README.md
@@ -15,4 +15,6 @@ pip install tpcgen-cli
 tpcgen-cli tpch -s 1 --output-dir /tmp/tpch
 tpcgen-cli tpch csv -s 1 --output-dir /tmp/tpch
 tpcgen-cli tpch parquet -s 100 --tables lineitem --parts 10 --output-dir /tmp/tpch
+tpcgen-cli tpcds csv -s 1 --output-dir /tmp/tpcds
+tpcgen-cli tpcds csv -s 1 --delimiter='\t' --output-dir /tmp/tpcds
 ```

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -2,16 +2,15 @@
 use crate::logging::configure_logging;
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
-use std::fmt;
 use std::path::PathBuf;
 use tpcdsgen::config::{CompatMode, Session, SessionBuilder, Table};
 use tpcdsgen::error::TpcdsError;
 
+pub mod csv;
 pub mod dat;
 pub mod parquet;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-const NOT_IMPLEMENTED: &str = "TPC-DS data generation is not yet implemented";
 
 #[derive(Args)]
 #[command(version)]
@@ -147,8 +146,7 @@ impl DatArgs {
 
 impl CsvArgs {
     fn run(self) -> Result<()> {
-        let _ = self.delimiter;
-        self.common.run_not_implemented()
+        self.common.run_csv(self.delimiter)
     }
 }
 
@@ -182,6 +180,19 @@ impl CommonArgs {
         for table in self.tables()? {
             let session = self.to_session(Some(table.get_name().to_string()))?;
             parquet::generate_table(table, session, self.output_dir.clone(), compression)?;
+        }
+
+        Ok(())
+    }
+
+    fn run_csv(self, delimiter: char) -> Result<()> {
+        configure_logging(self.verbose, self.quiet, None);
+        let _ = self.progress_bars_enabled;
+        std::fs::create_dir_all(&self.output_dir)?;
+
+        for table in self.tables()? {
+            let session = self.to_session(Some(table.get_name().to_string()))?;
+            csv::generate_table(table, session, self.output_dir.clone(), delimiter)?;
         }
 
         Ok(())
@@ -222,11 +233,6 @@ impl CommonArgs {
 
         Ok(builder.build()?)
     }
-
-    fn run_not_implemented(self) -> Result<()> {
-        let _ = self;
-        Err(Box::new(NotImplemented))
-    }
 }
 
 fn parse_table(table: &str) -> Result<Table> {
@@ -255,22 +261,6 @@ fn expected_table_names() -> String {
         .collect::<Vec<_>>()
         .join(", ")
 }
-
-struct NotImplemented;
-
-impl fmt::Display for NotImplemented {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(NOT_IMPLEMENTED)
-    }
-}
-
-impl fmt::Debug for NotImplemented {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl std::error::Error for NotImplemented {}
 
 fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
     let parsed = match s {

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -1,9 +1,11 @@
 //! TPC-DS CSV output.
 
+use arrow::array::RecordBatch;
 use arrow_csv::writer::WriterBuilder;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen_arrow::{
     CallCenterArrow, CatalogPageArrow, CatalogReturnsArrow, CatalogSalesArrow,
@@ -69,13 +71,15 @@ where
     let temp_path = path.with_extension("inprogress");
     let file = File::create(&temp_path)
         .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
-    let mut writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
-    write_header(&mut writer, batches.schema().fields(), delimiter)?;
+    let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
 
     let mut writer = WriterBuilder::new()
-        .with_header(false)
+        .with_header(true)
         .with_delimiter(delimiter as u8)
         .build(writer);
+
+    // Write the header first.
+    writer.write(&RecordBatch::new_empty(Arc::clone(batches.schema())))?;
 
     for batch in &mut batches {
         writer.write(&batch)?;
@@ -91,18 +95,4 @@ where
     })?;
 
     Ok(())
-}
-
-fn write_header(
-    writer: &mut dyn Write,
-    fields: &arrow::datatypes::Fields,
-    delimiter: char,
-) -> io::Result<()> {
-    for (index, field) in fields.iter().enumerate() {
-        if index > 0 {
-            write!(writer, "{delimiter}")?;
-        }
-        write!(writer, "{}", field.name())?;
-    }
-    writeln!(writer)
 }

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -1,0 +1,108 @@
+//! TPC-DS CSV output.
+
+use arrow_csv::writer::WriterBuilder;
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+use tpcdsgen::config::{Session, Table};
+use tpcdsgen_arrow::{
+    CallCenterArrow, CatalogPageArrow, CatalogReturnsArrow, CatalogSalesArrow,
+    CustomerAddressArrow, CustomerArrow, CustomerDemographicsArrow, DateDimArrow,
+    DbgenVersionArrow, HouseholdDemographicsArrow, IncomeBandArrow, InventoryArrow, ItemArrow,
+    PromotionArrow, ReasonArrow, RecordBatchIterator, ShipModeArrow, StoreArrow, StoreReturnsArrow,
+    StoreSalesArrow, TimeDimArrow, WarehouseArrow, WebPageArrow, WebReturnsArrow, WebSalesArrow,
+    WebSiteArrow,
+};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Generate one TPC-DS table as a CSV file in `output_dir`.
+pub fn generate_table(
+    table: Table,
+    session: Session,
+    output_dir: PathBuf,
+    delimiter: char,
+) -> Result<()> {
+    let path = output_dir.join(format!("{}.csv", table.get_name()));
+
+    match table {
+        Table::CallCenter => write_batches(path, CallCenterArrow::new(session), delimiter),
+        Table::CatalogPage => write_batches(path, CatalogPageArrow::new(session), delimiter),
+        Table::CatalogReturns => write_batches(path, CatalogReturnsArrow::new(session), delimiter),
+        Table::CatalogSales => write_batches(path, CatalogSalesArrow::new(session), delimiter),
+        Table::Customer => write_batches(path, CustomerArrow::new(session), delimiter),
+        Table::CustomerAddress => {
+            write_batches(path, CustomerAddressArrow::new(session), delimiter)
+        }
+        Table::CustomerDemographics => {
+            write_batches(path, CustomerDemographicsArrow::new(session), delimiter)
+        }
+        Table::DateDim => write_batches(path, DateDimArrow::new(session), delimiter),
+        Table::DbgenVersion => write_batches(path, DbgenVersionArrow::new(session), delimiter),
+        Table::HouseholdDemographics => {
+            write_batches(path, HouseholdDemographicsArrow::new(session), delimiter)
+        }
+        Table::IncomeBand => write_batches(path, IncomeBandArrow::new(session), delimiter),
+        Table::Inventory => write_batches(path, InventoryArrow::new(session), delimiter),
+        Table::Item => write_batches(path, ItemArrow::new(session), delimiter),
+        Table::Promotion => write_batches(path, PromotionArrow::new(session), delimiter),
+        Table::Reason => write_batches(path, ReasonArrow::new(session), delimiter),
+        Table::ShipMode => write_batches(path, ShipModeArrow::new(session), delimiter),
+        Table::Store => write_batches(path, StoreArrow::new(session), delimiter),
+        Table::StoreReturns => write_batches(path, StoreReturnsArrow::new(session), delimiter),
+        Table::StoreSales => write_batches(path, StoreSalesArrow::new(session), delimiter),
+        Table::TimeDim => write_batches(path, TimeDimArrow::new(session), delimiter),
+        Table::Warehouse => write_batches(path, WarehouseArrow::new(session), delimiter),
+        Table::WebPage => write_batches(path, WebPageArrow::new(session), delimiter),
+        Table::WebReturns => write_batches(path, WebReturnsArrow::new(session), delimiter),
+        Table::WebSales => write_batches(path, WebSalesArrow::new(session), delimiter),
+        Table::WebSite => write_batches(path, WebSiteArrow::new(session), delimiter),
+        _ => Ok(()),
+    }
+}
+
+/// Write the record batches to a CSV file at the specified path.
+fn write_batches<I>(path: PathBuf, mut batches: I, delimiter: char) -> Result<()>
+where
+    I: RecordBatchIterator,
+{
+    let temp_path = path.with_extension("inprogress");
+    let file = File::create(&temp_path)
+        .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
+    let mut writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
+    write_header(&mut writer, batches.schema().fields(), delimiter)?;
+
+    let mut writer = WriterBuilder::new()
+        .with_header(false)
+        .with_delimiter(delimiter as u8)
+        .build(writer);
+
+    for batch in &mut batches {
+        writer.write(&batch)?;
+    }
+
+    let mut writer = writer.into_inner();
+    writer.flush()?;
+
+    std::fs::rename(&temp_path, &path).map_err(|err| {
+        io::Error::other(format!(
+            "Failed to rename {temp_path:?} to {path:?} file: {err}"
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn write_header(
+    writer: &mut dyn Write,
+    fields: &arrow::datatypes::Fields,
+    delimiter: char,
+) -> io::Result<()> {
+    for (index, field) in fields.iter().enumerate() {
+        if index > 0 {
+            write!(writer, "{delimiter}")?;
+        }
+        write!(writer, "{}", field.name())?;
+    }
+    writeln!(writer)
+}

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -421,6 +421,40 @@ fn test_tpcgen_cli_tpcds_csv_custom_delimiter() {
     );
 }
 
+/// Test that TPC-DS CSV generation escapes headers containing the delimiter.
+#[test]
+fn test_tpcgen_cli_tpcds_csv_delimiter_in_header_is_escaped() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("csv")
+        .arg("--delimiter")
+        .arg("_")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let contents =
+        fs::read_to_string(temp_dir.path().join("reason.csv")).expect("Failed to read CSV file");
+    let first_line = contents.lines().next().expect("CSV output is empty");
+    let second_line = contents.lines().nth(1).expect("CSV data row is missing");
+    assert_eq!(
+        first_line,
+        "\"r_reason_sk\"_\"r_reason_id\"_\"r_reason_description\""
+    );
+    assert_eq!(
+        second_line.split('_').count(),
+        3,
+        "Expected underscore-delimited data rows to have three fields: {second_line}"
+    );
+}
+
 /// Test that default CSV output options generate every main TPC-DS output file.
 #[test]
 fn test_tpcgen_cli_tpcds_csv_default_options_generate_all_outputs() {

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -350,42 +350,156 @@ fn test_tpcgen_cli_tpcds_dat_default_options_generate_all_outputs() {
     );
 }
 
-/// Test that non implemented TPC-DS command forms report generation is unavailable.
+/// Test that TPC-DS CSV generation writes a headered CSV file for one table.
 #[test]
-fn test_tpcgen_cli_tpcds_csv_not_implemented() {
-    let forms: &[(&[&str], &[&str], &str)] =
-        &[(&["tpcds", "csv"], &["--delimiter", "|"], "reason.csv")];
+fn test_tpcgen_cli_tpcds_csv_single_table() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-    for (form, format_args, unexpected_file) in forms {
-        let temp_dir = tempdir().expect("Failed to create temporary directory");
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("csv")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
 
-        let assert = cargo_bin_cmd!("tpcgen-cli")
-            .args(*form)
-            .arg("--scale-factor")
-            .arg("1")
-            .arg("--tables")
-            .arg("reason")
-            .arg("--output-dir")
-            .arg(temp_dir.path())
-            .arg("--quiet")
-            .args(*format_args)
-            .assert()
-            .failure();
+    let csv_file = temp_dir.path().join("reason.csv");
+    assert!(csv_file.exists(), "Expected {:?} to exist", csv_file);
 
-        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-        assert!(
-            stderr.contains("TPC-DS data generation is not yet implemented"),
-            "Expected `tpcgen-cli {}` to report that TPC-DS generation is not implemented, got stderr: {}",
-            form.join(" "),
-            stderr
-        );
+    let contents = fs::read_to_string(&csv_file).expect("Failed to read CSV file");
+    let lines: Vec<_> = contents.lines().collect();
+    assert_eq!(
+        lines.first(),
+        Some(&"r_reason_sk,r_reason_id,r_reason_description")
+    );
+    assert_eq!(
+        lines.len(),
+        36,
+        "Expected CSV header plus 35 reason rows at scale factor 1"
+    );
+    assert!(
+        lines.iter().all(|line| !line.ends_with(',')),
+        "Expected CSV rows not to end with a trailing delimiter, got:\n{contents}"
+    );
+}
 
-        let unexpected_file = temp_dir.path().join(unexpected_file);
-        assert!(
-            !unexpected_file.exists(),
-            "Expected `tpcgen-cli {}` not to create {:?}",
-            form.join(" "),
-            unexpected_file
-        );
-    }
+/// Test that TPC-DS CSV generation supports a custom delimiter.
+#[test]
+fn test_tpcgen_cli_tpcds_csv_custom_delimiter() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("csv")
+        .arg("--delimiter")
+        .arg("\\t")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let contents =
+        fs::read_to_string(temp_dir.path().join("reason.csv")).expect("Failed to read CSV file");
+    let first_line = contents.lines().next().expect("CSV output is empty");
+    assert_eq!(first_line, "r_reason_sk\tr_reason_id\tr_reason_description");
+    assert!(
+        !first_line.contains(','),
+        "Expected custom-delimited CSV header not to use commas: {first_line}"
+    );
+    assert_eq!(
+        first_line.matches('\t').count(),
+        2,
+        "Expected exactly two tab delimiters in the reason header"
+    );
+}
+
+/// Test that default CSV output options generate every main TPC-DS output file.
+#[test]
+fn test_tpcgen_cli_tpcds_csv_default_options_generate_all_outputs() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("csv")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let expected_files: BTreeSet<_> = [
+        "call_center.csv",
+        "catalog_page.csv",
+        "catalog_returns.csv",
+        "catalog_sales.csv",
+        "customer.csv",
+        "customer_address.csv",
+        "customer_demographics.csv",
+        "date_dim.csv",
+        "dbgen_version.csv",
+        "household_demographics.csv",
+        "income_band.csv",
+        "inventory.csv",
+        "item.csv",
+        "promotion.csv",
+        "reason.csv",
+        "ship_mode.csv",
+        "store.csv",
+        "store_returns.csv",
+        "store_sales.csv",
+        "time_dim.csv",
+        "warehouse.csv",
+        "web_page.csv",
+        "web_returns.csv",
+        "web_sales.csv",
+        "web_site.csv",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    let actual_files = fs::read_dir(temp_dir.path())
+        .expect("Failed to read generated output directory")
+        .map(|entry| {
+            entry
+                .expect("Failed to read generated output directory entry")
+                .file_name()
+                .into_string()
+                .expect("Generated output file name is not valid UTF-8")
+        })
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        actual_files, expected_files,
+        "Expected default TPC-DS CSV generation to produce every main table"
+    );
+}
+
+/// Test that the TPC-DS CSV subcommand rejects a non-ASCII delimiter at parse time.
+#[test]
+fn test_tpcgen_cli_tpcds_csv_rejects_non_ascii_delimiter() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("csv")
+        .arg("--delimiter")
+        .arg("€")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("ASCII"));
 }


### PR DESCRIPTION
Closes #309
Really cool to just tell the agent to follow existing patterns 😄 

## Summary

Adds TPC-DS csv output support to `tpcgen-cli` using the existing `tpcdsgen-arrow` Arrow record batch generators and `arrow-csv` writer support.

This enables commands such as:
```
cargo run --bin tpcgen-cli -- tpcds csv
cargo run --bin tpcgen-cli -- tpcds csv --delimiter '\t'
```
<img width="1403" height="872" alt="Screenshot 2026-07-04 at 11 53 51 AM" src="https://github.com/user-attachments/assets/d08825c2-966b-4df9-9c0f-28aaab3235c3" />

## Details

• Wires the `tpcds csv` subcommand
• Adds TPC-DS csv output generation using `tpcdsgen-arrow` schemas and record batches
• Supports configurable csv delimiters via `--delimiter`
• Adds TPC-DS csv CLI integration coverage in `tests/cli_integration/tpcds.rs`
• Documents TPC-DS csv usage in `tpcgen-cli/README.md`

## Validation

CI