### PR TITLE
Refactor TPC-DS output dispatch

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -12,6 +12,12 @@ pub mod parquet;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+enum OutputFormat {
+    Dat(dat::Dat),
+    Csv(csv::Csv),
+    Parquet(parquet::Parquet),
+}
+
 #[derive(Args)]
 #[command(version)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -160,39 +166,29 @@ impl ParquetArgs {
 impl CommonArgs {
     fn run_dat(self) -> Result<()> {
         configure_logging(self.verbose, self.quiet, None);
-        std::fs::create_dir_all(&self.output_dir)?;
-        let output_options = dat::OutputOptions::new(self.output_dir.clone())?;
-        if let Some(tables) = &self.tables {
-            for table in tables {
-                self.run_dat_for_table(Some(table.clone()), &output_options)?;
-            }
-        } else {
-            self.run_dat_for_table(None, &output_options)?;
-        }
-
-        Ok(())
+        let output = dat::Dat::new(self.output_dir.clone())?;
+        self.run_output(OutputFormat::Dat(output))
     }
 
     fn run_parquet(self, compression: Compression) -> Result<()> {
         let _ = self.progress_bars_enabled;
-        std::fs::create_dir_all(&self.output_dir)?;
-
-        for table in self.tables()? {
-            let session = self.to_session(Some(table.get_name().to_string()))?;
-            parquet::generate_table(table, session, self.output_dir.clone(), compression)?;
-        }
-
-        Ok(())
+        let output = parquet::Parquet::new(self.output_dir.clone(), compression);
+        self.run_output(OutputFormat::Parquet(output))
     }
 
     fn run_csv(self, delimiter: char) -> Result<()> {
         configure_logging(self.verbose, self.quiet, None);
         let _ = self.progress_bars_enabled;
+        let output = csv::Csv::new(self.output_dir.clone(), delimiter);
+        self.run_output(OutputFormat::Csv(output))
+    }
+
+    fn run_output(self, output_format: OutputFormat) -> Result<()> {
         std::fs::create_dir_all(&self.output_dir)?;
 
         for table in self.tables()? {
             let session = self.to_session(Some(table.get_name().to_string()))?;
-            csv::generate_table(table, session, self.output_dir.clone(), delimiter)?;
+            output_format.generate_table(table, session)?;
         }
 
         Ok(())
@@ -205,15 +201,6 @@ impl CommonArgs {
         } else {
             Ok(Table::main_tables())
         }
-    }
-
-    fn run_dat_for_table(
-        &self,
-        table: Option<String>,
-        output_options: &dat::OutputOptions,
-    ) -> Result<()> {
-        let session = self.to_session(table)?;
-        dat::generate(&session, output_options)
     }
 
     fn to_session(&self, table: Option<String>) -> Result<Session> {
@@ -232,6 +219,16 @@ impl CommonArgs {
         }
 
         Ok(builder.build()?)
+    }
+}
+
+impl OutputFormat {
+    fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+        match self {
+            OutputFormat::Dat(output) => output.generate_table(table, &session),
+            OutputFormat::Csv(output) => output.generate_table(table, session),
+            OutputFormat::Parquet(output) => output.generate_table(table, session),
+        }
     }
 }
 

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -18,81 +18,90 @@ use tpcdsgen_arrow::{
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Generate one TPC-DS table as a CSV file in `output_dir`.
-pub fn generate_table(
-    table: Table,
-    session: Session,
+/// CSV output generator.
+#[derive(Debug, Clone)]
+pub(super) struct Csv {
     output_dir: PathBuf,
     delimiter: char,
-) -> Result<()> {
-    let path = output_dir.join(format!("{}.csv", table.get_name()));
-
-    match table {
-        Table::CallCenter => write_batches(path, CallCenterArrow::new(session), delimiter),
-        Table::CatalogPage => write_batches(path, CatalogPageArrow::new(session), delimiter),
-        Table::CatalogReturns => write_batches(path, CatalogReturnsArrow::new(session), delimiter),
-        Table::CatalogSales => write_batches(path, CatalogSalesArrow::new(session), delimiter),
-        Table::Customer => write_batches(path, CustomerArrow::new(session), delimiter),
-        Table::CustomerAddress => {
-            write_batches(path, CustomerAddressArrow::new(session), delimiter)
-        }
-        Table::CustomerDemographics => {
-            write_batches(path, CustomerDemographicsArrow::new(session), delimiter)
-        }
-        Table::DateDim => write_batches(path, DateDimArrow::new(session), delimiter),
-        Table::DbgenVersion => write_batches(path, DbgenVersionArrow::new(session), delimiter),
-        Table::HouseholdDemographics => {
-            write_batches(path, HouseholdDemographicsArrow::new(session), delimiter)
-        }
-        Table::IncomeBand => write_batches(path, IncomeBandArrow::new(session), delimiter),
-        Table::Inventory => write_batches(path, InventoryArrow::new(session), delimiter),
-        Table::Item => write_batches(path, ItemArrow::new(session), delimiter),
-        Table::Promotion => write_batches(path, PromotionArrow::new(session), delimiter),
-        Table::Reason => write_batches(path, ReasonArrow::new(session), delimiter),
-        Table::ShipMode => write_batches(path, ShipModeArrow::new(session), delimiter),
-        Table::Store => write_batches(path, StoreArrow::new(session), delimiter),
-        Table::StoreReturns => write_batches(path, StoreReturnsArrow::new(session), delimiter),
-        Table::StoreSales => write_batches(path, StoreSalesArrow::new(session), delimiter),
-        Table::TimeDim => write_batches(path, TimeDimArrow::new(session), delimiter),
-        Table::Warehouse => write_batches(path, WarehouseArrow::new(session), delimiter),
-        Table::WebPage => write_batches(path, WebPageArrow::new(session), delimiter),
-        Table::WebReturns => write_batches(path, WebReturnsArrow::new(session), delimiter),
-        Table::WebSales => write_batches(path, WebSalesArrow::new(session), delimiter),
-        Table::WebSite => write_batches(path, WebSiteArrow::new(session), delimiter),
-        _ => Ok(()),
-    }
 }
 
-/// Write the record batches to a CSV file at the specified path.
-fn write_batches<I>(path: PathBuf, mut batches: I, delimiter: char) -> Result<()>
-where
-    I: RecordBatchIterator,
-{
-    let temp_path = path.with_extension("inprogress");
-    let file = File::create(&temp_path)
-        .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
-    let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
-
-    let mut writer = WriterBuilder::new()
-        .with_header(true)
-        .with_delimiter(delimiter as u8)
-        .build(writer);
-
-    // Write the header first.
-    writer.write(&RecordBatch::new_empty(Arc::clone(batches.schema())))?;
-
-    for batch in &mut batches {
-        writer.write(&batch)?;
+impl Csv {
+    pub(super) fn new(output_dir: PathBuf, delimiter: char) -> Self {
+        Self {
+            output_dir,
+            delimiter,
+        }
     }
 
-    let mut writer = writer.into_inner();
-    writer.flush()?;
+    /// Generate one TPC-DS table as a CSV file.
+    pub(super) fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+        let path = self.output_dir.join(format!("{}.csv", table.get_name()));
 
-    std::fs::rename(&temp_path, &path).map_err(|err| {
-        io::Error::other(format!(
-            "Failed to rename {temp_path:?} to {path:?} file: {err}"
-        ))
-    })?;
+        match table {
+            Table::CallCenter => self.write_batches(path, CallCenterArrow::new(session)),
+            Table::CatalogPage => self.write_batches(path, CatalogPageArrow::new(session)),
+            Table::CatalogReturns => self.write_batches(path, CatalogReturnsArrow::new(session)),
+            Table::CatalogSales => self.write_batches(path, CatalogSalesArrow::new(session)),
+            Table::Customer => self.write_batches(path, CustomerArrow::new(session)),
+            Table::CustomerAddress => self.write_batches(path, CustomerAddressArrow::new(session)),
+            Table::CustomerDemographics => {
+                self.write_batches(path, CustomerDemographicsArrow::new(session))
+            }
+            Table::DateDim => self.write_batches(path, DateDimArrow::new(session)),
+            Table::DbgenVersion => self.write_batches(path, DbgenVersionArrow::new(session)),
+            Table::HouseholdDemographics => {
+                self.write_batches(path, HouseholdDemographicsArrow::new(session))
+            }
+            Table::IncomeBand => self.write_batches(path, IncomeBandArrow::new(session)),
+            Table::Inventory => self.write_batches(path, InventoryArrow::new(session)),
+            Table::Item => self.write_batches(path, ItemArrow::new(session)),
+            Table::Promotion => self.write_batches(path, PromotionArrow::new(session)),
+            Table::Reason => self.write_batches(path, ReasonArrow::new(session)),
+            Table::ShipMode => self.write_batches(path, ShipModeArrow::new(session)),
+            Table::Store => self.write_batches(path, StoreArrow::new(session)),
+            Table::StoreReturns => self.write_batches(path, StoreReturnsArrow::new(session)),
+            Table::StoreSales => self.write_batches(path, StoreSalesArrow::new(session)),
+            Table::TimeDim => self.write_batches(path, TimeDimArrow::new(session)),
+            Table::Warehouse => self.write_batches(path, WarehouseArrow::new(session)),
+            Table::WebPage => self.write_batches(path, WebPageArrow::new(session)),
+            Table::WebReturns => self.write_batches(path, WebReturnsArrow::new(session)),
+            Table::WebSales => self.write_batches(path, WebSalesArrow::new(session)),
+            Table::WebSite => self.write_batches(path, WebSiteArrow::new(session)),
+            _ => Ok(()),
+        }
+    }
 
-    Ok(())
+    /// Write the record batches to a CSV file at the specified path.
+    fn write_batches<I>(&self, path: PathBuf, mut batches: I) -> Result<()>
+    where
+        I: RecordBatchIterator,
+    {
+        let temp_path = path.with_extension("inprogress");
+        let file = File::create(&temp_path)
+            .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
+        let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
+
+        let mut writer = WriterBuilder::new()
+            .with_header(true)
+            .with_delimiter(self.delimiter as u8)
+            .build(writer);
+
+        // Write the header first.
+        writer.write(&RecordBatch::new_empty(Arc::clone(batches.schema())))?;
+
+        for batch in &mut batches {
+            writer.write(&batch)?;
+        }
+
+        let mut writer = writer.into_inner();
+        writer.flush()?;
+
+        std::fs::rename(&temp_path, &path).map_err(|err| {
+            io::Error::other(format!(
+                "Failed to rename {temp_path:?} to {path:?} file: {err}"
+            ))
+        })?;
+
+        Ok(())
+    }
 }

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -19,7 +19,6 @@
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::time::Instant;
 
 use log::info;
 use tpcdsgen::config::{Session, Table};
@@ -32,7 +31,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// DAT output configuration owned by the CLI layer.
 #[derive(Debug, Clone)]
-pub struct OutputOptions {
+struct OutputOptions {
     target_directory: PathBuf,
     suffix: String,
     null_string: String,
@@ -43,14 +42,14 @@ pub struct OutputOptions {
 }
 
 impl OutputOptions {
-    pub const DEFAULT_SUFFIX: &'static str = ".dat";
-    pub const DEFAULT_NULL_STRING: &'static str = "";
-    pub const DEFAULT_SEPARATOR: char = '|';
-    pub const DEFAULT_DO_NOT_TERMINATE: bool = false;
-    pub const DEFAULT_PARALLELISM: i32 = 1;
-    pub const DEFAULT_OVERWRITE: bool = true;
+    const DEFAULT_SUFFIX: &'static str = ".dat";
+    const DEFAULT_NULL_STRING: &'static str = "";
+    const DEFAULT_SEPARATOR: char = '|';
+    const DEFAULT_DO_NOT_TERMINATE: bool = false;
+    const DEFAULT_PARALLELISM: i32 = 1;
+    const DEFAULT_OVERWRITE: bool = true;
 
-    pub fn new(target_directory: PathBuf) -> Result<Self> {
+    fn new(target_directory: PathBuf) -> Result<Self> {
         let options = Self {
             target_directory,
             suffix: Self::DEFAULT_SUFFIX.to_string(),
@@ -96,85 +95,95 @@ impl OutputOptions {
     }
 }
 
-/// Generate TPC-DS data in DAT format.
-pub fn generate(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    info!("TPC-DS Data Generator (Rust)");
-    info!("Scale factor: {}", session.get_scaling().get_scale());
-    info!(
-        "Output directory: {}",
-        output_options.target_directory.display()
-    );
-
-    let start = Instant::now();
-
-    if session.generate_only_one_table() {
-        let table = session.get_only_table_to_generate();
-        generate_table(table, session, output_options)?;
-    } else {
-        for table in Table::main_tables() {
-            generate_table(table, session, output_options)?;
-        }
-    }
-
-    let elapsed = start.elapsed();
-    info!("Completed in {:.2}s", elapsed.as_secs_f64());
-
-    Ok(())
+/// DAT output generator.
+#[derive(Debug, Clone)]
+pub(super) struct Dat {
+    output_options: OutputOptions,
 }
 
-fn generate_table(table: Table, session: &Session, output_options: &OutputOptions) -> Result<()> {
-    match table {
-        // Simple dimension tables
-        Table::CallCenter => {
-            generate_simple::<CallCenterRowGenerator>(table, session, output_options)
-        }
-        Table::CatalogPage => {
-            generate_simple::<CatalogPageRowGenerator>(table, session, output_options)
-        }
-        Table::Customer => generate_simple::<CustomerRowGenerator>(table, session, output_options),
-        Table::CustomerAddress => {
-            generate_simple::<CustomerAddressRowGenerator>(table, session, output_options)
-        }
-        Table::CustomerDemographics => {
-            generate_simple::<CustomerDemographicsRowGenerator>(table, session, output_options)
-        }
-        Table::DateDim => generate_simple::<DateDimRowGenerator>(table, session, output_options),
-        Table::DbgenVersion => {
-            generate_simple::<DbgenVersionRowGenerator>(table, session, output_options)
-        }
-        Table::HouseholdDemographics => {
-            generate_simple::<HouseholdDemographicsRowGenerator>(table, session, output_options)
-        }
-        Table::IncomeBand => {
-            generate_simple::<IncomeBandRowGenerator>(table, session, output_options)
-        }
-        Table::Item => generate_simple::<ItemRowGenerator>(table, session, output_options),
-        Table::Promotion => {
-            generate_simple::<PromotionRowGenerator>(table, session, output_options)
-        }
-        Table::Reason => generate_simple::<ReasonRowGenerator>(table, session, output_options),
-        Table::ShipMode => generate_simple::<ShipModeRowGenerator>(table, session, output_options),
-        Table::Store => generate_simple::<StoreRowGenerator>(table, session, output_options),
-        Table::TimeDim => generate_simple::<TimeDimRowGenerator>(table, session, output_options),
-        Table::Warehouse => {
-            generate_simple::<WarehouseRowGenerator>(table, session, output_options)
-        }
-        Table::WebPage => generate_simple::<WebPageRowGenerator>(table, session, output_options),
-        Table::WebSite => generate_simple::<WebSiteRowGenerator>(table, session, output_options),
+impl Dat {
+    pub(super) fn new(target_directory: PathBuf) -> Result<Self> {
+        Ok(Self {
+            output_options: OutputOptions::new(target_directory)?,
+        })
+    }
 
-        // Sales + Returns pairs
-        Table::StoreSales => generate_store_sales(session, output_options),
-        Table::StoreReturns => Ok(()), // Generated with StoreSales
-        Table::CatalogSales => generate_catalog_sales(session, output_options),
-        Table::CatalogReturns => Ok(()), // Generated with CatalogSales
-        Table::WebSales => generate_web_sales(session, output_options),
-        Table::WebReturns => Ok(()), // Generated with WebSales
+    pub(super) fn generate_table(&self, table: Table, session: &Session) -> Result<()> {
+        match table {
+            // Simple dimension tables
+            Table::CallCenter => {
+                generate_simple::<CallCenterRowGenerator>(table, session, &self.output_options)
+            }
+            Table::CatalogPage => {
+                generate_simple::<CatalogPageRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Customer => {
+                generate_simple::<CustomerRowGenerator>(table, session, &self.output_options)
+            }
+            Table::CustomerAddress => {
+                generate_simple::<CustomerAddressRowGenerator>(table, session, &self.output_options)
+            }
+            Table::CustomerDemographics => generate_simple::<CustomerDemographicsRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+            ),
+            Table::DateDim => {
+                generate_simple::<DateDimRowGenerator>(table, session, &self.output_options)
+            }
+            Table::DbgenVersion => {
+                generate_simple::<DbgenVersionRowGenerator>(table, session, &self.output_options)
+            }
+            Table::HouseholdDemographics => generate_simple::<HouseholdDemographicsRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+            ),
+            Table::IncomeBand => {
+                generate_simple::<IncomeBandRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Item => {
+                generate_simple::<ItemRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Promotion => {
+                generate_simple::<PromotionRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Reason => {
+                generate_simple::<ReasonRowGenerator>(table, session, &self.output_options)
+            }
+            Table::ShipMode => {
+                generate_simple::<ShipModeRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Store => {
+                generate_simple::<StoreRowGenerator>(table, session, &self.output_options)
+            }
+            Table::TimeDim => {
+                generate_simple::<TimeDimRowGenerator>(table, session, &self.output_options)
+            }
+            Table::Warehouse => {
+                generate_simple::<WarehouseRowGenerator>(table, session, &self.output_options)
+            }
+            Table::WebPage => {
+                generate_simple::<WebPageRowGenerator>(table, session, &self.output_options)
+            }
+            Table::WebSite => {
+                generate_simple::<WebSiteRowGenerator>(table, session, &self.output_options)
+            }
 
-        // Special tables
-        Table::Inventory => generate_inventory(session, output_options),
+            // Sales + Returns pairs
+            Table::StoreSales => generate_store_sales(session, &self.output_options),
+            Table::StoreReturns => Ok(()), // Generated with StoreSales
+            Table::CatalogSales => generate_catalog_sales(session, &self.output_options),
+            Table::CatalogReturns => Ok(()), // Generated with CatalogSales
+            Table::WebSales => generate_web_sales(session, &self.output_options),
+            Table::WebReturns => Ok(()), // Generated with WebSales
 
-        // Source tables - skip
-        _ => Ok(()),
+            // Special tables
+            Table::Inventory => generate_inventory(session, &self.output_options),
+
+            // Source tables - skip
+            _ => Ok(()),
+        }
     }
 }
 

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -19,81 +19,90 @@ use tpcdsgen_arrow::{
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Generate one TPC-DS table as a Parquet file in `output_dir`.
-pub fn generate_table(
-    table: Table,
-    session: Session,
+/// Parquet output generator.
+#[derive(Debug, Clone)]
+pub(super) struct Parquet {
     output_dir: PathBuf,
     compression: Compression,
-) -> Result<()> {
-    let path = output_dir.join(format!("{}.parquet", table.get_name()));
-
-    match table {
-        Table::CallCenter => write_batches(path, CallCenterArrow::new(session), compression),
-        Table::CatalogPage => write_batches(path, CatalogPageArrow::new(session), compression),
-        Table::CatalogReturns => {
-            write_batches(path, CatalogReturnsArrow::new(session), compression)
-        }
-        Table::CatalogSales => write_batches(path, CatalogSalesArrow::new(session), compression),
-        Table::Customer => write_batches(path, CustomerArrow::new(session), compression),
-        Table::CustomerAddress => {
-            write_batches(path, CustomerAddressArrow::new(session), compression)
-        }
-        Table::CustomerDemographics => {
-            write_batches(path, CustomerDemographicsArrow::new(session), compression)
-        }
-        Table::DateDim => write_batches(path, DateDimArrow::new(session), compression),
-        Table::DbgenVersion => write_batches(path, DbgenVersionArrow::new(session), compression),
-        Table::HouseholdDemographics => {
-            write_batches(path, HouseholdDemographicsArrow::new(session), compression)
-        }
-        Table::IncomeBand => write_batches(path, IncomeBandArrow::new(session), compression),
-        Table::Inventory => write_batches(path, InventoryArrow::new(session), compression),
-        Table::Item => write_batches(path, ItemArrow::new(session), compression),
-        Table::Promotion => write_batches(path, PromotionArrow::new(session), compression),
-        Table::Reason => write_batches(path, ReasonArrow::new(session), compression),
-        Table::ShipMode => write_batches(path, ShipModeArrow::new(session), compression),
-        Table::Store => write_batches(path, StoreArrow::new(session), compression),
-        Table::StoreReturns => write_batches(path, StoreReturnsArrow::new(session), compression),
-        Table::StoreSales => write_batches(path, StoreSalesArrow::new(session), compression),
-        Table::TimeDim => write_batches(path, TimeDimArrow::new(session), compression),
-        Table::Warehouse => write_batches(path, WarehouseArrow::new(session), compression),
-        Table::WebPage => write_batches(path, WebPageArrow::new(session), compression),
-        Table::WebReturns => write_batches(path, WebReturnsArrow::new(session), compression),
-        Table::WebSales => write_batches(path, WebSalesArrow::new(session), compression),
-        Table::WebSite => write_batches(path, WebSiteArrow::new(session), compression),
-        _ => Ok(()),
-    }
 }
 
-/// Write the record batches to a Parquet file at the specified path with the given compression.
-fn write_batches<I>(path: PathBuf, mut batches: I, compression: Compression) -> Result<()>
-where
-    I: RecordBatchIterator,
-{
-    let temp_path = path.with_extension("inprogress");
-    let file = File::create(&temp_path)
-        .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
-    let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
-    let writer_properties = WriterProperties::builder()
-        .set_compression(compression)
-        .build();
-    let mut writer = ArrowWriter::try_new(
-        writer,
-        Arc::clone(batches.schema()),
-        Some(writer_properties),
-    )?;
-
-    for batch in &mut batches {
-        writer.write(&batch)?;
+impl Parquet {
+    pub(super) fn new(output_dir: PathBuf, compression: Compression) -> Self {
+        Self {
+            output_dir,
+            compression,
+        }
     }
 
-    writer.close()?;
-    std::fs::rename(&temp_path, &path).map_err(|err| {
-        io::Error::other(format!(
-            "Failed to rename {temp_path:?} to {path:?} file: {err}"
-        ))
-    })?;
+    /// Generate one TPC-DS table as a Parquet file.
+    pub(super) fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+        let path = self
+            .output_dir
+            .join(format!("{}.parquet", table.get_name()));
 
-    Ok(())
+        match table {
+            Table::CallCenter => self.write_batches(path, CallCenterArrow::new(session)),
+            Table::CatalogPage => self.write_batches(path, CatalogPageArrow::new(session)),
+            Table::CatalogReturns => self.write_batches(path, CatalogReturnsArrow::new(session)),
+            Table::CatalogSales => self.write_batches(path, CatalogSalesArrow::new(session)),
+            Table::Customer => self.write_batches(path, CustomerArrow::new(session)),
+            Table::CustomerAddress => self.write_batches(path, CustomerAddressArrow::new(session)),
+            Table::CustomerDemographics => {
+                self.write_batches(path, CustomerDemographicsArrow::new(session))
+            }
+            Table::DateDim => self.write_batches(path, DateDimArrow::new(session)),
+            Table::DbgenVersion => self.write_batches(path, DbgenVersionArrow::new(session)),
+            Table::HouseholdDemographics => {
+                self.write_batches(path, HouseholdDemographicsArrow::new(session))
+            }
+            Table::IncomeBand => self.write_batches(path, IncomeBandArrow::new(session)),
+            Table::Inventory => self.write_batches(path, InventoryArrow::new(session)),
+            Table::Item => self.write_batches(path, ItemArrow::new(session)),
+            Table::Promotion => self.write_batches(path, PromotionArrow::new(session)),
+            Table::Reason => self.write_batches(path, ReasonArrow::new(session)),
+            Table::ShipMode => self.write_batches(path, ShipModeArrow::new(session)),
+            Table::Store => self.write_batches(path, StoreArrow::new(session)),
+            Table::StoreReturns => self.write_batches(path, StoreReturnsArrow::new(session)),
+            Table::StoreSales => self.write_batches(path, StoreSalesArrow::new(session)),
+            Table::TimeDim => self.write_batches(path, TimeDimArrow::new(session)),
+            Table::Warehouse => self.write_batches(path, WarehouseArrow::new(session)),
+            Table::WebPage => self.write_batches(path, WebPageArrow::new(session)),
+            Table::WebReturns => self.write_batches(path, WebReturnsArrow::new(session)),
+            Table::WebSales => self.write_batches(path, WebSalesArrow::new(session)),
+            Table::WebSite => self.write_batches(path, WebSiteArrow::new(session)),
+            _ => Ok(()),
+        }
+    }
+
+    /// Write the record batches to a Parquet file at the specified path.
+    fn write_batches<I>(&self, path: PathBuf, mut batches: I) -> Result<()>
+    where
+        I: RecordBatchIterator,
+    {
+        let temp_path = path.with_extension("inprogress");
+        let file = File::create(&temp_path)
+            .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
+        let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
+        let writer_properties = WriterProperties::builder()
+            .set_compression(self.compression)
+            .build();
+        let mut writer = ArrowWriter::try_new(
+            writer,
+            Arc::clone(batches.schema()),
+            Some(writer_properties),
+        )?;
+
+        for batch in &mut batches {
+            writer.write(&batch)?;
+        }
+
+        writer.close()?;
+        std::fs::rename(&temp_path, &path).map_err(|err| {
+            io::Error::other(format!(
+                "Failed to rename {temp_path:?} to {path:?} file: {err}"
+            ))
+        })?;
+
+        Ok(())
+    }
 }

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -68,10 +68,6 @@ fn test_tpcgen_cli_tpcds_dat_verbose_enables_status_logging() {
         "Expected verbose mode setup log, got stderr: {stderr}"
     );
     assert!(
-        stderr.contains("TPC-DS Data Generator (Rust)"),
-        "Expected TPC-DS generator status log, got stderr: {stderr}"
-    );
-    assert!(
         stderr.contains("Generating reason..."),
         "Expected TPC-DS table start log, got stderr: {stderr}"
     );


### PR DESCRIPTION
## Summary

Refactor TPC-DS output generation so DAT, CSV, and Parquet share the same CLI dispatch path.

## Changes

- Add `CommonArgs::run_output` for shared table/session iteration.
- Add internal `OutputFormat` dispatch across DAT/CSV/Parquet.
- Move CSV and Parquet generation into format structs that own output settings.
- Convert DAT to the same generator shape with private `OutputOptions`.
- Remove DAT-only run-level start/finish logging.