### PR TITLE
[tpcgen-cli] Enable TPC-DS parquet logging

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -171,6 +171,7 @@ impl CommonArgs {
     }
 
     fn run_parquet(self, compression: Compression) -> Result<()> {
+        configure_logging(self.verbose, self.quiet, None);
         let _ = self.progress_bars_enabled;
         let output = parquet::Parquet::new(self.output_dir.clone(), compression);
         self.run_output(OutputFormat::Parquet(output))

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -110,6 +110,37 @@ fn test_tpcgen_cli_tpcds_parquet_single_table() {
 }
 
 #[test]
+fn test_tpcgen_cli_tpcds_parquet_verbose_enables_logging() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("-v")
+        .env("RUST_LOG", "warn")
+        .assert()
+        .success();
+
+    assert!(
+        assert.get_output().stdout.is_empty(),
+        "Expected verbose TPC-DS Parquet logging to use stderr, got stdout: {}",
+        String::from_utf8_lossy(&assert.get_output().stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Verbose output enabled (ignoring RUST_LOG environment variable)"),
+        "Expected verbose mode setup log, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_tpcgen_cli_tpcds_parquet_default_options_generate_all_outputs() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 


### PR DESCRIPTION
## Summary

Enable the TPC-DS Parquet CLI path to initialize logging, matching the DAT and CSV paths so `--verbose` and `--quiet` are applied consistently.

This fixes a parity gap where `tpcgen-cli tpcds parquet -v` accepted the flag but never called `configure_logging`, so it didn't do anything

