### PR TITLE
[tpcgen-cli]: extract shared parquet writer from tpch generation

### DIFF
--- a/tpcgen-cli/src/lib.rs
+++ b/tpcgen-cli/src/lib.rs
@@ -1,4 +1,5 @@
 //! This library contains both the TPCH and TPCDS command line clients.
 mod logging;
+mod parquet;
 pub mod tpcds_cli;
 pub mod tpch_cli;

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -1,0 +1,265 @@
+//! Shared Parquet output helpers.
+
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+use futures::StreamExt;
+use log::debug;
+use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
+use parquet::arrow::ArrowSchemaConverter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::types::SchemaDescPtr;
+use std::io;
+use std::io::Write;
+use std::sync::Arc;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::tpch_cli::progress::ProgressTracker;
+use crate::tpch_cli::statistics::WriteStatistics;
+
+pub trait IntoSize {
+    /// Convert the object into a size
+    fn into_size(self) -> Result<usize, io::Error>;
+}
+
+/// An iterator of Arrow [`RecordBatch`]es that also exposes its schema.
+pub trait RecordBatchIterator: Iterator<Item = RecordBatch> + Send {
+    fn schema(&self) -> &SchemaRef;
+}
+
+/// Adapter for TPCH Arrow record batch iterators.
+pub struct TpchRecordBatchIterator<I>(I);
+
+impl<I> TpchRecordBatchIterator<I> {
+    pub fn new(inner: I) -> Self {
+        Self(inner)
+    }
+}
+
+impl<I> Iterator for TpchRecordBatchIterator<I>
+where
+    I: tpchgen_arrow::RecordBatchIterator,
+{
+    type Item = RecordBatch;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<I> RecordBatchIterator for TpchRecordBatchIterator<I>
+where
+    I: tpchgen_arrow::RecordBatchIterator,
+{
+    fn schema(&self) -> &SchemaRef {
+        self.0.schema()
+    }
+}
+
+/// Converts a set of RecordBatchIterators into a Parquet file.
+///
+/// Uses num_threads to generate the data in parallel.
+///
+/// Note the input is an iterator of [`RecordBatchIterator`]; the batches
+/// produced by each iterator are encoded as their own row group.
+pub async fn generate_parquet_with_progress<W, I>(
+    writer: W,
+    iter_iter: I,
+    num_threads: usize,
+    parquet_compression: Compression,
+    progress: Arc<dyn ProgressTracker>,
+    table_name: &'static str,
+) -> Result<(), io::Error>
+where
+    W: Write + Send + IntoSize + 'static,
+    I: Iterator<Item: RecordBatchIterator> + 'static,
+{
+    debug!(
+        "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"
+    );
+    // Based on example in https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowColumnWriter.html
+    let mut iter_iter = iter_iter.peekable();
+
+    // get schema from the first iterator
+    let Some(first_iter) = iter_iter.peek() else {
+        return Ok(()); // no data
+    };
+    let schema = Arc::clone(first_iter.schema());
+
+    // Compute the parquet schema
+    let writer_properties = WriterProperties::builder()
+        .set_compression(parquet_compression)
+        .build();
+    let writer_properties = Arc::new(writer_properties);
+    let parquet_schema = Arc::new(
+        ArrowSchemaConverter::new()
+            .with_coerce_types(writer_properties.coerce_types())
+            .convert(&schema)
+            .unwrap(),
+    );
+
+    // create a stream that computes the data for each row group
+    let mut row_group_stream = futures::stream::iter(iter_iter)
+        .map(async |iter| {
+            let parquet_schema = Arc::clone(&parquet_schema);
+            let writer_properties = Arc::clone(&writer_properties);
+            let schema = Arc::clone(&schema);
+            // run on a separate thread
+            tokio::task::spawn(async move {
+                encode_row_group(parquet_schema, writer_properties, schema, iter)
+            })
+            .await
+            .expect("Inner task panicked")
+        })
+        .buffered(num_threads); // generate row groups in parallel
+
+    let mut statistics = WriteStatistics::new("row groups");
+
+    // A blocking task that writes the row groups to the file
+    // done in a blocking task to avoid having a thread waiting on IO
+    // Now, read each completed row group and write it to the file
+    let root_schema = parquet_schema.root_schema_ptr();
+    let writer_properties_captured = Arc::clone(&writer_properties);
+    let (tx, mut rx): (
+        Sender<Vec<ArrowColumnChunk>>,
+        Receiver<Vec<ArrowColumnChunk>>,
+    ) = tokio::sync::mpsc::channel(num_threads);
+    let writer_task = tokio::task::spawn_blocking(move || {
+        // Create parquet writer
+        let mut writer =
+            SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
+
+        while let Some(column_chunks) = rx.blocking_recv() {
+            // Start row group
+            let mut row_group_writer = writer.next_row_group().unwrap();
+
+            // Slap the chunks into the row group
+            for column_chunk in column_chunks {
+                column_chunk
+                    .append_to_row_group(&mut row_group_writer)
+                    .unwrap();
+            }
+            row_group_writer.close().unwrap();
+            statistics.increment_chunks(1);
+            progress.increment(table_name, 1);
+        }
+        let size = writer.into_inner()?.into_size()?;
+        statistics.increment_bytes(size);
+        Ok(()) as Result<(), io::Error>
+    });
+
+    // now, drive the input stream and send results to the writer task
+    while let Some(column_chunks) = row_group_stream.next().await {
+        // send the chunks to the writer task
+        if let Err(e) = tx.send(column_chunks).await {
+            debug!("Error sending row group to writer: {e}");
+            break; // stop early
+        }
+    }
+    // signal the writer task that we are done
+    drop(tx);
+
+    // Wait for the writer task to finish
+    writer_task.await??;
+
+    Ok(())
+}
+
+/// Creates the data for a particular row group.
+///
+/// Note at the moment it does not use multiple tasks/threads but it could
+/// potentially encode multiple columns with different threads.
+///
+/// Returns an array of [`ArrowColumnChunk`].
+fn encode_row_group<I>(
+    parquet_schema: SchemaDescPtr,
+    writer_properties: Arc<WriterProperties>,
+    schema: SchemaRef,
+    iter: I,
+) -> Vec<ArrowColumnChunk>
+where
+    I: RecordBatchIterator,
+{
+    // Create writers for each of the leaf columns
+    #[allow(deprecated)]
+    let mut col_writers = parquet::arrow::arrow_writer::get_column_writers(
+        &parquet_schema,
+        &writer_properties,
+        &schema,
+    )
+    .unwrap();
+
+    // generate the data and send it to the tasks (via the sender channels)
+    for batch in iter {
+        let columns = batch.columns().iter();
+        let col_writers = col_writers.iter_mut();
+        let fields = schema.fields().iter();
+
+        for ((col_writer, field), arr) in col_writers.zip(fields).zip(columns) {
+            for leaves in compute_leaves(field.as_ref(), arr).unwrap() {
+                col_writer.write(&leaves).unwrap();
+            }
+        }
+    }
+    // finish the writers and create the column chunks
+    col_writers
+        .into_iter()
+        .map(|col_writer| col_writer.close().unwrap())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tpch_cli::progress::ProgressTracker;
+    use std::fs::File;
+    use std::io::BufWriter;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+    use tpchgen::generators::RegionGenerator;
+    use tpchgen_arrow::RegionArrow;
+
+    #[derive(Debug, Default)]
+    struct CountingProgress {
+        increments: AtomicU64,
+    }
+
+    impl ProgressTracker for CountingProgress {
+        fn increment(&self, _item: &str, row_groups: u64) {
+            self.increments.fetch_add(row_groups, Ordering::Relaxed);
+        }
+    }
+
+    fn region_source() -> TpchRecordBatchIterator<RegionArrow> {
+        TpchRecordBatchIterator::new(
+            RegionArrow::new(RegionGenerator::default()).with_batch_size(5),
+        )
+    }
+
+    #[tokio::test]
+    async fn progress_counts_written_row_groups() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let output_path = output_dir.path().join("progress.parquet");
+        let writer = BufWriter::new(File::create(&output_path).unwrap());
+
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker.clone();
+
+        generate_parquet_with_progress(
+            writer,
+            vec![region_source(), region_source()].into_iter(),
+            1,
+            Compression::UNCOMPRESSED,
+            progress,
+            "ignored",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
+        assert!(std::fs::metadata(output_path).unwrap().len() > 0);
+    }
+}

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -1,7 +1,7 @@
 //! Shared Parquet output helpers.
 
-use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
@@ -23,48 +23,15 @@ pub trait IntoSize {
     fn into_size(self) -> Result<usize, io::Error>;
 }
 
-/// An iterator of Arrow [`RecordBatch`]es that also exposes its schema.
-pub trait RecordBatchIterator: Iterator<Item = RecordBatch> + Send {
-    fn schema(&self) -> &SchemaRef;
-}
-
-/// Adapter for TPCH Arrow record batch iterators.
-pub struct TpchRecordBatchIterator<I>(I);
-
-impl<I> TpchRecordBatchIterator<I> {
-    pub fn new(inner: I) -> Self {
-        Self(inner)
-    }
-}
-
-impl<I> Iterator for TpchRecordBatchIterator<I>
-where
-    I: tpchgen_arrow::RecordBatchIterator,
-{
-    type Item = RecordBatch;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-impl<I> RecordBatchIterator for TpchRecordBatchIterator<I>
-where
-    I: tpchgen_arrow::RecordBatchIterator,
-{
-    fn schema(&self) -> &SchemaRef {
-        self.0.schema()
-    }
-}
-
 /// Converts a set of RecordBatchIterators into a Parquet file.
 ///
 /// Uses num_threads to generate the data in parallel.
 ///
-/// Note the input is an iterator of [`RecordBatchIterator`]; the batches
+/// Note the input is an iterator of [`RecordBatch`] iterators; the batches
 /// produced by each iterator are encoded as their own row group.
-pub async fn generate_parquet_with_progress<W, I>(
+pub async fn generate_parquet<W, I>(
     writer: W,
+    schema: SchemaRef,
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
@@ -73,7 +40,7 @@ pub async fn generate_parquet_with_progress<W, I>(
 ) -> Result<(), io::Error>
 where
     W: Write + Send + IntoSize + 'static,
-    I: Iterator<Item: RecordBatchIterator> + 'static,
+    I: Iterator<Item: Iterator<Item = RecordBatch> + Send> + 'static,
 {
     debug!(
         "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"
@@ -81,11 +48,9 @@ where
     // Based on example in https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowColumnWriter.html
     let mut iter_iter = iter_iter.peekable();
 
-    // get schema from the first iterator
-    let Some(first_iter) = iter_iter.peek() else {
+    if iter_iter.peek().is_none() {
         return Ok(()); // no data
-    };
-    let schema = Arc::clone(first_iter.schema());
+    }
 
     // Compute the parquet schema
     let writer_properties = WriterProperties::builder()
@@ -179,7 +144,7 @@ fn encode_row_group<I>(
     iter: I,
 ) -> Vec<ArrowColumnChunk>
 where
-    I: RecordBatchIterator,
+    I: Iterator<Item = RecordBatch>,
 {
     // Create writers for each of the leaf columns
     #[allow(deprecated)]
@@ -220,6 +185,7 @@ mod tests {
         Arc,
     };
     use tpchgen::generators::RegionGenerator;
+    use tpchgen_arrow::RecordBatchIterator;
     use tpchgen_arrow::RegionArrow;
 
     #[derive(Debug, Default)]
@@ -233,10 +199,8 @@ mod tests {
         }
     }
 
-    fn region_source() -> TpchRecordBatchIterator<RegionArrow> {
-        TpchRecordBatchIterator::new(
-            RegionArrow::new(RegionGenerator::default()).with_batch_size(5),
-        )
+    fn region_source() -> RegionArrow {
+        RegionArrow::new(RegionGenerator::default()).with_batch_size(5)
     }
 
     #[tokio::test]
@@ -248,8 +212,9 @@ mod tests {
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
 
-        generate_parquet_with_progress(
+        generate_parquet(
             writer,
+            Arc::clone(region_source().schema()),
             vec![region_source(), region_source()].into_iter(),
             1,
             Compression::UNCOMPRESSED,

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -1,40 +1,29 @@
-//! Parquet output format
+//! TPCH Parquet output format.
 
+use crate::parquet::TpchRecordBatchIterator;
 use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
-use crate::tpch_cli::statistics::WriteStatistics;
-use arrow::datatypes::SchemaRef;
-use futures::StreamExt;
-use log::debug;
-use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
-use parquet::arrow::ArrowSchemaConverter;
 use parquet::basic::Compression;
-use parquet::file::properties::WriterProperties;
-use parquet::file::writer::SerializedFileWriter;
-use parquet::schema::types::SchemaDescPtr;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
-use tokio::sync::mpsc::{Receiver, Sender};
 use tpchgen_arrow::RecordBatchIterator;
 
-pub trait IntoSize {
-    /// Convert the object into a size
-    fn into_size(self) -> Result<usize, io::Error>;
-}
+pub use crate::parquet::IntoSize;
 
-/// Converts a set of RecordBatchIterators into a Parquet file
+/// Converts a set of RecordBatchIterators into a Parquet file.
 ///
-/// Uses num_threads to generate the data in parallel
+/// Uses num_threads to generate the data in parallel.
 ///
-/// Note the input is an iterator of [`RecordBatchIterator`]; The batches
-/// produced by each iterator is encoded as its own row group.
-pub async fn generate_parquet<W: Write + Send + IntoSize + 'static, I>(
+/// Note the input is an iterator of [`RecordBatchIterator`]; the batches
+/// produced by each iterator are encoded as their own row group.
+pub async fn generate_parquet<W, I>(
     writer: W,
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
 ) -> Result<(), io::Error>
 where
+    W: Write + Send + IntoSize + 'static,
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
     generate_parquet_with_progress(
@@ -48,7 +37,7 @@ where
     .await
 }
 
-pub(crate) async fn generate_parquet_with_progress<W: Write + Send + IntoSize + 'static, I>(
+pub(crate) async fn generate_parquet_with_progress<W, I>(
     writer: W,
     iter_iter: I,
     num_threads: usize,
@@ -57,191 +46,17 @@ pub(crate) async fn generate_parquet_with_progress<W: Write + Send + IntoSize + 
     table_name: &'static str,
 ) -> Result<(), io::Error>
 where
+    W: Write + Send + IntoSize + 'static,
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
-    debug!(
-        "Generating Parquet with {num_threads} threads, using {parquet_compression} compression"
-    );
-    // Based on example in https://docs.rs/parquet/latest/parquet/arrow/arrow_writer/struct.ArrowColumnWriter.html
-    let mut iter_iter = iter_iter.peekable();
-
-    // get schema from the first iterator
-    let Some(first_iter) = iter_iter.peek() else {
-        return Ok(()); // no data shrug
-    };
-    let schema = Arc::clone(first_iter.schema());
-
-    // Compute the parquet schema
-    let writer_properties = WriterProperties::builder()
-        .set_compression(parquet_compression)
-        .build();
-    let writer_properties = Arc::new(writer_properties);
-    let parquet_schema = Arc::new(
-        ArrowSchemaConverter::new()
-            .with_coerce_types(writer_properties.coerce_types())
-            .convert(&schema)
-            .unwrap(),
-    );
-
-    // create a stream that computes the data for each row group
-    let mut row_group_stream = futures::stream::iter(iter_iter)
-        .map(async |iter| {
-            let parquet_schema = Arc::clone(&parquet_schema);
-            let writer_properties = Arc::clone(&writer_properties);
-            let schema = Arc::clone(&schema);
-            // run on a separate thread
-            tokio::task::spawn(async move {
-                encode_row_group(parquet_schema, writer_properties, schema, iter)
-            })
-            .await
-            .expect("Inner task panicked")
-        })
-        .buffered(num_threads); // generate row groups in parallel
-
-    let mut statistics = WriteStatistics::new("row groups");
-
-    // A blocking task that writes the row groups to the file
-    // done in a blocking task to avoid having a thread waiting on IO
-    // Now, read each completed row group and write it to the file
-    let root_schema = parquet_schema.root_schema_ptr();
-    let writer_properties_captured = Arc::clone(&writer_properties);
-    let (tx, mut rx): (
-        Sender<Vec<ArrowColumnChunk>>,
-        Receiver<Vec<ArrowColumnChunk>>,
-    ) = tokio::sync::mpsc::channel(num_threads);
-    let writer_task = tokio::task::spawn_blocking(move || {
-        // Create parquet writer
-        let mut writer =
-            SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
-
-        while let Some(column_chunks) = rx.blocking_recv() {
-            // Start row group
-            let mut row_group_writer = writer.next_row_group().unwrap();
-
-            // Slap the chunks into the row group
-            for column_chunk in column_chunks {
-                column_chunk
-                    .append_to_row_group(&mut row_group_writer)
-                    .unwrap();
-            }
-            row_group_writer.close().unwrap();
-            statistics.increment_chunks(1);
-            progress.increment(table_name, 1);
-        }
-        let size = writer.into_inner()?.into_size()?;
-        statistics.increment_bytes(size);
-        Ok(()) as Result<(), io::Error>
-    });
-
-    // now, drive the input stream and send results to the writer task
-    while let Some(column_chunks) = row_group_stream.next().await {
-        // send the chunks to the writer task
-        if let Err(e) = tx.send(column_chunks).await {
-            debug!("Error sending row group to writer: {e}");
-            break; // stop early
-        }
-    }
-    // signal the writer task that we are done
-    drop(tx);
-
-    // Wait for the writer task to finish
-    writer_task.await??;
-
-    Ok(())
-}
-
-/// Creates the data for a particular row group
-///
-/// Note at the moment it does not use multiple tasks/threads but it could
-/// potentially encode multiple columns with different threads .
-///
-/// Returns an array of [`ArrowColumnChunk`]
-fn encode_row_group<I>(
-    parquet_schema: SchemaDescPtr,
-    writer_properties: Arc<WriterProperties>,
-    schema: SchemaRef,
-    iter: I,
-) -> Vec<ArrowColumnChunk>
-where
-    I: RecordBatchIterator,
-{
-    // Create writers for each of the leaf columns
-    #[allow(deprecated)]
-    let mut col_writers = parquet::arrow::arrow_writer::get_column_writers(
-        &parquet_schema,
-        &writer_properties,
-        &schema,
+    let iter_iter = iter_iter.map(TpchRecordBatchIterator::new);
+    crate::parquet::generate_parquet_with_progress(
+        writer,
+        iter_iter,
+        num_threads,
+        parquet_compression,
+        progress,
+        table_name,
     )
-    .unwrap();
-
-    // generate the data and send it to the tasks (via the sender channels)
-    for batch in iter {
-        let columns = batch.columns().iter();
-        let col_writers = col_writers.iter_mut();
-        let fields = schema.fields().iter();
-
-        for ((col_writer, field), arr) in col_writers.zip(fields).zip(columns) {
-            for leaves in compute_leaves(field.as_ref(), arr).unwrap() {
-                col_writer.write(&leaves).unwrap();
-            }
-        }
-    }
-    // finish the writers and create the column chunks
-    col_writers
-        .into_iter()
-        .map(|col_writer| col_writer.close().unwrap())
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tpch_cli::progress::ProgressTracker;
-    use std::fs::File;
-    use std::io::BufWriter;
-    use std::sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    };
-    use tpchgen::generators::RegionGenerator;
-    use tpchgen_arrow::RegionArrow;
-
-    #[derive(Debug, Default)]
-    struct CountingProgress {
-        increments: AtomicU64,
-    }
-
-    impl ProgressTracker for CountingProgress {
-        fn increment(&self, _item: &str, row_groups: u64) {
-            self.increments.fetch_add(row_groups, Ordering::Relaxed);
-        }
-    }
-
-    fn region_source() -> RegionArrow {
-        RegionArrow::new(RegionGenerator::default()).with_batch_size(5)
-    }
-
-    #[tokio::test]
-    async fn progress_counts_written_row_groups() {
-        let output_dir = tempfile::tempdir().unwrap();
-        let output_path = output_dir.path().join("progress.parquet");
-        let writer = BufWriter::new(File::create(&output_path).unwrap());
-
-        let tracker = Arc::new(CountingProgress::default());
-        let progress: Arc<dyn ProgressTracker> = tracker.clone();
-
-        generate_parquet_with_progress(
-            writer,
-            vec![region_source(), region_source()].into_iter(),
-            1,
-            Compression::UNCOMPRESSED,
-            progress,
-            "ignored",
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
-        assert!(std::fs::metadata(output_path).unwrap().len() > 0);
-    }
+    .await
 }

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -1,6 +1,5 @@
 //! TPCH Parquet output format.
 
-use crate::parquet::TpchRecordBatchIterator;
 use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
 use parquet::basic::Compression;
 use std::io;
@@ -49,9 +48,15 @@ where
     W: Write + Send + IntoSize + 'static,
     I: Iterator<Item: RecordBatchIterator> + 'static,
 {
-    let iter_iter = iter_iter.map(TpchRecordBatchIterator::new);
-    crate::parquet::generate_parquet_with_progress(
+    let mut iter_iter = iter_iter.peekable();
+    let Some(first_iter) = iter_iter.peek() else {
+        return Ok(());
+    };
+    let schema = Arc::clone(first_iter.schema());
+
+    crate::parquet::generate_parquet(
         writer,
+        schema,
         iter_iter,
         num_threads,
         parquet_compression,

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -1,6 +1,6 @@
 //! TPCH Parquet output format.
 
-use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
+use crate::tpch_cli::progress::ProgressTracker;
 use parquet::basic::Compression;
 use std::io;
 use std::io::Write;


### PR DESCRIPTION
## Why
- part of https://github.com/clflushopt/tpchgen-rs/issues/334

I am preparing  the codebase to reuse the same parallel parquet row-group encoding/writing implementation for both TPCH and TPCDS.

## What changed

Extracted the TPCH parquet row-group encoding and writing path into a shared  module.

## Performance

I double checked that this did not change performance by running

```shell
cargo build --bin tpcgen-cli --release && \
hyperfine --runs 5 --prepare "rm -rf /tmp/output" "target/release/tpcgen-cli tpch parquet --scale-factor=10 --tables=lineitem --output-dir /tmp/output"
```

Results on main:

```
Benchmark 1: target/release/tpcgen-cli tpch parquet --scale-factor=10 --tables=lineitem --output-dir /tmp/output
  Time (mean ± σ):      3.830 s ±  0.940 s    [User: 33.783 s, System: 0.850 s]
  Range (min … max):    3.390 s …  5.511 s    5 runs
```

Results on this branch: 
```
Benchmark 1: target/release/tpcgen-cli tpch parquet --scale-factor=10 --tables=lineitem --output-dir /tmp/output
  Time (mean ± σ):      3.667 s ±  0.483 s    [User: 33.518 s, System: 0.880 s]
  Range (min … max):    3.424 s …  4.530 s    5 runs
```

