### PR TITLE
[tpcgen-cli] Remove dead code in TPCH parquet generation

### DIFF
--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -1,6 +1,6 @@
 //! Parquet output format
 
-use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
+use crate::tpch_cli::progress::ProgressTracker;
 use crate::tpch_cli::statistics::WriteStatistics;
 use arrow::datatypes::SchemaRef;
 use futures::StreamExt;
@@ -29,26 +29,6 @@ pub trait IntoSize {
 /// Note the input is an iterator of [`RecordBatchIterator`]; The batches
 /// produced by each iterator is encoded as its own row group.
 pub async fn generate_parquet<W: Write + Send + IntoSize + 'static, I>(
-    writer: W,
-    iter_iter: I,
-    num_threads: usize,
-    parquet_compression: Compression,
-) -> Result<(), io::Error>
-where
-    I: Iterator<Item: RecordBatchIterator> + 'static,
-{
-    generate_parquet_with_progress(
-        writer,
-        iter_iter,
-        num_threads,
-        parquet_compression,
-        no_op_progress_tracker(),
-        "",
-    )
-    .await
-}
-
-pub(crate) async fn generate_parquet_with_progress<W: Write + Send + IntoSize + 'static, I>(
     writer: W,
     iter_iter: I,
     num_threads: usize,
@@ -230,7 +210,7 @@ mod tests {
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
 
-        generate_parquet_with_progress(
+        generate_parquet(
             writer,
             vec![region_source(), region_source()].into_iter(),
             1,

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -4,7 +4,7 @@ use crate::tpch_cli::csv::*;
 use crate::tpch_cli::generate::generate_in_chunks_with_progress;
 use crate::tpch_cli::generate::Source;
 use crate::tpch_cli::output_plan::{OutputLocation, OutputPlan};
-use crate::tpch_cli::parquet::generate_parquet_with_progress;
+use crate::tpch_cli::parquet::generate_parquet;
 use crate::tpch_cli::progress::no_op_progress_tracker;
 use crate::tpch_cli::progress::ProgressTracker;
 use crate::tpch_cli::tbl::*;
@@ -287,7 +287,7 @@ where
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
-            generate_parquet_with_progress(
+            generate_parquet(
                 writer,
                 sources,
                 num_threads,
@@ -307,7 +307,7 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, file); // 32MB buffer
-            generate_parquet_with_progress(
+            generate_parquet(
                 writer,
                 sources,
                 num_threads,


### PR DESCRIPTION
## Summary

Remove the no-progress `generate_parquet` wrapper and rename the progress-aware TPCH parquet helper to `generate_parquet`.

All TPCH parquet call sites now pass an explicit progress tracker and table name, so parquet generation follows the same explicit progress contract as the rest of the TPCH writer path.

