### PR TITLE
[tpcdsgen-arrow]: add source row range generation

### DIFF
--- a/tpcdsgen-arrow/src/lib.rs
+++ b/tpcdsgen-arrow/src/lib.rs
@@ -64,6 +64,13 @@ impl<G: RowGenerator> RowIter<G> {
             pending: VecDeque::new(),
         }
     }
+
+    pub(crate) fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.generator
+            .skip_rows_until_starting_row_number(starting_row_number);
+        self.current_row = starting_row_number;
+        self.pending.clear();
+    }
 }
 
 impl<G: RowGenerator> Iterator for RowIter<G> {

--- a/tpcdsgen-arrow/src/tables/call_center.rs
+++ b/tpcdsgen-arrow/src/tables/call_center.rs
@@ -22,6 +22,10 @@ impl CallCenterArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/catalog_page.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_page.rs
@@ -19,6 +19,10 @@ impl CatalogPageArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/catalog_returns.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_returns.rs
@@ -19,6 +19,10 @@ impl CatalogReturnsArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/catalog_sales.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_sales.rs
@@ -19,6 +19,10 @@ impl CatalogSalesArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/customer.rs
+++ b/tpcdsgen-arrow/src/tables/customer.rs
@@ -19,6 +19,10 @@ impl CustomerArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/customer_address.rs
+++ b/tpcdsgen-arrow/src/tables/customer_address.rs
@@ -19,6 +19,10 @@ impl CustomerAddressArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/customer_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/customer_demographics.rs
@@ -21,6 +21,10 @@ impl CustomerDemographicsArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/date_dim.rs
+++ b/tpcdsgen-arrow/src/tables/date_dim.rs
@@ -19,6 +19,10 @@ impl DateDimArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/dbgen_version.rs
+++ b/tpcdsgen-arrow/src/tables/dbgen_version.rs
@@ -19,6 +19,10 @@ impl DbgenVersionArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/household_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/household_demographics.rs
@@ -21,6 +21,10 @@ impl HouseholdDemographicsArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/income_band.rs
+++ b/tpcdsgen-arrow/src/tables/income_band.rs
@@ -19,6 +19,10 @@ impl IncomeBandArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/inventory.rs
+++ b/tpcdsgen-arrow/src/tables/inventory.rs
@@ -19,6 +19,10 @@ impl InventoryArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/item.rs
+++ b/tpcdsgen-arrow/src/tables/item.rs
@@ -21,6 +21,10 @@ impl ItemArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/promotion.rs
+++ b/tpcdsgen-arrow/src/tables/promotion.rs
@@ -21,6 +21,10 @@ impl PromotionArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/reason.rs
+++ b/tpcdsgen-arrow/src/tables/reason.rs
@@ -19,6 +19,10 @@ impl ReasonArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/ship_mode.rs
+++ b/tpcdsgen-arrow/src/tables/ship_mode.rs
@@ -19,6 +19,10 @@ impl ShipModeArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/store.rs
+++ b/tpcdsgen-arrow/src/tables/store.rs
@@ -22,6 +22,10 @@ impl StoreArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/store_returns.rs
+++ b/tpcdsgen-arrow/src/tables/store_returns.rs
@@ -19,6 +19,10 @@ impl StoreReturnsArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/store_sales.rs
+++ b/tpcdsgen-arrow/src/tables/store_sales.rs
@@ -19,6 +19,10 @@ impl StoreSalesArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/time_dim.rs
+++ b/tpcdsgen-arrow/src/tables/time_dim.rs
@@ -19,6 +19,10 @@ impl TimeDimArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/warehouse.rs
+++ b/tpcdsgen-arrow/src/tables/warehouse.rs
@@ -19,6 +19,10 @@ impl WarehouseArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/web_page.rs
+++ b/tpcdsgen-arrow/src/tables/web_page.rs
@@ -21,6 +21,10 @@ impl WebPageArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/web_returns.rs
+++ b/tpcdsgen-arrow/src/tables/web_returns.rs
@@ -19,6 +19,10 @@ impl WebReturnsArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/web_sales.rs
+++ b/tpcdsgen-arrow/src/tables/web_sales.rs
@@ -19,6 +19,10 @@ impl WebSalesArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/src/tables/web_site.rs
+++ b/tpcdsgen-arrow/src/tables/web_site.rs
@@ -22,6 +22,10 @@ impl WebSiteArrow {
             batch_size: DEFAULT_BATCH_SIZE,
         }
     }
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.inner
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;

--- a/tpcdsgen-arrow/tests/reparse.rs
+++ b/tpcdsgen-arrow/tests/reparse.rs
@@ -68,12 +68,15 @@ fn parse_dat<'a>(data: &'a [u8], schema: &'a SchemaRef) -> impl Iterator<Item = 
         .map(|batch| batch.expect("parse .tbl data into RecordBatch"))
 }
 
-/// Yields RecordBatches re-parsed from pipe-delimited output for the specified
-/// table generator `gen`, selecting only rows for which `select` returns true.
+/// Yields Arrow RecordBatches by creating pipe-delimited output for the
+/// specified table generator `gen`, and parsing the result to Arrow.
+///
+/// Returns only rows for which `select` returns true.
 fn reparsed_batches<G, F>(
     mut gen: G,
     schema: &SchemaRef,
     select: F,
+    starting_row_number: i64,
     source_row_count: i64,
 ) -> impl Iterator<Item = RecordBatch>
 where
@@ -83,7 +86,7 @@ where
     let schema = Arc::clone(schema);
 
     const REPARSE_BUFFER_TARGET_BYTES: usize = 256 * 1024;
-    let mut source_row = 1;
+    let mut source_row = starting_row_number;
     std::iter::from_fn(move || {
         let mut data = Vec::new();
 
@@ -117,52 +120,56 @@ where
     })
 }
 
-/// Compares the output of an Arrow generator `arrow_gen` and an underlying table
-/// generator `gen` by generating and then re-parsing `.tbl` output produced by
-/// the table generator.
+/// Asserts that two streams of Arrow RecordBatches are logically equal up to a
+/// specified row limit.
 ///
-/// The `select` predicate is used to select which rows to include in the
-/// reparsed data.
-///
-/// Arguments:
-/// * `gen`: the [`RowGenerator`] for the table(s)
-/// * `source_row_count`: the number of source rows to generate
-/// * `row_limit`: the maximum number of selected output rows to compare
-/// * `arrow_gen`: the [`RecordBatchIterator`] for the table
-/// * `select`: a predicate to select which rows to include in the reparsed data
-fn run_test<G, A, F>(gen: G, source_row_count: i64, row_limit: usize, arrow_gen: A, select: F)
+/// It ignores any differences in how the rows are distributed across batches
+/// by realigning the batches before comparison.
+fn assert_record_batch_streams<L, R>(left: L, right: R, row_limit: usize)
 where
-    G: RowGenerator,
-    A: RecordBatchIterator,
-    F: Fn(&GeneratedRow) -> bool,
+    L: Iterator<Item = RecordBatch>,
+    R: Iterator<Item = RecordBatch>,
 {
-    let schema = Arc::clone(arrow_gen.schema());
-
-    // Stream of batches from reparsing `.tbl` output.
-    let reparsed = reparsed_batches(gen, &schema, select, source_row_count);
-
     // Use FixedSizeBatches to align batch boundaries for comparison.
-    let mut reparsed = FixedSizeBatches::new(reparsed, row_limit);
-    let mut arrow = FixedSizeBatches::new(arrow_gen, row_limit);
+    let mut left = FixedSizeBatches::new(left, row_limit);
+    let mut right = FixedSizeBatches::new(right, row_limit);
 
     // Compare the two streams, batch by batch.
     let mut compared_rows = 0;
-    arrow
-        .by_ref()
-        .zip(reparsed.by_ref())
-        .for_each(|(arrow_batch, reparsed_batch)| {
-            compared_rows += arrow_batch.num_rows();
-            assert_eq!(arrow_batch, reparsed_batch);
+    left.by_ref()
+        .zip(right.by_ref())
+        .for_each(|(left_batch, right_batch)| {
+            compared_rows += left_batch.num_rows();
+            assert_eq!(left_batch, right_batch);
         });
     assert_eq!(compared_rows, row_limit);
+    assert!(left.next().is_none(), "left stream produced extra batches");
     assert!(
-        arrow.next().is_none(),
-        "direct Arrow iterator produced extra batches"
+        right.next().is_none(),
+        "right stream produced extra batches"
     );
-    assert!(
-        reparsed.next().is_none(),
-        "reparsed Arrow iterator produced extra batches"
-    );
+}
+
+/// Returns the source row to start skip tests from for the specified table.
+///
+/// Defaults to source row 100 and has special handling for slowly changing
+/// dimension (SCD) tables.
+fn skip_starting_row(table: Table, source_row_count: i64) -> i64 {
+    let max_skip_row = source_row_count.min(100);
+    if !matches!(
+        table,
+        Table::CallCenter | Table::Store | Table::WebPage | Table::WebSite | Table::Item
+    ) {
+        return max_skip_row;
+    }
+
+    // SCD tables reuse values from the previous source row for continuation
+    // records. Pick a new business-key row so a skipped generator does not need
+    // previous-row state initialized before the first generated row.
+    (1..=max_skip_row)
+        .rev()
+        .find(|row| row % 6 == 1)
+        .unwrap_or(1)
 }
 
 // ---------------------------------------------------------------------------
@@ -170,21 +177,63 @@ where
 // ---------------------------------------------------------------------------
 
 macro_rules! table_test {
-    ($name:ident, $gen:expr, $arrow:expr, $table:expr, $variant:ident) => {
-        #[test]
-        fn $name() {
-            let source_row_count = SESSION.get_scaling().get_row_count($table);
-            let row_limit = test_row_count($table) as usize;
-            run_test(
-                $gen,
-                source_row_count,
-                row_limit,
-                $arrow(SESSION.clone()),
-                |g| match g {
-                    GeneratedRow::$variant(_) => true,
-                    _ => false,
-                },
-            );
+    // $name: module name
+    // $gen: TPC-DS row generator used to produce canonical `.dat` rows.
+    // $arrow_gen: constructor for the matching Arrow RecordBatch generator.
+    // $table: TPC-DS table enum value used for row counts and skip planning.
+    // $variant: GeneratedRow enum variant to select rows for this table.
+    ($name:ident, $gen:expr, $arrow_gen:expr, $table:expr, $variant:ident) => {
+        mod $name {
+            use super::*;
+
+            #[test]
+            fn from_start() {
+                let source_row_count = SESSION.get_scaling().get_row_count($table);
+                let row_limit = test_row_count($table) as usize;
+                let arrow_gen = $arrow_gen(SESSION.clone());
+                let schema = Arc::clone(arrow_gen.schema());
+                let reparsed = reparsed_batches(
+                    $gen,
+                    &schema,
+                    |g| match g {
+                        GeneratedRow::$variant(_) => true,
+                        _ => false,
+                    },
+                    1,
+                    source_row_count,
+                );
+
+                assert_record_batch_streams(arrow_gen, reparsed, row_limit);
+            }
+
+            #[test]
+            fn skip() {
+                let source_row_count = SESSION.get_scaling().get_row_count($table);
+                let starting_row_number = skip_starting_row($table, source_row_count);
+                let remaining_source_rows = source_row_count - starting_row_number + 1;
+                let row_limit =
+                    test_row_count($table).min(remaining_source_rows).min(1024) as usize;
+
+                let mut gen = $gen;
+                gen.skip_rows_until_starting_row_number(starting_row_number);
+
+                let mut arrow_gen = $arrow_gen(SESSION.clone());
+                arrow_gen.skip_rows_until_starting_row_number(starting_row_number);
+
+                let schema = Arc::clone(arrow_gen.schema());
+                let reparsed = reparsed_batches(
+                    gen,
+                    &schema,
+                    |g| match g {
+                        GeneratedRow::$variant(_) => true,
+                        _ => false,
+                    },
+                    starting_row_number,
+                    source_row_count,
+                );
+
+                assert_record_batch_streams(arrow_gen, reparsed, row_limit);
+            }
         }
     };
 }

--- a/tpcdsgen/src/row/abstract_row_generator.rs
+++ b/tpcdsgen/src/row/abstract_row_generator.rs
@@ -88,8 +88,9 @@ impl AbstractRowGenerator {
 
     /// Skip rows for all streams until reaching the starting row number
     pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        let rows_to_skip = starting_row_number.saturating_sub(1);
         for stream in self.random_number_streams.iter_mut() {
-            stream.skip_rows(starting_row_number);
+            stream.skip_rows(rows_to_skip);
         }
     }
 }

--- a/tpcdsgen/src/row/tables/catalog_sales_row_generator.rs
+++ b/tpcdsgen/src/row/tables/catalog_sales_row_generator.rs
@@ -471,5 +471,7 @@ impl RowGenerator for CatalogSalesRowGenerator {
     fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
         self.abstract_generator
             .skip_rows_until_starting_row_number(starting_row_number);
+        self.catalog_returns_generator
+            .skip_rows_until_starting_row_number(starting_row_number);
     }
 }

--- a/tpcdsgen/src/row/tables/inventory_row_generator.rs
+++ b/tpcdsgen/src/row/tables/inventory_row_generator.rs
@@ -115,7 +115,8 @@ impl RowGenerator for InventoryRowGenerator {
         self.abstract_generator.consume_remaining_seeds_for_row();
     }
 
-    fn skip_rows_until_starting_row_number(&mut self, _starting_row_number: i64) {
-        // Inventory doesn't need special skip logic as it's not order-based
+    fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.abstract_generator
+            .skip_rows_until_starting_row_number(starting_row_number);
     }
 }

--- a/tpcdsgen/src/row/tables/store_sales_row_generator.rs
+++ b/tpcdsgen/src/row/tables/store_sales_row_generator.rs
@@ -345,6 +345,8 @@ impl RowGenerator for StoreSalesRowGenerator {
     fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
         self.abstract_generator
             .skip_rows_until_starting_row_number(starting_row_number);
+        self.store_returns_generator
+            .skip_rows_until_starting_row_number(starting_row_number);
     }
 }
 

--- a/tpcdsgen/src/row/tables/web_returns_row_generator.rs
+++ b/tpcdsgen/src/row/tables/web_returns_row_generator.rs
@@ -190,6 +190,11 @@ impl WebReturnsRowGenerator {
     pub fn consume_remaining_seeds_for_row(&mut self) {
         self.abstract_generator.consume_remaining_seeds_for_row();
     }
+
+    pub fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
+        self.abstract_generator
+            .skip_rows_until_starting_row_number(starting_row_number);
+    }
 }
 
 impl Default for WebReturnsRowGenerator {

--- a/tpcdsgen/src/row/tables/web_sales_row_generator.rs
+++ b/tpcdsgen/src/row/tables/web_sales_row_generator.rs
@@ -437,5 +437,7 @@ impl RowGenerator for WebSalesRowGenerator {
     fn skip_rows_until_starting_row_number(&mut self, starting_row_number: i64) {
         self.abstract_generator
             .skip_rows_until_starting_row_number(starting_row_number);
+        self.web_returns_generator
+            .skip_rows_until_starting_row_number(starting_row_number);
     }
 }


### PR DESCRIPTION
- Part of https://github.com/clflushopt/tpchgen-rs/issues/334 (Item 3)

The idea is that in order to generate parquet files in parallel, we need to initialize the TPCDS generators for different distinct parts of the input tables. 

Changes:
- Adds new_range(session, start_row, end_row) constructors for TPCDS Arrow table iterators.
- Add tests

