### PR TITLE
[tpcgen-cli] Validate TPC-DS row group bytes with clap

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -12,6 +12,8 @@ pub mod parquet;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+const DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES: usize = DEFAULT_PARQUET_ROW_GROUP_BYTES as usize;
+
 enum OutputFormat {
     Dat(dat::Dat),
     Csv(csv::Csv),
@@ -93,8 +95,12 @@ struct ParquetArgs {
     /// groups under this limit.
     ///
     /// Typical values range from 10MB to 100MB.
-    #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
-    row_group_bytes: i64,
+    #[arg(
+        long,
+        default_value_t = DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
+        value_parser = parse_row_group_bytes
+    )]
+    row_group_bytes: usize,
 }
 
 #[derive(Args)]
@@ -158,22 +164,8 @@ impl CsvArgs {
 
 impl ParquetArgs {
     fn run(self) -> Result<()> {
-        if self.row_group_bytes <= 0 {
-            return Err(TpcdsError::new(&format!(
-                "--row-group-bytes must be greater than zero, got {}",
-                self.row_group_bytes
-            ))
-            .into());
-        }
-
-        let row_group_bytes = usize::try_from(self.row_group_bytes).map_err(|_| {
-            TpcdsError::new(&format!(
-                "--row-group-bytes is too large, got {}",
-                self.row_group_bytes
-            ))
-        })?;
-
-        self.common.run_parquet(self.compression, row_group_bytes)
+        self.common
+            .run_parquet(self.compression, self.row_group_bytes)
     }
 }
 
@@ -298,4 +290,13 @@ fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
         ));
     }
     Ok(parsed)
+}
+
+fn parse_row_group_bytes(s: &str) -> std::result::Result<usize, String> {
+    let parsed = s.parse::<usize>().map_err(|e| e.to_string())?;
+    if parsed == 0 {
+        Err("must be greater than zero".to_string())
+    } else {
+        Ok(parsed)
+    }
 }

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -264,6 +264,31 @@ fn test_tpcgen_cli_tpcds_parquet_row_group_size_1mb() {
 }
 
 #[test]
+fn test_tpcgen_cli_tpcds_parquet_rejects_zero_row_group_bytes() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--row-group-bytes")
+        .arg("0")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert_eq!(
+        stderr,
+        "error: invalid value '0' for '--row-group-bytes <ROW_GROUP_BYTES>': must be greater than zero\n\nFor more information, try '--help'.\n"
+    );
+}
+
+#[test]
 fn test_tpcgen_cli_tpcds_parquet_unknown_table_error_lists_valid_tables() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 


### PR DESCRIPTION
## Summary

Move TPC-DS parquet row group byte validation into ParquetArgs clap parsing instead of checking it inside ParquetArgs::run.

This follows up on the review comment from PR #341: https://github.com/clflushopt/tpchgen-rs/pull/341#discussion_r3533784008

## Details

The --row-group-bytes argument now parses directly as a usize using a dedicated clap value parser that rejects zero. ParquetArgs::run can pass the parsed value through without manual validation or conversion.

A CLI regression test asserts the full clap error message for --row-group-bytes 0.

## Validation

- cargo test