### PR TITLE
Wire progress tracker with dat/csv/parquet

### DIFF
--- a/tpcgen-cli/src/lib.rs
+++ b/tpcgen-cli/src/lib.rs
@@ -1,5 +1,6 @@
 //! This library contains both the TPCH and TPCDS command line clients.
 mod logging;
 mod parquet;
+pub mod progress;
 pub mod tpcds_cli;
 pub mod tpch_cli;

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use crate::tpch_cli::statistics::WriteStatistics;
 
 pub trait IntoSize {
@@ -182,7 +182,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tpch_cli::progress::ProgressTracker;
+    use crate::progress::ProgressTracker;
     use std::fs::File;
     use std::io::BufWriter;
     use std::sync::{

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -37,7 +37,7 @@
 //!
 //! ```
 //! use std::sync::atomic::{AtomicU64, Ordering};
-//! use tpcgen_cli::tpch_cli::progress::ProgressTracker;
+//! use tpcgen_cli::progress::ProgressTracker;
 //!
 //! #[derive(Debug)]
 //! struct LoggingTracker {

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -1,8 +1,8 @@
 //! TPC-DS data generation CLI with a dbgen compatible API.
 use crate::logging::configure_logging;
 #[cfg(feature = "indicatif-progress")]
-use crate::tpch_cli::progress::IndicatifProgress;
-use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
+use crate::progress::IndicatifProgress;
+use crate::progress::{no_op_progress_tracker, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
 use std::io;

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -1,8 +1,15 @@
 //! TPC-DS data generation CLI with a dbgen compatible API.
 use crate::logging::configure_logging;
+#[cfg(feature = "indicatif-progress")]
+use crate::tpch_cli::progress::IndicatifProgress;
+use crate::tpch_cli::progress::{no_op_progress_tracker, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
+use std::io;
+#[cfg(feature = "indicatif-progress")]
+use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tpcdsgen::config::{CompatMode, Session, SessionBuilder, Table};
 use tpcdsgen::error::TpcdsError;
 
@@ -171,34 +178,49 @@ impl ParquetArgs {
 
 impl CommonArgs {
     fn run_dat(self) -> Result<()> {
-        configure_logging(self.verbose, self.quiet, None);
         let output = dat::Dat::new(self.output_dir.clone())?;
         self.run_output(OutputFormat::Dat(output))
     }
 
     fn run_parquet(self, compression: Compression, row_group_bytes: usize) -> Result<()> {
-        configure_logging(self.verbose, self.quiet, None);
-        let _ = self.progress_bars_enabled;
         let output = parquet::Parquet::new(self.output_dir.clone(), compression, row_group_bytes);
         self.run_output(OutputFormat::Parquet(output))
     }
 
     fn run_csv(self, delimiter: char) -> Result<()> {
-        configure_logging(self.verbose, self.quiet, None);
-        let _ = self.progress_bars_enabled;
         let output = csv::Csv::new(self.output_dir.clone(), delimiter);
         self.run_output(OutputFormat::Csv(output))
     }
 
     fn run_output(self, output_format: OutputFormat) -> Result<()> {
+        let (progress, log_writer) = self.progress_tracker();
+        configure_logging(self.verbose, self.quiet, log_writer);
+
         std::fs::create_dir_all(&self.output_dir)?;
 
         for table in self.tables()? {
             let session = self.to_session(Some(table.get_name().to_string()))?;
-            output_format.generate_table(table, session)?;
+            output_format.generate_table(table, session, progress.as_ref())?;
         }
 
+        progress.finish();
         Ok(())
+    }
+
+    fn progress_tracker(
+        &self,
+    ) -> (
+        Arc<dyn ProgressTracker>,
+        Option<Box<dyn io::Write + Send + 'static>>,
+    ) {
+        #[cfg(feature = "indicatif-progress")]
+        if self.progress_bars_enabled && !self.quiet && io::stderr().is_terminal() {
+            let progress = Arc::new(IndicatifProgress::new());
+            let tracker: Arc<dyn ProgressTracker> = progress.clone();
+            return (tracker, Some(progress.log_writer()));
+        }
+
+        (no_op_progress_tracker(), None)
     }
 
     /// Return the tables that should be generated.
@@ -230,11 +252,16 @@ impl CommonArgs {
 }
 
 impl OutputFormat {
-    fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+    fn generate_table(
+        &self,
+        table: Table,
+        session: Session,
+        progress: &dyn ProgressTracker,
+    ) -> Result<()> {
         match self {
-            OutputFormat::Dat(output) => output.generate_table(table, &session),
-            OutputFormat::Csv(output) => output.generate_table(table, session),
-            OutputFormat::Parquet(output) => output.generate_table(table, session),
+            OutputFormat::Dat(output) => output.generate_table(table, &session, progress),
+            OutputFormat::Csv(output) => output.generate_table(table, session, progress),
+            OutputFormat::Parquet(output) => output.generate_table(table, session, progress),
         }
     }
 }

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -1,5 +1,6 @@
 //! TPC-DS CSV output.
 
+use crate::tpch_cli::progress::ProgressTracker;
 use arrow::array::RecordBatch;
 use arrow::record_batch::RecordBatchReader;
 use arrow_csv::writer::WriterBuilder;
@@ -33,45 +34,121 @@ impl Csv {
     }
 
     /// Generate one TPC-DS table as a CSV file.
-    pub(super) fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+    pub(super) fn generate_table(
+        &self,
+        table: Table,
+        session: Session,
+        progress: &dyn ProgressTracker,
+    ) -> Result<()> {
         let path = self.output_dir.join(format!("{}.csv", table.get_name()));
+        let table_name = table.get_name();
+        let rows: u64 = session
+            .get_scaling()
+            .get_row_count(table)
+            .try_into()
+            .unwrap_or(0);
+        // Progress is row-based: register the table row count, then advance by
+        // each written batch's row count.
+        progress.register(table_name, rows);
 
         match table {
-            Table::CallCenter => self.write_batches(path, CallCenterArrow::new(session)),
-            Table::CatalogPage => self.write_batches(path, CatalogPageArrow::new(session)),
-            Table::CatalogReturns => self.write_batches(path, CatalogReturnsArrow::new(session)),
-            Table::CatalogSales => self.write_batches(path, CatalogSalesArrow::new(session)),
-            Table::Customer => self.write_batches(path, CustomerArrow::new(session)),
-            Table::CustomerAddress => self.write_batches(path, CustomerAddressArrow::new(session)),
-            Table::CustomerDemographics => {
-                self.write_batches(path, CustomerDemographicsArrow::new(session))
+            Table::CallCenter => {
+                self.write_batches(path, CallCenterArrow::new(session), progress, table_name)
             }
-            Table::DateDim => self.write_batches(path, DateDimArrow::new(session)),
-            Table::DbgenVersion => self.write_batches(path, DbgenVersionArrow::new(session)),
-            Table::HouseholdDemographics => {
-                self.write_batches(path, HouseholdDemographicsArrow::new(session))
+            Table::CatalogPage => {
+                self.write_batches(path, CatalogPageArrow::new(session), progress, table_name)
             }
-            Table::IncomeBand => self.write_batches(path, IncomeBandArrow::new(session)),
-            Table::Inventory => self.write_batches(path, InventoryArrow::new(session)),
-            Table::Item => self.write_batches(path, ItemArrow::new(session)),
-            Table::Promotion => self.write_batches(path, PromotionArrow::new(session)),
-            Table::Reason => self.write_batches(path, ReasonArrow::new(session)),
-            Table::ShipMode => self.write_batches(path, ShipModeArrow::new(session)),
-            Table::Store => self.write_batches(path, StoreArrow::new(session)),
-            Table::StoreReturns => self.write_batches(path, StoreReturnsArrow::new(session)),
-            Table::StoreSales => self.write_batches(path, StoreSalesArrow::new(session)),
-            Table::TimeDim => self.write_batches(path, TimeDimArrow::new(session)),
-            Table::Warehouse => self.write_batches(path, WarehouseArrow::new(session)),
-            Table::WebPage => self.write_batches(path, WebPageArrow::new(session)),
-            Table::WebReturns => self.write_batches(path, WebReturnsArrow::new(session)),
-            Table::WebSales => self.write_batches(path, WebSalesArrow::new(session)),
-            Table::WebSite => self.write_batches(path, WebSiteArrow::new(session)),
+            Table::CatalogReturns => self.write_batches(
+                path,
+                CatalogReturnsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::CatalogSales => {
+                self.write_batches(path, CatalogSalesArrow::new(session), progress, table_name)
+            }
+            Table::Customer => {
+                self.write_batches(path, CustomerArrow::new(session), progress, table_name)
+            }
+            Table::CustomerAddress => self.write_batches(
+                path,
+                CustomerAddressArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::CustomerDemographics => self.write_batches(
+                path,
+                CustomerDemographicsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::DateDim => {
+                self.write_batches(path, DateDimArrow::new(session), progress, table_name)
+            }
+            Table::DbgenVersion => {
+                self.write_batches(path, DbgenVersionArrow::new(session), progress, table_name)
+            }
+            Table::HouseholdDemographics => self.write_batches(
+                path,
+                HouseholdDemographicsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::IncomeBand => {
+                self.write_batches(path, IncomeBandArrow::new(session), progress, table_name)
+            }
+            Table::Inventory => {
+                self.write_batches(path, InventoryArrow::new(session), progress, table_name)
+            }
+            Table::Item => self.write_batches(path, ItemArrow::new(session), progress, table_name),
+            Table::Promotion => {
+                self.write_batches(path, PromotionArrow::new(session), progress, table_name)
+            }
+            Table::Reason => {
+                self.write_batches(path, ReasonArrow::new(session), progress, table_name)
+            }
+            Table::ShipMode => {
+                self.write_batches(path, ShipModeArrow::new(session), progress, table_name)
+            }
+            Table::Store => {
+                self.write_batches(path, StoreArrow::new(session), progress, table_name)
+            }
+            Table::StoreReturns => {
+                self.write_batches(path, StoreReturnsArrow::new(session), progress, table_name)
+            }
+            Table::StoreSales => {
+                self.write_batches(path, StoreSalesArrow::new(session), progress, table_name)
+            }
+            Table::TimeDim => {
+                self.write_batches(path, TimeDimArrow::new(session), progress, table_name)
+            }
+            Table::Warehouse => {
+                self.write_batches(path, WarehouseArrow::new(session), progress, table_name)
+            }
+            Table::WebPage => {
+                self.write_batches(path, WebPageArrow::new(session), progress, table_name)
+            }
+            Table::WebReturns => {
+                self.write_batches(path, WebReturnsArrow::new(session), progress, table_name)
+            }
+            Table::WebSales => {
+                self.write_batches(path, WebSalesArrow::new(session), progress, table_name)
+            }
+            Table::WebSite => {
+                self.write_batches(path, WebSiteArrow::new(session), progress, table_name)
+            }
             _ => Ok(()),
         }
     }
 
     /// Write the record batches to a CSV file at the specified path.
-    fn write_batches<I>(&self, path: PathBuf, mut batches: I) -> Result<()>
+    fn write_batches<I>(
+        &self,
+        path: PathBuf,
+        mut batches: I,
+        progress: &dyn ProgressTracker,
+        table_name: &'static str,
+    ) -> Result<()>
     where
         I: RecordBatchReader,
     {
@@ -91,6 +168,7 @@ impl Csv {
         for batch in &mut batches {
             let batch = batch?;
             writer.write(&batch)?;
+            progress.increment(table_name, batch.num_rows() as u64);
         }
 
         let mut writer = writer.into_inner();

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -1,6 +1,6 @@
 //! TPC-DS CSV output.
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use arrow::array::RecordBatch;
 use arrow::record_batch::RecordBatchReader;
 use arrow_csv::writer::WriterBuilder;

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -47,8 +47,8 @@ impl Csv {
             .get_row_count(table)
             .try_into()
             .unwrap_or(0);
-        // Progress is row-based: register the table row count, then advance by
-        // each written batch's row count.
+        // Register the table row count, then advance by each written batch's
+        // row count.
         progress.register(table_name, rows);
 
         match table {

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -218,9 +218,12 @@ impl Dat {
                 &self.output_options,
                 progress,
             ),
-            Table::Inventory => {
-                generate_simple::<InventoryRowGenerator>(table, session, &self.output_options, progress)
-            }
+            Table::Inventory => generate_simple::<InventoryRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
 
             // Sales generators write their return tables at the same time.
             Table::StoreSales => generate_store_sales(session, &self.output_options, progress),

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -285,7 +285,7 @@ fn generate_simple<G: RowGeneratorFactory>(
     let row_count = session.get_scaling().get_row_count(table);
     let table_name = table.get_name();
     // Register the scaling row count, then advance after each written row.
-    progress.register(table_name, progress_units(row_count));
+    progress.register(table_name, row_count.try_into().unwrap_or(0));
 
     let path = get_output_path(table, output_options);
     let file = create_output_file(&path, output_options)?;
@@ -323,12 +323,12 @@ fn generate_store_sales(
 ) -> Result<()> {
     let mut generator = StoreSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::StoreSales);
+    let return_rows = session.get_scaling().get_row_count(Table::StoreReturns);
     let sales_name = Table::StoreSales.get_name();
     let returns_name = Table::StoreReturns.get_name();
-    // Return rows are produced by the sales generator; the return bar completes
-    // after the paired files are written.
-    progress.register(sales_name, progress_units(num_orders));
-    progress.register(returns_name, 1);
+    // Register the scaling row counts, then advance after each written row.
+    progress.register(sales_name, num_orders.try_into().unwrap_or(0));
+    progress.register(returns_name, return_rows.try_into().unwrap_or(0));
 
     let sales_path = get_output_path(Table::StoreSales, output_options);
     let returns_path = get_output_path(Table::StoreReturns, output_options);
@@ -361,6 +361,7 @@ fn generate_store_sales(
         if rows.len() > 1 {
             write_row(&rows[1], &mut returns_writer, output_options)?;
             returns_count += 1;
+            progress.increment(returns_name, 1);
         }
 
         if result.should_end_row() {
@@ -372,7 +373,6 @@ fn generate_store_sales(
 
     sales_writer.flush()?;
     returns_writer.flush()?;
-    progress.increment(returns_name, 1);
 
     info!(
         "Generated store_sales + store_returns: {} sales, {} returns -> {}, {}",
@@ -393,12 +393,12 @@ fn generate_catalog_sales(
 ) -> Result<()> {
     let mut generator = CatalogSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::CatalogSales);
+    let return_rows = session.get_scaling().get_row_count(Table::CatalogReturns);
     let sales_name = Table::CatalogSales.get_name();
     let returns_name = Table::CatalogReturns.get_name();
-    // Return rows are produced by the sales generator; the return bar completes
-    // after the paired files are written.
-    progress.register(sales_name, progress_units(num_orders));
-    progress.register(returns_name, 1);
+    // Register the scaling row counts, then advance after each written row.
+    progress.register(sales_name, num_orders.try_into().unwrap_or(0));
+    progress.register(returns_name, return_rows.try_into().unwrap_or(0));
 
     let sales_path = get_output_path(Table::CatalogSales, output_options);
     let returns_path = get_output_path(Table::CatalogReturns, output_options);
@@ -431,6 +431,7 @@ fn generate_catalog_sales(
         if rows.len() > 1 {
             write_row(&rows[1], &mut returns_writer, output_options)?;
             returns_count += 1;
+            progress.increment(returns_name, 1);
         }
 
         if result.should_end_row() {
@@ -442,7 +443,6 @@ fn generate_catalog_sales(
 
     sales_writer.flush()?;
     returns_writer.flush()?;
-    progress.increment(returns_name, 1);
 
     info!(
         "Generated catalog_sales + catalog_returns: {} sales, {} returns -> {}, {}",
@@ -463,12 +463,12 @@ fn generate_web_sales(
 ) -> Result<()> {
     let mut generator = WebSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::WebSales);
+    let return_rows = session.get_scaling().get_row_count(Table::WebReturns);
     let sales_name = Table::WebSales.get_name();
     let returns_name = Table::WebReturns.get_name();
-    // Return rows are produced by the sales generator; the return bar completes
-    // after the paired files are written.
-    progress.register(sales_name, progress_units(num_orders));
-    progress.register(returns_name, 1);
+    // Register the scaling row counts, then advance after each written row.
+    progress.register(sales_name, num_orders.try_into().unwrap_or(0));
+    progress.register(returns_name, return_rows.try_into().unwrap_or(0));
 
     let sales_path = get_output_path(Table::WebSales, output_options);
     let returns_path = get_output_path(Table::WebReturns, output_options);
@@ -501,6 +501,7 @@ fn generate_web_sales(
         if rows.len() > 1 {
             write_row(&rows[1], &mut returns_writer, output_options)?;
             returns_count += 1;
+            progress.increment(returns_name, 1);
         }
 
         if result.should_end_row() {
@@ -512,7 +513,6 @@ fn generate_web_sales(
 
     sales_writer.flush()?;
     returns_writer.flush()?;
-    progress.increment(returns_name, 1);
 
     info!(
         "Generated web_sales + web_returns: {} sales, {} returns -> {}, {}",
@@ -541,7 +541,7 @@ fn generate_inventory(
     let num_rows = item_count * warehouse_count * n_weeks as i64;
     let table_name = Table::Inventory.get_name();
     // Register the calculated row count, then advance after each written row.
-    progress.register(table_name, progress_units(num_rows));
+    progress.register(table_name, num_rows.try_into().unwrap_or(0));
 
     let path = get_output_path(Table::Inventory, output_options);
     let mut writer = CompatWriter::new(
@@ -570,10 +570,6 @@ fn generate_inventory(
     );
 
     Ok(())
-}
-
-fn progress_units(count: i64) -> u64 {
-    count.try_into().unwrap_or(0)
 }
 
 /// Get output file path for a table

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -16,6 +16,7 @@
 //!
 //! Generates TPC-DS benchmark data with byte-for-byte compatibility with the Java reference.
 
+use crate::tpch_cli::progress::ProgressTracker;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -108,78 +109,127 @@ impl Dat {
         })
     }
 
-    pub(super) fn generate_table(&self, table: Table, session: &Session) -> Result<()> {
+    pub(super) fn generate_table(
+        &self,
+        table: Table,
+        session: &Session,
+        progress: &dyn ProgressTracker,
+    ) -> Result<()> {
         match table {
             // Simple dimension tables
-            Table::CallCenter => {
-                generate_simple::<CallCenterRowGenerator>(table, session, &self.output_options)
-            }
-            Table::CatalogPage => {
-                generate_simple::<CatalogPageRowGenerator>(table, session, &self.output_options)
-            }
-            Table::Customer => {
-                generate_simple::<CustomerRowGenerator>(table, session, &self.output_options)
-            }
-            Table::CustomerAddress => {
-                generate_simple::<CustomerAddressRowGenerator>(table, session, &self.output_options)
-            }
+            Table::CallCenter => generate_simple::<CallCenterRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::CatalogPage => generate_simple::<CatalogPageRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::Customer => generate_simple::<CustomerRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::CustomerAddress => generate_simple::<CustomerAddressRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
             Table::CustomerDemographics => generate_simple::<CustomerDemographicsRowGenerator>(
                 table,
                 session,
                 &self.output_options,
+                progress,
             ),
-            Table::DateDim => {
-                generate_simple::<DateDimRowGenerator>(table, session, &self.output_options)
-            }
-            Table::DbgenVersion => {
-                generate_simple::<DbgenVersionRowGenerator>(table, session, &self.output_options)
-            }
+            Table::DateDim => generate_simple::<DateDimRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::DbgenVersion => generate_simple::<DbgenVersionRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
             Table::HouseholdDemographics => generate_simple::<HouseholdDemographicsRowGenerator>(
                 table,
                 session,
                 &self.output_options,
+                progress,
             ),
-            Table::IncomeBand => {
-                generate_simple::<IncomeBandRowGenerator>(table, session, &self.output_options)
-            }
+            Table::IncomeBand => generate_simple::<IncomeBandRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
             Table::Item => {
-                generate_simple::<ItemRowGenerator>(table, session, &self.output_options)
+                generate_simple::<ItemRowGenerator>(table, session, &self.output_options, progress)
             }
-            Table::Promotion => {
-                generate_simple::<PromotionRowGenerator>(table, session, &self.output_options)
-            }
-            Table::Reason => {
-                generate_simple::<ReasonRowGenerator>(table, session, &self.output_options)
-            }
-            Table::ShipMode => {
-                generate_simple::<ShipModeRowGenerator>(table, session, &self.output_options)
-            }
+            Table::Promotion => generate_simple::<PromotionRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::Reason => generate_simple::<ReasonRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::ShipMode => generate_simple::<ShipModeRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
             Table::Store => {
-                generate_simple::<StoreRowGenerator>(table, session, &self.output_options)
+                generate_simple::<StoreRowGenerator>(table, session, &self.output_options, progress)
             }
-            Table::TimeDim => {
-                generate_simple::<TimeDimRowGenerator>(table, session, &self.output_options)
-            }
-            Table::Warehouse => {
-                generate_simple::<WarehouseRowGenerator>(table, session, &self.output_options)
-            }
-            Table::WebPage => {
-                generate_simple::<WebPageRowGenerator>(table, session, &self.output_options)
-            }
-            Table::WebSite => {
-                generate_simple::<WebSiteRowGenerator>(table, session, &self.output_options)
-            }
+            Table::TimeDim => generate_simple::<TimeDimRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::Warehouse => generate_simple::<WarehouseRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::WebPage => generate_simple::<WebPageRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
+            Table::WebSite => generate_simple::<WebSiteRowGenerator>(
+                table,
+                session,
+                &self.output_options,
+                progress,
+            ),
 
-            // Sales + Returns pairs
-            Table::StoreSales => generate_store_sales(session, &self.output_options),
+            // Sales generators write their return tables at the same time.
+            Table::StoreSales => generate_store_sales(session, &self.output_options, progress),
             Table::StoreReturns => Ok(()), // Generated with StoreSales
-            Table::CatalogSales => generate_catalog_sales(session, &self.output_options),
+            Table::CatalogSales => generate_catalog_sales(session, &self.output_options, progress),
             Table::CatalogReturns => Ok(()), // Generated with CatalogSales
-            Table::WebSales => generate_web_sales(session, &self.output_options),
+            Table::WebSales => generate_web_sales(session, &self.output_options, progress),
             Table::WebReturns => Ok(()), // Generated with WebSales
 
             // Special tables
-            Table::Inventory => generate_inventory(session, &self.output_options),
+            Table::Inventory => generate_inventory(session, &self.output_options, progress),
 
             // Source tables - skip
             _ => Ok(()),
@@ -224,14 +274,19 @@ impl_factory!(
     WebSiteRowGenerator
 );
 
-/// Generate a simple table (one row per row_number, no child tables)
+/// Generate a simple table (one row per row_number, no paired return output)
 fn generate_simple<G: RowGeneratorFactory>(
     table: Table,
     session: &Session,
     output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
 ) -> Result<()> {
     let mut generator = G::create();
     let row_count = session.get_scaling().get_row_count(table);
+    let table_name = table.get_name();
+    // Progress is row-based: register the table row count, then advance after
+    // each written row.
+    progress.register(table_name, progress_units(row_count));
 
     let path = get_output_path(table, output_options);
     let file = create_output_file(&path, output_options)?;
@@ -247,6 +302,7 @@ fn generate_simple<G: RowGeneratorFactory>(
         }
 
         generator.consume_remaining_seeds_for_row();
+        progress.increment(table_name, 1);
     }
 
     writer.flush()?;
@@ -261,9 +317,19 @@ fn generate_simple<G: RowGeneratorFactory>(
 }
 
 /// Generate store_sales and store_returns together
-fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_store_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     let mut generator = StoreSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::StoreSales);
+    let sales_name = Table::StoreSales.get_name();
+    let returns_name = Table::StoreReturns.get_name();
+    // Return rows are produced by the sales generator; the return bar completes
+    // after the paired files are written.
+    progress.register(sales_name, progress_units(num_orders));
+    progress.register(returns_name, 1);
 
     let sales_path = get_output_path(Table::StoreSales, output_options);
     let returns_path = get_output_path(Table::StoreReturns, output_options);
@@ -301,11 +367,13 @@ fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Re
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment(sales_name, 1);
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
+    progress.increment(returns_name, 1);
 
     info!(
         "Generated store_sales + store_returns: {} sales, {} returns -> {}, {}",
@@ -319,9 +387,19 @@ fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Re
 }
 
 /// Generate catalog_sales and catalog_returns together
-fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_catalog_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     let mut generator = CatalogSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::CatalogSales);
+    let sales_name = Table::CatalogSales.get_name();
+    let returns_name = Table::CatalogReturns.get_name();
+    // Return rows are produced by the sales generator; the return bar completes
+    // after the paired files are written.
+    progress.register(sales_name, progress_units(num_orders));
+    progress.register(returns_name, 1);
 
     let sales_path = get_output_path(Table::CatalogSales, output_options);
     let returns_path = get_output_path(Table::CatalogReturns, output_options);
@@ -359,11 +437,13 @@ fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> 
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment(sales_name, 1);
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
+    progress.increment(returns_name, 1);
 
     info!(
         "Generated catalog_sales + catalog_returns: {} sales, {} returns -> {}, {}",
@@ -377,9 +457,19 @@ fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> 
 }
 
 /// Generate web_sales and web_returns together
-fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_web_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     let mut generator = WebSalesRowGenerator::new();
     let num_orders = session.get_scaling().get_row_count(Table::WebSales);
+    let sales_name = Table::WebSales.get_name();
+    let returns_name = Table::WebReturns.get_name();
+    // Return rows are produced by the sales generator; the return bar completes
+    // after the paired files are written.
+    progress.register(sales_name, progress_units(num_orders));
+    progress.register(returns_name, 1);
 
     let sales_path = get_output_path(Table::WebSales, output_options);
     let returns_path = get_output_path(Table::WebReturns, output_options);
@@ -417,11 +507,13 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
+            progress.increment(sales_name, 1);
         }
     }
 
     sales_writer.flush()?;
     returns_writer.flush()?;
+    progress.increment(returns_name, 1);
 
     info!(
         "Generated web_sales + web_returns: {} sales, {} returns -> {}, {}",
@@ -435,7 +527,11 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
 }
 
 /// Generate inventory table (special row count calculation)
-fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_inventory(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     let mut generator = InventoryRowGenerator::new();
     let scaling = session.get_scaling();
 
@@ -444,6 +540,10 @@ fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Resu
     let n_days = Date::JULIAN_DATE_MAXIMUM - Date::JULIAN_DATE_MINIMUM;
     let n_weeks = (n_days + 7) / 7;
     let num_rows = item_count * warehouse_count * n_weeks as i64;
+    let table_name = Table::Inventory.get_name();
+    // Progress is row-based: register the table row count, then advance after
+    // each written row.
+    progress.register(table_name, progress_units(num_rows));
 
     let path = get_output_path(Table::Inventory, output_options);
     let mut writer = CompatWriter::new(
@@ -461,6 +561,7 @@ fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Resu
         }
 
         generator.consume_remaining_seeds_for_row();
+        progress.increment(table_name, 1);
     }
 
     writer.flush()?;
@@ -471,6 +572,10 @@ fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Resu
     );
 
     Ok(())
+}
+
+fn progress_units(count: i64) -> u64 {
+    count.try_into().unwrap_or(0)
 }
 
 /// Get output file path for a table

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -16,7 +16,7 @@
 //!
 //! Generates TPC-DS benchmark data with byte-for-byte compatibility with the Java reference.
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -284,8 +284,7 @@ fn generate_simple<G: RowGeneratorFactory>(
     let mut generator = G::create();
     let row_count = session.get_scaling().get_row_count(table);
     let table_name = table.get_name();
-    // Progress is row-based: register the table row count, then advance after
-    // each written row.
+    // Register the scaling row count, then advance after each written row.
     progress.register(table_name, progress_units(row_count));
 
     let path = get_output_path(table, output_options);
@@ -541,8 +540,7 @@ fn generate_inventory(
     let n_weeks = (n_days + 7) / 7;
     let num_rows = item_count * warehouse_count * n_weeks as i64;
     let table_name = Table::Inventory.get_name();
-    // Progress is row-based: register the table row count, then advance after
-    // each written row.
+    // Register the calculated row count, then advance after each written row.
     progress.register(table_name, progress_units(num_rows));
 
     let path = get_output_path(Table::Inventory, output_options);

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -56,8 +56,8 @@ impl Parquet {
             .get_row_count(table)
             .try_into()
             .unwrap_or(0);
-        // Progress is row-based: register the table row count, then advance by
-        // each written batch's row count.
+        // Register the table row count, then advance by each written batch's
+        // row count.
         progress.register(table_name, rows);
 
         match table {

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -1,6 +1,6 @@
 //! TPC-DS Parquet output.
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use arrow::record_batch::RecordBatchReader;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -1,5 +1,6 @@
 //! TPC-DS Parquet output.
 
+use crate::tpch_cli::progress::ProgressTracker;
 use arrow::record_batch::RecordBatchReader;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
@@ -40,47 +41,123 @@ impl Parquet {
     }
 
     /// Generate one TPC-DS table as a Parquet file.
-    pub(super) fn generate_table(&self, table: Table, session: Session) -> Result<()> {
+    pub(super) fn generate_table(
+        &self,
+        table: Table,
+        session: Session,
+        progress: &dyn ProgressTracker,
+    ) -> Result<()> {
         let path = self
             .output_dir
             .join(format!("{}.parquet", table.get_name()));
+        let table_name = table.get_name();
+        let rows: u64 = session
+            .get_scaling()
+            .get_row_count(table)
+            .try_into()
+            .unwrap_or(0);
+        // Progress is row-based: register the table row count, then advance by
+        // each written batch's row count.
+        progress.register(table_name, rows);
 
         match table {
-            Table::CallCenter => self.write_batches(path, CallCenterArrow::new(session)),
-            Table::CatalogPage => self.write_batches(path, CatalogPageArrow::new(session)),
-            Table::CatalogReturns => self.write_batches(path, CatalogReturnsArrow::new(session)),
-            Table::CatalogSales => self.write_batches(path, CatalogSalesArrow::new(session)),
-            Table::Customer => self.write_batches(path, CustomerArrow::new(session)),
-            Table::CustomerAddress => self.write_batches(path, CustomerAddressArrow::new(session)),
-            Table::CustomerDemographics => {
-                self.write_batches(path, CustomerDemographicsArrow::new(session))
+            Table::CallCenter => {
+                self.write_batches(path, CallCenterArrow::new(session), progress, table_name)
             }
-            Table::DateDim => self.write_batches(path, DateDimArrow::new(session)),
-            Table::DbgenVersion => self.write_batches(path, DbgenVersionArrow::new(session)),
-            Table::HouseholdDemographics => {
-                self.write_batches(path, HouseholdDemographicsArrow::new(session))
+            Table::CatalogPage => {
+                self.write_batches(path, CatalogPageArrow::new(session), progress, table_name)
             }
-            Table::IncomeBand => self.write_batches(path, IncomeBandArrow::new(session)),
-            Table::Inventory => self.write_batches(path, InventoryArrow::new(session)),
-            Table::Item => self.write_batches(path, ItemArrow::new(session)),
-            Table::Promotion => self.write_batches(path, PromotionArrow::new(session)),
-            Table::Reason => self.write_batches(path, ReasonArrow::new(session)),
-            Table::ShipMode => self.write_batches(path, ShipModeArrow::new(session)),
-            Table::Store => self.write_batches(path, StoreArrow::new(session)),
-            Table::StoreReturns => self.write_batches(path, StoreReturnsArrow::new(session)),
-            Table::StoreSales => self.write_batches(path, StoreSalesArrow::new(session)),
-            Table::TimeDim => self.write_batches(path, TimeDimArrow::new(session)),
-            Table::Warehouse => self.write_batches(path, WarehouseArrow::new(session)),
-            Table::WebPage => self.write_batches(path, WebPageArrow::new(session)),
-            Table::WebReturns => self.write_batches(path, WebReturnsArrow::new(session)),
-            Table::WebSales => self.write_batches(path, WebSalesArrow::new(session)),
-            Table::WebSite => self.write_batches(path, WebSiteArrow::new(session)),
+            Table::CatalogReturns => self.write_batches(
+                path,
+                CatalogReturnsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::CatalogSales => {
+                self.write_batches(path, CatalogSalesArrow::new(session), progress, table_name)
+            }
+            Table::Customer => {
+                self.write_batches(path, CustomerArrow::new(session), progress, table_name)
+            }
+            Table::CustomerAddress => self.write_batches(
+                path,
+                CustomerAddressArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::CustomerDemographics => self.write_batches(
+                path,
+                CustomerDemographicsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::DateDim => {
+                self.write_batches(path, DateDimArrow::new(session), progress, table_name)
+            }
+            Table::DbgenVersion => {
+                self.write_batches(path, DbgenVersionArrow::new(session), progress, table_name)
+            }
+            Table::HouseholdDemographics => self.write_batches(
+                path,
+                HouseholdDemographicsArrow::new(session),
+                progress,
+                table_name,
+            ),
+            Table::IncomeBand => {
+                self.write_batches(path, IncomeBandArrow::new(session), progress, table_name)
+            }
+            Table::Inventory => {
+                self.write_batches(path, InventoryArrow::new(session), progress, table_name)
+            }
+            Table::Item => self.write_batches(path, ItemArrow::new(session), progress, table_name),
+            Table::Promotion => {
+                self.write_batches(path, PromotionArrow::new(session), progress, table_name)
+            }
+            Table::Reason => {
+                self.write_batches(path, ReasonArrow::new(session), progress, table_name)
+            }
+            Table::ShipMode => {
+                self.write_batches(path, ShipModeArrow::new(session), progress, table_name)
+            }
+            Table::Store => {
+                self.write_batches(path, StoreArrow::new(session), progress, table_name)
+            }
+            Table::StoreReturns => {
+                self.write_batches(path, StoreReturnsArrow::new(session), progress, table_name)
+            }
+            Table::StoreSales => {
+                self.write_batches(path, StoreSalesArrow::new(session), progress, table_name)
+            }
+            Table::TimeDim => {
+                self.write_batches(path, TimeDimArrow::new(session), progress, table_name)
+            }
+            Table::Warehouse => {
+                self.write_batches(path, WarehouseArrow::new(session), progress, table_name)
+            }
+            Table::WebPage => {
+                self.write_batches(path, WebPageArrow::new(session), progress, table_name)
+            }
+            Table::WebReturns => {
+                self.write_batches(path, WebReturnsArrow::new(session), progress, table_name)
+            }
+            Table::WebSales => {
+                self.write_batches(path, WebSalesArrow::new(session), progress, table_name)
+            }
+            Table::WebSite => {
+                self.write_batches(path, WebSiteArrow::new(session), progress, table_name)
+            }
             _ => Ok(()),
         }
     }
 
     /// Write the record batches to a Parquet file at the specified path.
-    fn write_batches<I>(&self, path: PathBuf, mut batches: I) -> Result<()>
+    fn write_batches<I>(
+        &self,
+        path: PathBuf,
+        mut batches: I,
+        progress: &dyn ProgressTracker,
+        table_name: &'static str,
+    ) -> Result<()>
     where
         I: RecordBatchReader,
     {
@@ -97,6 +174,7 @@ impl Parquet {
         for batch in &mut batches {
             let batch = batch?;
             writer.write(&batch)?;
+            progress.increment(table_name, batch.num_rows() as u64);
         }
 
         writer.close()?;

--- a/tpcgen-cli/src/tpch_cli.rs
+++ b/tpcgen-cli/src/tpch_cli.rs
@@ -8,11 +8,11 @@ pub mod generate;
 pub mod output_plan;
 pub mod parquet;
 pub mod plan;
-pub mod progress;
 pub mod runner;
 pub mod statistics;
 pub mod tbl;
 
+pub use crate::progress;
 pub use cli::Cli;
 pub use generator::{
     Compression, GeneratorConfig, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "indicatif-progress")]
-use super::progress::IndicatifProgress;
 use super::{
     Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
     DEFAULT_PARQUET_ROW_GROUP_BYTES,
 };
 use crate::logging::configure_logging;
+#[cfg(feature = "indicatif-progress")]
+use crate::progress::IndicatifProgress;
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
 use std::io;

--- a/tpcgen-cli/src/tpch_cli/generate.rs
+++ b/tpcgen-cli/src/tpch_cli/generate.rs
@@ -3,7 +3,7 @@
 //! These traits and function are used to generate data in parallel and write it to a sink
 //! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use futures::StreamExt;
 use log::debug;
 use std::collections::VecDeque;
@@ -175,7 +175,7 @@ impl BufferRecycler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tpch_cli::progress::ProgressTracker;
+    use crate::progress::ProgressTracker;
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Mutex,

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -2,9 +2,9 @@ use super::generate::Sink;
 use super::output_plan::OutputPlanGenerator;
 use super::parquet::IntoSize;
 use super::plan::DEFAULT_PARQUET_ROW_GROUP_BYTES;
-use super::progress::{no_op_progress_tracker, ProgressTracker};
 use super::runner::PlanRunner;
 use super::statistics::WriteStatistics;
+use crate::progress::{no_op_progress_tracker, ProgressTracker};
 pub use ::parquet::basic::Compression;
 use log::info;
 use std::fmt::Display;
@@ -382,7 +382,7 @@ impl TpchGeneratorBuilder {
     ///
     /// The runner calls [`ProgressTracker::finish`] on successful completion.
     /// Trackers that need error or panic cleanup should use `Drop` as a
-    /// fallback. See [`crate::tpch_cli::progress`] for the full contract and examples.
+    /// fallback. See [`crate::progress`] for the full contract and examples.
     pub fn with_progress_tracker(mut self, tracker: Arc<dyn ProgressTracker>) -> Self {
         self.progress_tracker = tracker;
         self
@@ -406,7 +406,7 @@ impl Default for TpchGeneratorBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tpch_cli::progress::ProgressTracker;
+    use crate::progress::ProgressTracker;
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,

--- a/tpcgen-cli/src/tpch_cli/parquet.rs
+++ b/tpcgen-cli/src/tpch_cli/parquet.rs
@@ -1,6 +1,6 @@
 //! TPCH Parquet output format.
 
-use crate::tpch_cli::progress::ProgressTracker;
+use crate::progress::ProgressTracker;
 use arrow::record_batch::RecordBatchReader;
 use parquet::basic::Compression;
 use std::io;

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -1,12 +1,12 @@
 //! [`PlanRunner`] for running [`OutputPlan`]s.
 
+use crate::progress::no_op_progress_tracker;
+use crate::progress::ProgressTracker;
 use crate::tpch_cli::csv::*;
 use crate::tpch_cli::generate::generate_in_chunks;
 use crate::tpch_cli::generate::Source;
 use crate::tpch_cli::output_plan::{OutputLocation, OutputPlan};
 use crate::tpch_cli::parquet::generate_parquet;
-use crate::tpch_cli::progress::no_op_progress_tracker;
-use crate::tpch_cli::progress::ProgressTracker;
 use crate::tpch_cli::tbl::*;
 use crate::tpch_cli::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::tpch_cli::{OutputFormat, Table, WriterSink};
@@ -476,7 +476,7 @@ define_run!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tpch_cli::progress::ProgressTracker;
+    use crate::progress::ProgressTracker;
     use crate::tpch_cli::{Compression, GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};
     use std::sync::{
         atomic::{AtomicU64, Ordering},


### PR DESCRIPTION
Closes #302

Wire up the default indicatif progress tracker with the `tpcgen` CLI for dat/csv/parquet. 

### Dat
https://github.com/user-attachments/assets/4d7b0d3a-5480-47a6-9a61-b94d3e5b9332

### Csv
https://github.com/user-attachments/assets/45541410-8849-4664-be79-8e19bfc63a69

### Parquet
https://github.com/user-attachments/assets/cb9a9f1c-0a6a-407a-853d-324a611b49ef

Also moved `progress.rs` to a common shared location

Note: progress for parent/child return tables is **best effort** because return rows are generated during parent sales generation, so their exact totals are not known up front. This leads to some incomplete progress bars. Will follow up and investigate how to fix it