### PR TITLE
refactor: simplify TPC-DS inventory DAT generation

### DIFF
--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -25,7 +25,6 @@ use tpcdsgen::config::{Session, Table};
 use tpcdsgen::error::InvalidOptionError;
 use tpcdsgen::output::CompatWriter;
 use tpcdsgen::row::{GeneratedRow, TableRow, *};
-use tpcdsgen::types::Date;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -178,8 +177,9 @@ impl Dat {
             Table::WebSales => generate_web_sales(session, &self.output_options),
             Table::WebReturns => Ok(()), // Generated with WebSales
 
-            // Special tables
-            Table::Inventory => generate_inventory(session, &self.output_options),
+            Table::Inventory => {
+                generate_simple::<InventoryRowGenerator>(table, session, &self.output_options)
+            }
 
             // Source tables - skip
             _ => Ok(()),
@@ -213,6 +213,7 @@ impl_factory!(
     DbgenVersionRowGenerator,
     HouseholdDemographicsRowGenerator,
     IncomeBandRowGenerator,
+    InventoryRowGenerator,
     ItemRowGenerator,
     PromotionRowGenerator,
     ReasonRowGenerator,
@@ -429,45 +430,6 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
         returns_count,
         sales_path.display(),
         returns_path.display()
-    );
-
-    Ok(())
-}
-
-/// Generate inventory table (special row count calculation)
-fn generate_inventory(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    let mut generator = InventoryRowGenerator::new();
-    let scaling = session.get_scaling();
-
-    let item_count = scaling.get_id_count(Table::Item);
-    let warehouse_count = scaling.get_row_count(Table::Warehouse);
-    let n_days = Date::JULIAN_DATE_MAXIMUM - Date::JULIAN_DATE_MINIMUM;
-    let n_weeks = (n_days + 7) / 7;
-    let num_rows = item_count * warehouse_count * n_weeks as i64;
-
-    let path = get_output_path(Table::Inventory, output_options);
-    let mut writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&path, output_options)?),
-        session.get_compat_mode(),
-    );
-
-    info!("Generating inventory...");
-
-    for row_number in 1..=num_rows {
-        let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
-
-        for row in result.get_rows() {
-            write_row(row, &mut writer, output_options)?;
-        }
-
-        generator.consume_remaining_seeds_for_row();
-    }
-
-    writer.flush()?;
-    info!(
-        "Generated inventory: {} rows -> {}",
-        num_rows,
-        path.display()
     );
 
     Ok(())

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -168,6 +168,9 @@ impl Dat {
             Table::WebSite => {
                 generate_simple::<WebSiteRowGenerator>(table, session, &self.output_options)
             }
+            Table::Inventory => {
+                generate_simple::<InventoryRowGenerator>(table, session, &self.output_options)
+            }
 
             // Sales + Returns pairs
             Table::StoreSales => generate_store_sales(session, &self.output_options),
@@ -176,10 +179,6 @@ impl Dat {
             Table::CatalogReturns => Ok(()), // Generated with CatalogSales
             Table::WebSales => generate_web_sales(session, &self.output_options),
             Table::WebReturns => Ok(()), // Generated with WebSales
-
-            Table::Inventory => {
-                generate_simple::<InventoryRowGenerator>(table, session, &self.output_options)
-            }
 
             // Source tables - skip
             _ => Ok(()),


### PR DESCRIPTION
I was looking at the `dat.rs` code and noticed that `generate_inventory` only differs from `generate_simple` in its special row-count logic, which is already handled by [`Scaling::get_row_count`](https://github.com/clflushopt/tpchgen-rs/blob/main/tpcdsgen/src/config/scaling.rs#L46-L50).

We can remove this helper function and reuse `generate_simple` instead.