### PR TITLE
[tpcgen-cli] Fix TPC-DS dat table selection

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -173,7 +173,10 @@ impl CommonArgs {
     fn run_dat(self) -> Result<()> {
         configure_logging(self.verbose, self.quiet, None);
         let output = dat::Dat::new(self.output_dir.clone())?;
-        self.run_output(OutputFormat::Dat(output))
+        let tables = self.dat_tables()?;
+        // DAT return tables are emitted as side effects of their sales table generator.
+        // CSV and Parquet have direct return-table generators and do not need expansion.
+        self.run_output_with_tables(OutputFormat::Dat(output), tables)
     }
 
     fn run_parquet(self, compression: Compression, row_group_bytes: usize) -> Result<()> {
@@ -191,9 +194,14 @@ impl CommonArgs {
     }
 
     fn run_output(self, output_format: OutputFormat) -> Result<()> {
+        let tables = self.tables()?;
+        self.run_output_with_tables(output_format, tables)
+    }
+
+    fn run_output_with_tables(self, output_format: OutputFormat, tables: Vec<Table>) -> Result<()> {
         std::fs::create_dir_all(&self.output_dir)?;
 
-        for table in self.tables()? {
+        for table in tables {
             let session = self.to_session(Some(table.get_name().to_string()))?;
             output_format.generate_table(table, session)?;
         }
@@ -208,6 +216,24 @@ impl CommonArgs {
         } else {
             Ok(Table::main_tables())
         }
+    }
+
+    /// Return the DAT tables to generate, mapping return-only selections to
+    /// their sales table generators because DAT emits return files as side effects.
+    fn dat_tables(&self) -> Result<Vec<Table>> {
+        let mut tables = Vec::new();
+        for table in self.tables()? {
+            let table = match table {
+                Table::CatalogReturns => Table::CatalogSales,
+                Table::StoreReturns => Table::StoreSales,
+                Table::WebReturns => Table::WebSales,
+                table => table,
+            };
+            if !tables.contains(&table) {
+                tables.push(table);
+            }
+        }
+        Ok(tables)
     }
 
     fn to_session(&self, table: Option<String>) -> Result<Session> {

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::fs::File;
 use tempfile::tempdir;
+use tpcdsgen::config::Table;
 
 /// Test that TPC-DS DAT generation is quiet unless logging is explicitly enabled.
 #[test]
@@ -339,6 +340,34 @@ fn test_tpcgen_cli_tpcds_dat_multiple_table_selection_command_forms() {
             2,
             "Expected `tpcgen-cli {}` to produce the selected table output set",
             form.join(" ")
+        );
+    }
+}
+
+/// Test each TPC-DS DAT table can be selected individually and creates output.
+#[test]
+fn test_tpcgen_cli_tpcds_dat_individual_table_selection_outputs_requested_table() {
+    // The CLI accepts only main tables; source/internal tables are rejected by parse_table.
+    for table in Table::main_tables() {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen-cli")
+            .arg("tpcds")
+            .arg("dat")
+            .arg("--scale-factor")
+            .arg("0")
+            .arg("--tables")
+            .arg(table.get_name())
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .assert()
+            .success();
+
+        let expected_file = temp_dir.path().join(format!("{}.dat", table.get_name()));
+        assert!(
+            expected_file.exists(),
+            "Expected selecting {table} to create {:?}",
+            expected_file
         );
     }
 }


### PR DESCRIPTION
- Closes #301

## Summary
- Fix `tpcgen tpcds dat --tables <return_table>` so return-only selections generate the requested DAT output.
- Map DAT return-table selections to their paired sales generators, which emit both sales and returns files.
- Add DAT individual table-selection coverage to catch return-only no-output regressions.

## Root cause
The DAT writer emits `store_returns`, `catalog_returns`, and `web_returns` as side effects of the corresponding sales generators. Selecting a return table directly previously called a DAT match arm that returned `Ok(())`, so the command succeeded without creating the requested file.

## Validation
- `cargo fmt -p tpcgen-cli -- --check`
- `cargo test -p tpcgen-cli --test cli_integration tpcds::`

