### PR TITLE
refactor: share TPC-DS sales returns DAT generation

### DIFF
--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -326,32 +326,47 @@ fn generate_simple<G: RowGeneratorFactory>(
 }
 
 /// Generate store_sales and store_returns together
-fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_store_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     generate_sales_and_returns::<StoreSalesRowGenerator>(
         Table::StoreSales,
         Table::StoreReturns,
         session,
         output_options,
+        progress,
     )
 }
 
 /// Generate catalog_sales and catalog_returns together
-fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_catalog_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     generate_sales_and_returns::<CatalogSalesRowGenerator>(
         Table::CatalogSales,
         Table::CatalogReturns,
         session,
         output_options,
+        progress,
     )
 }
 
 /// Generate web_sales and web_returns together
-fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
+fn generate_web_sales(
+    session: &Session,
+    output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
+) -> Result<()> {
     generate_sales_and_returns::<WebSalesRowGenerator>(
         Table::WebSales,
         Table::WebReturns,
         session,
         output_options,
+        progress,
     )
 }
 
@@ -364,9 +379,16 @@ fn generate_sales_and_returns<G: RowGeneratorFactory>(
     returns_table: Table,
     session: &Session,
     output_options: &OutputOptions,
+    progress: &dyn ProgressTracker,
 ) -> Result<()> {
     let mut generator = G::create();
     let source_row_count = session.get_scaling().get_row_count(sales_table);
+    let return_row_count = session.get_scaling().get_row_count(returns_table);
+    let sales_name = sales_table.get_name();
+    let returns_name = returns_table.get_name();
+    // Register the scaling row counts, then advance after each written row.
+    progress.register(sales_name, source_row_count.try_into().unwrap_or(0));
+    progress.register(returns_name, return_row_count.try_into().unwrap_or(0));
 
     let sales_path = get_output_path(sales_table, output_options);
     let returns_path = get_output_path(returns_table, output_options);

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -191,7 +191,6 @@ trait RowGeneratorFactory: RowGenerator + Sized {
     fn create() -> Self;
 }
 
-// Implement factory for all simple generators
 macro_rules! impl_factory {
     ($($gen:ty),*) => {
         $(
@@ -202,6 +201,7 @@ macro_rules! impl_factory {
     };
 }
 
+// Implement factory for all simple generators
 impl_factory!(
     CallCenterRowGenerator,
     CatalogPageRowGenerator,
@@ -222,6 +222,13 @@ impl_factory!(
     WarehouseRowGenerator,
     WebPageRowGenerator,
     WebSiteRowGenerator
+);
+
+// Implement factory for generators that emit sales and returns rows
+impl_factory!(
+    CatalogSalesRowGenerator,
+    StoreSalesRowGenerator,
+    WebSalesRowGenerator
 );
 
 /// Generate a simple table (one row per row_number, no child tables)
@@ -262,127 +269,49 @@ fn generate_simple<G: RowGeneratorFactory>(
 
 /// Generate store_sales and store_returns together
 fn generate_store_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    let mut generator = StoreSalesRowGenerator::new();
-    let num_orders = session.get_scaling().get_row_count(Table::StoreSales);
-
-    let sales_path = get_output_path(Table::StoreSales, output_options);
-    let returns_path = get_output_path(Table::StoreReturns, output_options);
-
-    let compat_mode = session.get_compat_mode();
-    let mut sales_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&sales_path, output_options)?),
-        compat_mode,
-    );
-    let mut returns_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&returns_path, output_options)?),
-        compat_mode,
-    );
-
-    info!("Generating store_sales + store_returns...");
-
-    let mut sales_count = 0i64;
-    let mut returns_count = 0i64;
-    let mut row_number = 1i64;
-
-    while row_number <= num_orders {
-        let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
-        let rows = result.get_rows();
-
-        if !rows.is_empty() {
-            write_row(&rows[0], &mut sales_writer, output_options)?;
-            sales_count += 1;
-        }
-
-        if rows.len() > 1 {
-            write_row(&rows[1], &mut returns_writer, output_options)?;
-            returns_count += 1;
-        }
-
-        if result.should_end_row() {
-            generator.consume_remaining_seeds_for_row();
-            row_number += 1;
-        }
-    }
-
-    sales_writer.flush()?;
-    returns_writer.flush()?;
-
-    info!(
-        "Generated store_sales + store_returns: {} sales, {} returns -> {}, {}",
-        sales_count,
-        returns_count,
-        sales_path.display(),
-        returns_path.display()
-    );
-
-    Ok(())
+    generate_sales_and_returns::<StoreSalesRowGenerator>(
+        Table::StoreSales,
+        Table::StoreReturns,
+        session,
+        output_options,
+    )
 }
 
 /// Generate catalog_sales and catalog_returns together
 fn generate_catalog_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    let mut generator = CatalogSalesRowGenerator::new();
-    let num_orders = session.get_scaling().get_row_count(Table::CatalogSales);
-
-    let sales_path = get_output_path(Table::CatalogSales, output_options);
-    let returns_path = get_output_path(Table::CatalogReturns, output_options);
-
-    let compat_mode = session.get_compat_mode();
-    let mut sales_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&sales_path, output_options)?),
-        compat_mode,
-    );
-    let mut returns_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&returns_path, output_options)?),
-        compat_mode,
-    );
-
-    info!("Generating catalog_sales + catalog_returns...");
-
-    let mut sales_count = 0i64;
-    let mut returns_count = 0i64;
-    let mut row_number = 1i64;
-
-    while row_number <= num_orders {
-        let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
-        let rows = result.get_rows();
-
-        if !rows.is_empty() {
-            write_row(&rows[0], &mut sales_writer, output_options)?;
-            sales_count += 1;
-        }
-
-        if rows.len() > 1 {
-            write_row(&rows[1], &mut returns_writer, output_options)?;
-            returns_count += 1;
-        }
-
-        if result.should_end_row() {
-            generator.consume_remaining_seeds_for_row();
-            row_number += 1;
-        }
-    }
-
-    sales_writer.flush()?;
-    returns_writer.flush()?;
-
-    info!(
-        "Generated catalog_sales + catalog_returns: {} sales, {} returns -> {}, {}",
-        sales_count,
-        returns_count,
-        sales_path.display(),
-        returns_path.display()
-    );
-
-    Ok(())
+    generate_sales_and_returns::<CatalogSalesRowGenerator>(
+        Table::CatalogSales,
+        Table::CatalogReturns,
+        session,
+        output_options,
+    )
 }
 
 /// Generate web_sales and web_returns together
 fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Result<()> {
-    let mut generator = WebSalesRowGenerator::new();
-    let num_orders = session.get_scaling().get_row_count(Table::WebSales);
+    generate_sales_and_returns::<WebSalesRowGenerator>(
+        Table::WebSales,
+        Table::WebReturns,
+        session,
+        output_options,
+    )
+}
 
-    let sales_path = get_output_path(Table::WebSales, output_options);
-    let returns_path = get_output_path(Table::WebReturns, output_options);
+/// Generate sales and returns tables in one pass.
+///
+/// Sales generators can emit rows for both output tables. Keeping them paired
+/// preserves row advancement and seed consumption.
+fn generate_sales_and_returns<G: RowGeneratorFactory>(
+    sales_table: Table,
+    returns_table: Table,
+    session: &Session,
+    output_options: &OutputOptions,
+) -> Result<()> {
+    let mut generator = G::create();
+    let source_row_count = session.get_scaling().get_row_count(sales_table);
+
+    let sales_path = get_output_path(sales_table, output_options);
+    let returns_path = get_output_path(returns_table, output_options);
 
     let compat_mode = session.get_compat_mode();
     let mut sales_writer = CompatWriter::new(
@@ -394,13 +323,17 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
         compat_mode,
     );
 
-    info!("Generating web_sales + web_returns...");
+    info!(
+        "Generating {} + {}...",
+        sales_table.get_name(),
+        returns_table.get_name()
+    );
 
     let mut sales_count = 0i64;
     let mut returns_count = 0i64;
     let mut row_number = 1i64;
 
-    while row_number <= num_orders {
+    while row_number <= source_row_count {
         let result = generator.generate_row_and_child_rows(row_number, session, None, None)?;
         let rows = result.get_rows();
 
@@ -424,7 +357,9 @@ fn generate_web_sales(session: &Session, output_options: &OutputOptions) -> Resu
     returns_writer.flush()?;
 
     info!(
-        "Generated web_sales + web_returns: {} sales, {} returns -> {}, {}",
+        "Generated {} + {}: {} sales, {} returns -> {}, {}",
+        sales_table.get_name(),
+        returns_table.get_name(),
         sales_count,
         returns_count,
         sales_path.display(),


### PR DESCRIPTION
This refactor is purely optional. I feel like it makes the code cleaner and easier to understand

## Summary
- keep table-specific sales/returns entry points for readability
- share the duplicated DAT loop through `generate_sales_and_returns`
- preserve one-pass paired generation for sales and optional returns rows

## Testing
- `cargo fmt --check`
- `cargo test -p tpcgen-cli test_tpcgen_cli_tpcds_dat_default_options_generate_all_outputs`
- `cd tpcdsgen && ./scripts/compare-all-tables.sh --quiet`