### PR TITLE
feat: use fmt::Display buffering for Dat output

### DIFF
--- a/tpcdsgen/src/output.rs
+++ b/tpcdsgen/src/output.rs
@@ -294,7 +294,7 @@ mod tests {
         let mut writer = DatWriter::new(&mut out, CompatMode::Trino);
         writer.write_display_row(&TestRow).unwrap();
         // Small rows stay buffered until an explicit flush.
-        assert!(writer.buffer().len() > 0);
+        assert!(!writer.buffer.is_empty());
         writer.flush().unwrap();
         // Ô (U+00D4) must come out as the single ISO-8859-1 byte 0xD4.
         assert_eq!(out, b"1|C\xD4TE|2.50|\n");

--- a/tpcdsgen/src/output.rs
+++ b/tpcdsgen/src/output.rs
@@ -20,9 +20,11 @@
 //!
 //! [`CompatWriter`] selects the right behavior based on [`CompatMode`].
 
+use std::fmt;
 use std::io::{self, Write};
 
 use crate::config::CompatMode;
+use crate::row::TableRow;
 
 /// Converts a UTF-8 string to ISO-8859-1 bytes.
 ///
@@ -136,6 +138,90 @@ impl<W: Write> Write for CompatWriter<W> {
     }
 }
 
+/// Buffered DAT row writer.
+///
+/// Rows are formatted into an in-memory UTF-8 buffer which is encoded and
+/// flushed to the inner writer one large chunk at a time. Encoding per chunk
+/// instead of per field keeps the hot path to plain byte appends: the common
+/// all-ASCII chunk is written through unchanged in both compat modes (ASCII
+/// bytes are identical in UTF-8 and ISO-8859-1), and only chunks that
+/// actually contain non-ASCII characters pay for ISO-8859-1 conversion in
+/// Trino mode.
+pub struct DatWriter<W: Write> {
+    inner: W,
+    compat_mode: CompatMode,
+    /// Pending formatted rows (UTF-8).
+    buffer: Vec<u8>,
+}
+
+impl<W: Write> DatWriter<W> {
+    /// Flush the pending buffer once it grows past this size: large enough to
+    /// amortize the encoding scan and write call, small enough to stay in L2.
+    const FLUSH_THRESHOLD: usize = 64 * 1024;
+
+    pub fn new(inner: W, compat_mode: CompatMode) -> Self {
+        Self {
+            inner,
+            compat_mode,
+            buffer: Vec::with_capacity(Self::FLUSH_THRESHOLD + 1024),
+        }
+    }
+
+    /// Write one row whose `Display` impl emits the DAT line (fields joined
+    /// by the separator, with a trailing separator); appends the newline.
+    pub fn write_display_row(&mut self, row: &impl fmt::Display) -> io::Result<()> {
+        writeln!(self.buffer, "{row}")?;
+        self.maybe_flush()
+    }
+
+    /// Write one row through the legacy [`TableRow`] interface, for row types
+    /// without a `Display` impl yet.
+    pub fn write_table_row(&mut self, row: &dyn TableRow, separator: char) -> io::Result<()> {
+        row.write_to(&mut self.buffer, separator)?;
+        self.maybe_flush()
+    }
+
+    /// The pending in-memory buffer. Callers with custom formatting needs may
+    /// append UTF-8 rows directly, followed by [`Self::maybe_flush`].
+    pub fn buffer(&mut self) -> &mut Vec<u8> {
+        &mut self.buffer
+    }
+
+    /// Encode and flush the pending buffer if it has grown past the threshold.
+    pub fn maybe_flush(&mut self) -> io::Result<()> {
+        if self.buffer.len() >= Self::FLUSH_THRESHOLD {
+            self.flush_buffer()?;
+        }
+        Ok(())
+    }
+
+    fn flush_buffer(&mut self) -> io::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        match self.compat_mode {
+            CompatMode::C => self.inner.write_all(&self.buffer)?,
+            CompatMode::Trino => {
+                if self.buffer.is_ascii() {
+                    self.inner.write_all(&self.buffer)?;
+                } else {
+                    let s = std::str::from_utf8(&self.buffer)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                    self.inner.write_all(&to_iso_8859_1(s)?)?;
+                }
+            }
+        }
+        self.buffer.clear();
+        Ok(())
+    }
+
+    /// Flush all pending rows and the inner writer.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.flush_buffer()?;
+        self.inner.flush()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,6 +272,72 @@ mod tests {
         // Trino/Java emits a single 0xD4 byte for Ô.
         assert_eq!(buffer[1], 0xD4);
         assert_eq!(buffer.len(), 13);
+    }
+
+    struct TestRow;
+
+    impl std::fmt::Display for TestRow {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "1|CÔTE|2.50|")
+        }
+    }
+
+    impl TableRow for TestRow {
+        fn get_values(&self) -> Vec<String> {
+            vec!["1".to_string(), "CÔTE".to_string(), "2.50".to_string()]
+        }
+    }
+
+    #[test]
+    fn test_dat_writer_buffers_until_flush() {
+        let mut out = Vec::new();
+        let mut writer = DatWriter::new(&mut out, CompatMode::Trino);
+        writer.write_display_row(&TestRow).unwrap();
+        // Small rows stay buffered until an explicit flush.
+        assert!(writer.buffer().len() > 0);
+        writer.flush().unwrap();
+        // Ô (U+00D4) must come out as the single ISO-8859-1 byte 0xD4.
+        assert_eq!(out, b"1|C\xD4TE|2.50|\n");
+    }
+
+    #[test]
+    fn test_dat_writer_utf8_mode_passes_through() {
+        let mut out = Vec::new();
+        let mut writer = DatWriter::new(&mut out, CompatMode::C);
+        writer.write_display_row(&TestRow).unwrap();
+        writer.flush().unwrap();
+        assert_eq!(out, "1|CÔTE|2.50|\n".as_bytes());
+    }
+
+    #[test]
+    fn test_dat_writer_table_row_matches_display_row() {
+        let mut display_out = Vec::new();
+        let mut writer = DatWriter::new(&mut display_out, CompatMode::Trino);
+        writer.write_display_row(&TestRow).unwrap();
+        writer.flush().unwrap();
+
+        let mut table_out = Vec::new();
+        let mut writer = DatWriter::new(&mut table_out, CompatMode::Trino);
+        writer.write_table_row(&TestRow, '|').unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(display_out, table_out);
+    }
+
+    #[test]
+    fn test_dat_writer_rejects_non_latin1_in_trino_mode() {
+        struct EuroRow;
+        impl std::fmt::Display for EuroRow {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "€100|")
+            }
+        }
+
+        let mut out = Vec::new();
+        let mut writer = DatWriter::new(&mut out, CompatMode::Trino);
+        writer.write_display_row(&EuroRow).unwrap();
+        let err = writer.flush().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/tpcdsgen/src/row/table_row.rs
+++ b/tpcdsgen/src/row/table_row.rs
@@ -1,4 +1,32 @@
+use std::fmt;
 use std::io::{self, Write};
+
+/// A single DAT-format field: formats the value, or nothing when the column
+/// is NULL.
+///
+/// Row types use this in their `Display` impls (which emit the DAT line) so
+/// that NULL handling stays out of the format string.
+pub(crate) struct DatField<T>(Option<T>);
+
+impl<T: fmt::Display> fmt::Display for DatField<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Some(value) => value.fmt(f),
+            None => Ok(()),
+        }
+    }
+}
+
+/// DAT field for a regular value: NULL when the row's null bit is set.
+pub(crate) fn dat_field<T>(value: T, is_null: bool) -> DatField<T> {
+    DatField((!is_null).then_some(value))
+}
+
+/// DAT field for a surrogate key: NULL when the row's null bit is set or the
+/// key is -1 (the generators' "no reference" sentinel).
+pub(crate) fn dat_key(key: i64, is_null: bool) -> DatField<i64> {
+    DatField((!is_null && key != -1).then_some(key))
+}
 
 /// TableRow trait matching the Java TableRow interface
 /// Represents a single row of data from any TPC-DS table

--- a/tpcdsgen/src/row/tables/store_returns_row.rs
+++ b/tpcdsgen/src/row/tables/store_returns_row.rs
@@ -15,8 +15,10 @@
 //! Store returns row data structure
 
 use crate::generator::{GeneratorColumn, StoreReturnsGeneratorColumn};
+use crate::row::table_row::{dat_field, dat_key};
 use crate::row::TableRow;
 use crate::types::Pricing;
+use std::fmt;
 
 /// Row data structure for the store_returns table
 #[derive(Debug, Clone)]
@@ -150,6 +152,67 @@ impl StoreReturnsRow {
     }
 }
 
+/// Formats the row as a DAT line: `|`-separated values with a trailing
+/// separator and empty fields for NULL columns (no newline). Produces the
+/// same bytes as joining [`TableRow::get_values`] with `|`.
+impl fmt::Display for StoreReturnsRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use StoreReturnsGeneratorColumn::*;
+
+        write!(
+            f,
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|",
+            dat_key(self.sr_returned_date_sk, self.is_null_at(SrReturnedDateSk)),
+            dat_key(self.sr_returned_time_sk, self.is_null_at(SrReturnedTimeSk)),
+            dat_key(self.sr_item_sk, self.is_null_at(SrItemSk)),
+            dat_key(self.sr_customer_sk, self.is_null_at(SrCustomerSk)),
+            dat_key(self.sr_cdemo_sk, self.is_null_at(SrCdemoSk)),
+            dat_key(self.sr_hdemo_sk, self.is_null_at(SrHdemoSk)),
+            dat_key(self.sr_addr_sk, self.is_null_at(SrAddrSk)),
+            dat_key(self.sr_store_sk, self.is_null_at(SrStoreSk)),
+            dat_key(self.sr_reason_sk, self.is_null_at(SrReasonSk)),
+            dat_key(self.sr_ticket_number, self.is_null_at(SrTicketNumber)),
+            dat_field(
+                self.sr_pricing.get_quantity(),
+                self.is_null_at(SrPricingQuantity)
+            ),
+            dat_field(
+                self.sr_pricing.get_net_paid(),
+                self.is_null_at(SrPricingNetPaid)
+            ),
+            dat_field(
+                self.sr_pricing.get_ext_tax(),
+                self.is_null_at(SrPricingExtTax)
+            ),
+            dat_field(
+                self.sr_pricing.get_net_paid_including_tax(),
+                self.is_null_at(SrPricingNetPaidIncTax)
+            ),
+            dat_field(self.sr_pricing.get_fee(), self.is_null_at(SrPricingFee)),
+            dat_field(
+                self.sr_pricing.get_ext_ship_cost(),
+                self.is_null_at(SrPricingExtShipCost)
+            ),
+            dat_field(
+                self.sr_pricing.get_refunded_cash(),
+                self.is_null_at(SrPricingRefundedCash)
+            ),
+            dat_field(
+                self.sr_pricing.get_reversed_charge(),
+                self.is_null_at(SrPricingReversedCharge)
+            ),
+            dat_field(
+                self.sr_pricing.get_store_credit(),
+                self.is_null_at(SrPricingStoreCredit)
+            ),
+            dat_field(
+                self.sr_pricing.get_net_loss(),
+                self.is_null_at(SrPricingNetLoss)
+            ),
+        )
+    }
+}
+
 impl TableRow for StoreReturnsRow {
     fn get_values(&self) -> Vec<String> {
         use StoreReturnsGeneratorColumn::*;
@@ -249,6 +312,19 @@ mod tests {
         assert_eq!(values.len(), 20);
         assert_eq!(values[0], "2451545"); // sr_returned_date_sk
         assert_eq!(values[9], "1"); // sr_ticket_number
+    }
+
+    #[test]
+    fn test_display_matches_get_values() {
+        let pricing = create_test_pricing();
+        // A null bit (sr_returned_time_sk) plus a -1 key (sr_reason_sk)
+        // exercise both NULL paths.
+        let row = StoreReturnsRow::new(
+            0b10, 2451545, 36000, 1, 100, 200, 300, 400, 500, -1, 1, pricing,
+        );
+
+        let expected = format!("{}|", row.get_values().join("|"));
+        assert_eq!(row.to_string(), expected);
     }
 
     #[test]

--- a/tpcdsgen/src/row/tables/store_sales_row.rs
+++ b/tpcdsgen/src/row/tables/store_sales_row.rs
@@ -15,8 +15,10 @@
 //! Store sales row data structure
 
 use crate::generator::{GeneratorColumn, StoreSalesGeneratorColumn};
+use crate::row::table_row::{dat_field, dat_key};
 use crate::row::TableRow;
 use crate::types::Pricing;
+use std::fmt;
 
 /// Row data structure for the store_sales table
 #[derive(Debug, Clone)]
@@ -155,6 +157,84 @@ impl StoreSalesRow {
     }
 }
 
+/// Formats the row as a DAT line: `|`-separated values with a trailing
+/// separator and empty fields for NULL columns (no newline). Produces the
+/// same bytes as joining [`TableRow::get_values`] with `|`.
+impl fmt::Display for StoreSalesRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use StoreSalesGeneratorColumn::*;
+
+        // Note: Java has coupon_amount twice at positions 15 and 20 (bug in original)
+        // We replicate this for byte-for-byte compatibility
+        write!(
+            f,
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|",
+            dat_key(self.ss_sold_date_sk, self.is_null_at(SsSoldDateSk)),
+            dat_key(self.ss_sold_time_sk, self.is_null_at(SsSoldTimeSk)),
+            dat_key(self.ss_sold_item_sk, self.is_null_at(SsSoldItemSk)),
+            dat_key(self.ss_sold_customer_sk, self.is_null_at(SsSoldCustomerSk)),
+            dat_key(self.ss_sold_cdemo_sk, self.is_null_at(SsSoldCdemoSk)),
+            dat_key(self.ss_sold_hdemo_sk, self.is_null_at(SsSoldHdemoSk)),
+            dat_key(self.ss_sold_addr_sk, self.is_null_at(SsSoldAddrSk)),
+            dat_key(self.ss_sold_store_sk, self.is_null_at(SsSoldStoreSk)),
+            dat_key(self.ss_sold_promo_sk, self.is_null_at(SsSoldPromoSk)),
+            dat_key(self.ss_ticket_number, self.is_null_at(SsTicketNumber)),
+            dat_field(
+                self.ss_pricing.get_quantity(),
+                self.is_null_at(SsPricingQuantity)
+            ),
+            dat_field(
+                self.ss_pricing.get_wholesale_cost(),
+                self.is_null_at(SsPricingWholesaleCost)
+            ),
+            dat_field(
+                self.ss_pricing.get_list_price(),
+                self.is_null_at(SsPricingListPrice)
+            ),
+            dat_field(
+                self.ss_pricing.get_sales_price(),
+                self.is_null_at(SsPricingSalesPrice)
+            ),
+            dat_field(
+                self.ss_pricing.get_coupon_amount(),
+                self.is_null_at(SsPricingCouponAmt)
+            ),
+            dat_field(
+                self.ss_pricing.get_ext_sales_price(),
+                self.is_null_at(SsPricingExtSalesPrice)
+            ),
+            dat_field(
+                self.ss_pricing.get_ext_wholesale_cost(),
+                self.is_null_at(SsPricingExtWholesaleCost)
+            ),
+            dat_field(
+                self.ss_pricing.get_ext_list_price(),
+                self.is_null_at(SsPricingExtListPrice)
+            ),
+            dat_field(
+                self.ss_pricing.get_ext_tax(),
+                self.is_null_at(SsPricingExtTax)
+            ),
+            dat_field(
+                self.ss_pricing.get_coupon_amount(),
+                self.is_null_at(SsPricingCouponAmt)
+            ),
+            dat_field(
+                self.ss_pricing.get_net_paid(),
+                self.is_null_at(SsPricingNetPaid)
+            ),
+            dat_field(
+                self.ss_pricing.get_net_paid_including_tax(),
+                self.is_null_at(SsPricingNetPaidIncTax)
+            ),
+            dat_field(
+                self.ss_pricing.get_net_profit(),
+                self.is_null_at(SsPricingNetProfit)
+            ),
+        )
+    }
+}
+
 impl TableRow for StoreSalesRow {
     fn get_values(&self) -> Vec<String> {
         use StoreSalesGeneratorColumn::*;
@@ -283,6 +363,19 @@ mod tests {
         assert_eq!(values[2], "1"); // ss_sold_item_sk
         assert_eq!(values[9], "1"); // ss_ticket_number
         assert_eq!(values[10], "5"); // quantity
+    }
+
+    #[test]
+    fn test_display_matches_get_values() {
+        let pricing = create_test_pricing();
+        // A null bit (ss_sold_time_sk) plus a -1 key (ss_sold_promo_sk)
+        // exercise both NULL paths.
+        let row = StoreSalesRow::new(
+            0b10, 2451545, 36000, 1, 100, 200, 300, 400, 500, -1, 1, pricing,
+        );
+
+        let expected = format!("{}|", row.get_values().join("|"));
+        assert_eq!(row.to_string(), expected);
     }
 
     #[test]

--- a/tpcdsgen/src/types/decimal.rs
+++ b/tpcdsgen/src/types/decimal.rs
@@ -148,22 +148,23 @@ impl Decimal {
 
 impl std::fmt::Display for Decimal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // This loses all of the benefit of having exact numeric types
-        // but it's what the C code does, so we have to follow it.
-        // In particular this copies the behavior of print_decimal in print.c.
-        // The C code has a different function called dectostr in decimal.c that
-        // does a proper string representation but it never gets called.
-        let mut temp = self.number as f64;
-        for _i in 0..self.precision {
-            temp /= 10.0;
+        // The C code (print_decimal in print.c) converts to double and prints
+        // with %.*f. For the magnitudes TPC-DS produces (far below 2^53) the
+        // double round-trip always recovers the exact digits of `number`, so
+        // we format the integer directly and avoid float formatting entirely.
+        if self.precision <= 0 {
+            return write!(f, "{}", self.number);
         }
-
-        write!(
-            f,
-            "{:.precision$}",
-            temp,
-            precision = self.precision as usize
-        )
+        let divisor = 10i64.pow(self.precision as u32);
+        let int_part = self.number / divisor;
+        let frac = (self.number % divisor).unsigned_abs();
+        let width = self.precision as usize;
+        if self.number < 0 && int_part == 0 {
+            // integer division dropped the sign (e.g. -0.05)
+            write!(f, "-0.{:0width$}", frac)
+        } else {
+            write!(f, "{}.{:0width$}", int_part, frac)
+        }
     }
 }
 
@@ -215,5 +216,27 @@ mod tests {
 
         let decimal = Decimal::new(123, 0).unwrap();
         assert_eq!(format!("{}", decimal), "123");
+    }
+
+    #[test]
+    fn test_display_negative() {
+        let decimal = Decimal::new(-12345, 2).unwrap();
+        assert_eq!(format!("{}", decimal), "-123.45");
+
+        // sign must survive a zero integer part
+        let decimal = Decimal::new(-5, 2).unwrap();
+        assert_eq!(format!("{}", decimal), "-0.05");
+    }
+
+    #[test]
+    fn test_display_zero_padding() {
+        let decimal = Decimal::new(5, 2).unwrap();
+        assert_eq!(format!("{}", decimal), "0.05");
+
+        let decimal = Decimal::new(10005, 4).unwrap();
+        assert_eq!(format!("{}", decimal), "1.0005");
+
+        let decimal = Decimal::new(0, 2).unwrap();
+        assert_eq!(format!("{}", decimal), "0.00");
     }
 }

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -18,13 +18,13 @@
 
 use crate::progress::ProgressTracker;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use log::info;
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen::error::InvalidOptionError;
-use tpcdsgen::output::CompatWriter;
+use tpcdsgen::output::DatWriter;
 use tpcdsgen::row::{GeneratedRow, TableRow, *};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -299,7 +299,7 @@ fn generate_simple<G: RowGeneratorFactory>(
 
     let path = get_output_path(table, output_options);
     let file = create_output_file(&path, output_options)?;
-    let mut writer = CompatWriter::new(BufWriter::new(file), session.get_compat_mode());
+    let mut writer = DatWriter::new(file, session.get_compat_mode());
 
     info!("Generating {}...", table.get_name());
 
@@ -394,12 +394,12 @@ fn generate_sales_and_returns<G: RowGeneratorFactory>(
     let returns_path = get_output_path(returns_table, output_options);
 
     let compat_mode = session.get_compat_mode();
-    let mut sales_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&sales_path, output_options)?),
+    let mut sales_writer = DatWriter::new(
+        create_output_file(&sales_path, output_options)?,
         compat_mode,
     );
-    let mut returns_writer = CompatWriter::new(
-        BufWriter::new(create_output_file(&returns_path, output_options)?),
+    let mut returns_writer = DatWriter::new(
+        create_output_file(&returns_path, output_options)?,
         compat_mode,
     );
 
@@ -469,27 +469,38 @@ fn create_output_file(path: &Path, output_options: &OutputOptions) -> Result<Fil
 
 fn write_row(
     row: &GeneratedRow,
-    writer: &mut dyn Write,
+    writer: &mut DatWriter<File>,
     output_options: &OutputOptions,
 ) -> Result<()> {
-    if output_options.null_string.is_empty() && !output_options.do_not_terminate {
-        row.write_to(writer, output_options.separator)?;
+    if output_options.null_string.is_empty()
+        && !output_options.do_not_terminate
+        && output_options.separator == '|'
+    {
+        // Fast path: row types with a `Display` impl format the DAT line
+        // with no per-field allocations; the rest go through `TableRow`.
+        match row {
+            GeneratedRow::StoreSales(row) => writer.write_display_row(row)?,
+            GeneratedRow::StoreReturns(row) => writer.write_display_row(row)?,
+            row => writer.write_table_row(row, output_options.separator)?,
+        }
         return Ok(());
     }
 
+    let buffer = writer.buffer();
     for (i, value) in row.get_values().iter().enumerate() {
         if i > 0 {
-            write!(writer, "{}", output_options.separator)?;
+            write!(buffer, "{}", output_options.separator)?;
         }
         if value.is_empty() {
-            write!(writer, "{}", output_options.null_string)?;
+            write!(buffer, "{}", output_options.null_string)?;
         } else {
-            write!(writer, "{value}")?;
+            write!(buffer, "{value}")?;
         }
     }
     if !output_options.do_not_terminate {
-        write!(writer, "{}", output_options.separator)?;
+        write!(buffer, "{}", output_options.separator)?;
     }
-    writeln!(writer)?;
+    writeln!(buffer)?;
+    writer.maybe_flush()?;
     Ok(())
 }


### PR DESCRIPTION
This PR aligns `tpcdsgen` to use the same approach as `tpchgen` as we discussed in #320 this PR is kept small and only shows the change for two tables with the remaining tables in a separate PR.