### PR TITLE
[tpcgen-cli]: parallel TPC-DS parquet generation (10x faster)

### DIFF
--- a/tpcdsgen-arrow/src/lib.rs
+++ b/tpcdsgen-arrow/src/lib.rs
@@ -64,6 +64,19 @@ impl<G: RowGenerator> RowIter<G> {
         self.current_row = starting_row_number;
         self.pending.clear();
     }
+
+    /// Restrict generation to source rows
+    /// `starting_row_number..=ending_row_number` (1-based, inclusive).
+    ///
+    /// The ending row number is clamped to the table's row count.
+    pub(crate) fn set_source_row_range(
+        &mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) {
+        self.skip_rows_until_starting_row_number(starting_row_number);
+        self.row_count = self.row_count.min(ending_row_number);
+    }
 }
 
 impl<G: RowGenerator> Iterator for RowIter<G> {

--- a/tpcdsgen-arrow/src/tables/call_center.rs
+++ b/tpcdsgen-arrow/src/tables/call_center.rs
@@ -29,6 +29,19 @@ impl CallCenterArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/catalog_page.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_page.rs
@@ -26,6 +26,19 @@ impl CatalogPageArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/catalog_returns.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_returns.rs
@@ -26,6 +26,19 @@ impl CatalogReturnsArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/catalog_sales.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_sales.rs
@@ -26,6 +26,19 @@ impl CatalogSalesArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/customer.rs
+++ b/tpcdsgen-arrow/src/tables/customer.rs
@@ -26,6 +26,19 @@ impl CustomerArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/customer_address.rs
+++ b/tpcdsgen-arrow/src/tables/customer_address.rs
@@ -26,6 +26,19 @@ impl CustomerAddressArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/customer_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/customer_demographics.rs
@@ -28,6 +28,19 @@ impl CustomerDemographicsArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/date_dim.rs
+++ b/tpcdsgen-arrow/src/tables/date_dim.rs
@@ -26,6 +26,19 @@ impl DateDimArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/dbgen_version.rs
+++ b/tpcdsgen-arrow/src/tables/dbgen_version.rs
@@ -26,6 +26,19 @@ impl DbgenVersionArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/household_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/household_demographics.rs
@@ -28,6 +28,19 @@ impl HouseholdDemographicsArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/income_band.rs
+++ b/tpcdsgen-arrow/src/tables/income_band.rs
@@ -26,6 +26,19 @@ impl IncomeBandArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/inventory.rs
+++ b/tpcdsgen-arrow/src/tables/inventory.rs
@@ -26,6 +26,19 @@ impl InventoryArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/item.rs
+++ b/tpcdsgen-arrow/src/tables/item.rs
@@ -28,6 +28,19 @@ impl ItemArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/promotion.rs
+++ b/tpcdsgen-arrow/src/tables/promotion.rs
@@ -28,6 +28,19 @@ impl PromotionArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/reason.rs
+++ b/tpcdsgen-arrow/src/tables/reason.rs
@@ -26,6 +26,19 @@ impl ReasonArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/ship_mode.rs
+++ b/tpcdsgen-arrow/src/tables/ship_mode.rs
@@ -26,6 +26,19 @@ impl ShipModeArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/store.rs
+++ b/tpcdsgen-arrow/src/tables/store.rs
@@ -29,6 +29,19 @@ impl StoreArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/store_returns.rs
+++ b/tpcdsgen-arrow/src/tables/store_returns.rs
@@ -26,6 +26,19 @@ impl StoreReturnsArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/store_sales.rs
+++ b/tpcdsgen-arrow/src/tables/store_sales.rs
@@ -26,6 +26,19 @@ impl StoreSalesArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/time_dim.rs
+++ b/tpcdsgen-arrow/src/tables/time_dim.rs
@@ -26,6 +26,19 @@ impl TimeDimArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/warehouse.rs
+++ b/tpcdsgen-arrow/src/tables/warehouse.rs
@@ -26,6 +26,19 @@ impl WarehouseArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/web_page.rs
+++ b/tpcdsgen-arrow/src/tables/web_page.rs
@@ -28,6 +28,19 @@ impl WebPageArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/web_returns.rs
+++ b/tpcdsgen-arrow/src/tables/web_returns.rs
@@ -26,6 +26,19 @@ impl WebReturnsArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/web_sales.rs
+++ b/tpcdsgen-arrow/src/tables/web_sales.rs
@@ -26,6 +26,19 @@ impl WebSalesArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen-arrow/src/tables/web_site.rs
+++ b/tpcdsgen-arrow/src/tables/web_site.rs
@@ -29,6 +29,19 @@ impl WebSiteArrow {
             .skip_rows_until_starting_row_number(starting_row_number);
     }
 
+    /// Generate only source rows `starting_row_number..=ending_row_number`
+    /// (1-based, inclusive). The ending row number is clamped to the table's
+    /// row count.
+    pub fn with_source_row_range(
+        mut self,
+        starting_row_number: i64,
+        ending_row_number: i64,
+    ) -> Self {
+        self.inner
+            .set_source_row_range(starting_row_number, ending_row_number);
+        self
+    }
+
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/tpcdsgen/src/config/table.rs
+++ b/tpcdsgen/src/config/table.rs
@@ -147,6 +147,25 @@ impl Table {
         )
     }
 
+    /// Return the table whose source rows drive generation of this table.
+    ///
+    /// The returns tables are generated row by row from their corresponding
+    /// sales generators, so anything that partitions generation by source row
+    /// (for example parallel Parquet generation) must use the sales table's
+    /// row counts; the returns tables' own scaling row counts would miss or
+    /// duplicate return rows. Every other table generates from its own rows.
+    ///
+    /// Note this is unrelated to the `S*` source schema tables (see
+    /// [`Self::is_main_table`]).
+    pub fn source_table(&self) -> Table {
+        match self {
+            Table::StoreReturns => Table::StoreSales,
+            Table::CatalogReturns => Table::CatalogSales,
+            Table::WebReturns => Table::WebSales,
+            other => *other,
+        }
+    }
+
     /// Basic properties for now - will be expanded later
     pub fn is_small(&self) -> bool {
         // Simplified - these tables have small row counts
@@ -273,6 +292,15 @@ mod tests {
 
         assert!(Table::StoreSales.is_main_table());
         assert!(!Table::SBrand.is_main_table());
+    }
+
+    #[test]
+    fn test_source_table() {
+        assert_eq!(Table::StoreReturns.source_table(), Table::StoreSales);
+        assert_eq!(Table::CatalogReturns.source_table(), Table::CatalogSales);
+        assert_eq!(Table::WebReturns.source_table(), Table::WebSales);
+        assert_eq!(Table::StoreSales.source_table(), Table::StoreSales);
+        assert_eq!(Table::Reason.source_table(), Table::Reason);
     }
 
     #[test]

--- a/tpcgen-cli/bin/tpcgen_cli.rs
+++ b/tpcgen-cli/bin/tpcgen_cli.rs
@@ -47,7 +47,7 @@ impl Cli {
     async fn run(self) -> Result<()> {
         match self.command {
             Command::Tpch(args) => args.run().await?,
-            Command::Tpcds(args) => args.run()?,
+            Command::Tpcds(args) => args.run().await?,
         }
 
         Ok(())

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -5,7 +5,7 @@ use arrow::record_batch::RecordBatchReader;
 use futures::StreamExt;
 use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
-use parquet::arrow::ArrowSchemaConverter;
+use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
@@ -54,9 +54,13 @@ where
     }
 
     // Compute the parquet schema
-    let writer_properties = WriterProperties::builder()
+    let mut writer_properties = WriterProperties::builder()
         .set_compression(parquet_compression)
         .build();
+    // Embed the Arrow schema in the Parquet metadata (as ArrowWriter does) so
+    // readers recover Arrow types with no exact Parquet equivalent (e.g. the
+    // Time32(seconds) column in the TPC-DS dbgen_version table)
+    add_encoded_arrow_schema_to_metadata(&schema, &mut writer_properties);
     let writer_properties = Arc::new(writer_properties);
     let parquet_schema = Arc::new(
         ArrowSchemaConverter::new()

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -111,7 +111,12 @@ struct ParquetArgs {
     row_group_bytes: usize,
 
     /// The number of threads for parallel generation, defaults to the number of CPUs
-    #[arg(short, long, default_value_t = num_cpus::get())]
+    #[arg(
+        short,
+        long,
+        default_value_t = num_cpus::get(),
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
+    )]
     num_threads: usize,
 }
 

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -16,6 +16,7 @@ use tpcdsgen::error::TpcdsError;
 pub mod csv;
 pub mod dat;
 pub mod parquet;
+mod plan;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -108,6 +109,10 @@ struct ParquetArgs {
         value_parser = parse_row_group_bytes
     )]
     row_group_bytes: usize,
+
+    /// The number of threads for parallel generation, defaults to the number of CPUs
+    #[arg(short, long, default_value_t = num_cpus::get())]
+    num_threads: usize,
 }
 
 #[derive(Args)]
@@ -147,60 +152,76 @@ pub struct CommonArgs {
 }
 
 impl Cli {
-    pub fn run(self) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
         match self.command {
-            Some(Commands::Dat(args)) => args.run(),
-            Some(Commands::Csv(args)) => args.run(),
-            Some(Commands::Parquet(args)) => args.run(),
-            None => self.args.run(),
+            Some(Commands::Dat(args)) => args.run().await,
+            Some(Commands::Csv(args)) => args.run().await,
+            Some(Commands::Parquet(args)) => args.run().await,
+            None => self.args.run().await,
         }
     }
 }
 
 impl DatArgs {
-    fn run(self) -> Result<()> {
-        self.common.run_dat()
+    async fn run(self) -> Result<()> {
+        self.common.run_dat().await
     }
 }
 
 impl CsvArgs {
-    fn run(self) -> Result<()> {
-        self.common.run_csv(self.delimiter)
+    async fn run(self) -> Result<()> {
+        self.common.run_csv(self.delimiter).await
     }
 }
 
 impl ParquetArgs {
-    fn run(self) -> Result<()> {
+    async fn run(self) -> Result<()> {
         self.common
-            .run_parquet(self.compression, self.row_group_bytes)
+            .run_parquet(self.compression, self.row_group_bytes, self.num_threads)
+            .await
     }
 }
 
 impl CommonArgs {
-    fn run_dat(self) -> Result<()> {
+    async fn run_dat(self) -> Result<()> {
         let output = dat::Dat::new(self.output_dir.clone())?;
         let tables = self.dat_tables()?;
         // DAT return tables are emitted as side effects of their sales table generator.
         // CSV and Parquet have direct return-table generators and do not need expansion.
         self.run_output_with_tables(OutputFormat::Dat(output), tables)
+            .await
     }
 
-    fn run_parquet(self, compression: Compression, row_group_bytes: usize) -> Result<()> {
-        let output = parquet::Parquet::new(self.output_dir.clone(), compression, row_group_bytes);
-        self.run_output(OutputFormat::Parquet(output))
+    async fn run_parquet(
+        self,
+        compression: Compression,
+        row_group_bytes: usize,
+        num_threads: usize,
+    ) -> Result<()> {
+        let output = parquet::Parquet::new(
+            self.output_dir.clone(),
+            compression,
+            row_group_bytes,
+            num_threads,
+        );
+        self.run_output(OutputFormat::Parquet(output)).await
     }
 
-    fn run_csv(self, delimiter: char) -> Result<()> {
+    async fn run_csv(self, delimiter: char) -> Result<()> {
         let output = csv::Csv::new(self.output_dir.clone(), delimiter);
-        self.run_output(OutputFormat::Csv(output))
+        self.run_output(OutputFormat::Csv(output)).await
     }
 
-    fn run_output(self, output_format: OutputFormat) -> Result<()> {
+    async fn run_output(self, output_format: OutputFormat) -> Result<()> {
         let tables = self.tables()?;
-        self.run_output_with_tables(output_format, tables)
+        self.run_output_with_tables(output_format, tables).await
     }
 
-    fn run_output_with_tables(self, output_format: OutputFormat, tables: Vec<Table>) -> Result<()> {
+    async fn run_output_with_tables(
+        self,
+        output_format: OutputFormat,
+        tables: Vec<Table>,
+    ) -> Result<()> {
         let (progress, log_writer) = self.progress_tracker();
         configure_logging(self.verbose, self.quiet, log_writer);
 
@@ -208,7 +229,9 @@ impl CommonArgs {
 
         for table in tables {
             let session = self.to_session(Some(table.get_name().to_string()))?;
-            output_format.generate_table(table, session, progress.as_ref())?;
+            output_format
+                .generate_table(table, session, &progress)
+                .await?;
         }
 
         progress.finish();
@@ -278,16 +301,20 @@ impl CommonArgs {
 }
 
 impl OutputFormat {
-    fn generate_table(
+    async fn generate_table(
         &self,
         table: Table,
         session: Session,
-        progress: &dyn ProgressTracker,
+        progress: &Arc<dyn ProgressTracker>,
     ) -> Result<()> {
         match self {
-            OutputFormat::Dat(output) => output.generate_table(table, &session, progress),
-            OutputFormat::Csv(output) => output.generate_table(table, session, progress),
-            OutputFormat::Parquet(output) => output.generate_table(table, session, progress),
+            OutputFormat::Dat(output) => output.generate_table(table, &session, progress.as_ref()),
+            OutputFormat::Csv(output) => output.generate_table(table, session, progress.as_ref()),
+            OutputFormat::Parquet(output) => {
+                output
+                    .generate_table(table, session, Arc::clone(progress))
+                    .await
+            }
         }
     }
 }

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -1,13 +1,14 @@
 //! TPC-DS Parquet output.
 
+use super::plan::TpcdsGenerationPlan;
 use crate::progress::ProgressTracker;
+use crate::tpch_cli::parquet::generate_parquet;
 use arrow::record_batch::RecordBatchReader;
-use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
-use parquet::file::properties::WriterProperties;
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen_arrow::{
     CallCenterArrow, CatalogPageArrow, CatalogReturnsArrow, CatalogSalesArrow,
@@ -25,6 +26,7 @@ pub(super) struct Parquet {
     output_dir: PathBuf,
     compression: Compression,
     row_group_bytes: usize,
+    num_threads: usize,
 }
 
 impl Parquet {
@@ -32,152 +34,224 @@ impl Parquet {
         output_dir: PathBuf,
         compression: Compression,
         row_group_bytes: usize,
+        num_threads: usize,
     ) -> Self {
         Self {
             output_dir,
             compression,
             row_group_bytes,
+            num_threads,
         }
     }
 
     /// Generate one TPC-DS table as a Parquet file.
-    pub(super) fn generate_table(
+    pub(super) async fn generate_table(
         &self,
         table: Table,
         session: Session,
-        progress: &dyn ProgressTracker,
+        progress: Arc<dyn ProgressTracker>,
     ) -> Result<()> {
         let path = self
             .output_dir
             .join(format!("{}.parquet", table.get_name()));
-        let table_name = table.get_name();
-        let rows: u64 = session
-            .get_scaling()
-            .get_row_count(table)
-            .try_into()
-            .unwrap_or(0);
-        // Register the table row count, then advance by each written batch's
-        // row count.
-        progress.register(table_name, rows);
 
         match table {
             Table::CallCenter => {
-                self.write_batches(path, CallCenterArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CallCenterArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::CatalogPage => {
-                self.write_batches(path, CatalogPageArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CatalogPageArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
-            Table::CatalogReturns => self.write_batches(
-                path,
-                CatalogReturnsArrow::new(session),
-                progress,
-                table_name,
-            ),
+            Table::CatalogReturns => {
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CatalogReturnsArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
+            }
             Table::CatalogSales => {
-                self.write_batches(path, CatalogSalesArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CatalogSalesArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::Customer => {
-                self.write_batches(path, CustomerArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CustomerArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
-            Table::CustomerAddress => self.write_batches(
-                path,
-                CustomerAddressArrow::new(session),
-                progress,
-                table_name,
-            ),
-            Table::CustomerDemographics => self.write_batches(
-                path,
-                CustomerDemographicsArrow::new(session),
-                progress,
-                table_name,
-            ),
+            Table::CustomerAddress => {
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CustomerAddressArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
+            }
+            Table::CustomerDemographics => {
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    CustomerDemographicsArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
+            }
             Table::DateDim => {
-                self.write_batches(path, DateDimArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    DateDimArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::DbgenVersion => {
-                self.write_batches(path, DbgenVersionArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    DbgenVersionArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
-            Table::HouseholdDemographics => self.write_batches(
-                path,
-                HouseholdDemographicsArrow::new(session),
-                progress,
-                table_name,
-            ),
+            Table::HouseholdDemographics => {
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    HouseholdDemographicsArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
+            }
             Table::IncomeBand => {
-                self.write_batches(path, IncomeBandArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    IncomeBandArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::Inventory => {
-                self.write_batches(path, InventoryArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    InventoryArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
-            Table::Item => self.write_batches(path, ItemArrow::new(session), progress, table_name),
+            Table::Item => {
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    ItemArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
+            }
             Table::Promotion => {
-                self.write_batches(path, PromotionArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    PromotionArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::Reason => {
-                self.write_batches(path, ReasonArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    ReasonArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::ShipMode => {
-                self.write_batches(path, ShipModeArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    ShipModeArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::Store => {
-                self.write_batches(path, StoreArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    StoreArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::StoreReturns => {
-                self.write_batches(path, StoreReturnsArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    StoreReturnsArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::StoreSales => {
-                self.write_batches(path, StoreSalesArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    StoreSalesArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::TimeDim => {
-                self.write_batches(path, TimeDimArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    TimeDimArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::Warehouse => {
-                self.write_batches(path, WarehouseArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    WarehouseArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::WebPage => {
-                self.write_batches(path, WebPageArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    WebPageArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::WebReturns => {
-                self.write_batches(path, WebReturnsArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    WebReturnsArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::WebSales => {
-                self.write_batches(path, WebSalesArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    WebSalesArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             Table::WebSite => {
-                self.write_batches(path, WebSiteArrow::new(session), progress, table_name)
+                self.write_table(path, table, session, progress, |session, start, end| {
+                    WebSiteArrow::new(session).with_source_row_range(start, end)
+                })
+                .await
             }
             _ => Ok(()),
         }
     }
 
-    /// Write the record batches to a Parquet file at the specified path.
-    fn write_batches<I>(
+    /// Write one table to a Parquet file at the specified path.
+    ///
+    /// `make_reader` creates a [`RecordBatchReader`] for one planned source
+    /// row range; the batches of each reader are encoded (in parallel, using
+    /// up to `num_threads` threads) as one row group.
+    ///
+    /// Progress is reported in row groups: the plan's row group count is
+    /// registered, then the shared writer advances by one per written row
+    /// group (the same output units as TPC-H parquet generation).
+    async fn write_table<R, F>(
         &self,
         path: PathBuf,
-        mut batches: I,
-        progress: &dyn ProgressTracker,
-        table_name: &'static str,
+        table: Table,
+        session: Session,
+        progress: Arc<dyn ProgressTracker>,
+        make_reader: F,
     ) -> Result<()>
     where
-        I: RecordBatchReader,
+        R: RecordBatchReader + Send + 'static,
+        F: Fn(Session, i64, i64) -> R + 'static,
     {
+        let table_name = table.get_name();
+        let plan = TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
+        progress.register(table_name, plan.row_group_count() as u64);
+        let sources = plan
+            .into_iter()
+            .map(move |range| make_reader(session.clone(), *range.start(), *range.end()));
+
+        // write to a temp file and then rename to avoid partial files
         let temp_path = path.with_extension("inprogress");
         let file = File::create(&temp_path)
             .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
         let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
-        let writer_properties = WriterProperties::builder()
-            .set_compression(self.compression)
-            .set_max_row_group_bytes(Some(self.row_group_bytes))
-            .build();
-        let mut writer = ArrowWriter::try_new(writer, batches.schema(), Some(writer_properties))?;
-
-        for batch in &mut batches {
-            let batch = batch?;
-            writer.write(&batch)?;
-            progress.increment(table_name, batch.num_rows() as u64);
-        }
-
-        writer.close()?;
+        generate_parquet(
+            writer,
+            sources,
+            self.num_threads,
+            self.compression,
+            progress,
+            table_name,
+        )
+        .await?;
         std::fs::rename(&temp_path, &path).map_err(|err| {
             io::Error::other(format!(
                 "Failed to rename {temp_path:?} to {path:?} file: {err}"

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -86,7 +86,7 @@ impl IntoIterator for TpcdsGenerationPlan {
 ///   (select count(distinct ss_ticket_number) from 'store_sales.parquet') as source_rows,
 ///   (select sum(total_uncompressed_size) from parquet_metadata('store_sales.parquet'))
 ///     / (select count(distinct ss_ticket_number) from 'store_sales.parquet') as bytes_per_source_row
-// "
+/// "
 /// ```
 ///
 /// Which results in something like

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -159,7 +159,7 @@ fn estimated_bytes_per_source_row(table: Table) -> i64 {
         Table::WebSales => 3119,
         Table::WebSite => 218,
         // Not a main table; never generated as Parquet output
-        _ => 100,
+        _ => unreachable!("Parquet generation plans are only defined for main TPC-DS tables"),
     }
 }
 

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -1,0 +1,212 @@
+//! [`TpcdsGenerationPlan`]: row group layout for TPC-DS Parquet files.
+
+use std::ops::RangeInclusive;
+use tpcdsgen::config::{Scaling, Table};
+
+/// Parquet files can have at most 32767 row groups
+const MAX_ROW_GROUPS: i64 = 32767;
+
+/// How to generate a TPC-DS table as a Parquet file: a list of contiguous
+/// source row ranges, each of which is generated as one row group.
+///
+/// The number of row groups is computed from the source row count, an estimated
+/// Parquet bytes per source row, and the target row group size, capped at
+/// Parquet's row group limit. Each range can then be generated (and encoded)
+/// independently, in parallel.
+///
+/// Note the ranges are over *source* rows, which is not the same as output rows
+/// for all tables: for example, the sales generators emit several output rows
+/// per source row, and the returns tables are generated from their paired sales
+/// generator, so their ranges are over the *sales* source rows.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct TpcdsGenerationPlan {
+    /// Inclusive 1-based source row ranges, one per row group
+    ranges: Vec<RangeInclusive<i64>>,
+}
+
+impl TpcdsGenerationPlan {
+    /// Compute the row group layout for `table` given the target
+    /// `row_group_bytes`.
+    pub(super) fn new(table: Table, scaling: &Scaling, row_group_bytes: usize) -> Self {
+        let source_rows = scaling.get_row_count(table.source_table());
+        let estimated_bytes = source_rows.saturating_mul(estimated_bytes_per_source_row(table));
+        let num_row_groups = (estimated_bytes / row_group_bytes.max(1) as i64 + 1)
+            .min(MAX_ROW_GROUPS)
+            .min(source_rows)
+            .max(1);
+        // ceiling division so the last row group is the one that comes up short
+        let rows_per_group = ((source_rows + num_row_groups - 1) / num_row_groups).max(1);
+
+        let mut ranges = Vec::with_capacity(num_row_groups as usize);
+        let mut start = 1;
+        while start <= source_rows {
+            let end = (start + rows_per_group - 1).min(source_rows);
+            ranges.push(start..=end);
+            start = end + 1;
+        }
+        // An empty table still needs one (empty) range so that a valid
+        // Parquet file containing the table schema is written.
+        if ranges.is_empty() {
+            #[allow(clippy::reversed_empty_ranges)]
+            ranges.push(1..=0);
+        }
+        Self { ranges }
+    }
+
+    /// Return the number of row groups this plan will generate
+    pub(super) fn row_group_count(&self) -> usize {
+        self.ranges.len()
+    }
+}
+
+/// Converts the plan into an iterator of inclusive source row ranges
+impl IntoIterator for TpcdsGenerationPlan {
+    type Item = RangeInclusive<i64>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ranges.into_iter()
+    }
+}
+
+/// Estimated (uncompressed) Parquet bytes written per *source* row (see
+/// [`TpcdsGenerationPlan`] for what a source row is).
+///
+/// Row group sizes are conventionally measured in uncompressed bytes, which
+/// is also what the previous `ArrowWriter` based implementation limited.
+///
+/// Measured from files generated at scale factor 1: the total uncompressed
+/// bytes, computed using datafusion-cli:
+///
+/// You can verify these numbers using
+/// ```shell
+/// datafusion-cli -c "
+/// select
+///   (select sum(total_uncompressed_size) from parquet_metadata('store_sales.parquet')) as total_uncompressed_bytes,
+///   (select count(distinct ss_ticket_number) from 'store_sales.parquet') as source_rows,
+///   (select sum(total_uncompressed_size) from parquet_metadata('store_sales.parquet'))
+///     / (select count(distinct ss_ticket_number) from 'store_sales.parquet') as bytes_per_source_row
+// "
+/// ```
+///
+/// Which results in something like
+/// ```text
+/// DataFusion CLI v54.0.0
+/// +--------------------------+-------------+----------------------+
+/// | total_uncompressed_bytes | source_rows | bytes_per_source_row |
+/// +--------------------------+-------------+----------------------+
+/// | 572780007                | 240000      | 2386                 |
+/// +--------------------------+-------------+----------------------+
+/// ```
+///
+/// Remember you have to divide by the **source** row count (which is different
+/// for sales vs returns tables) to get the bytes per source row.
+fn estimated_bytes_per_source_row(table: Table) -> i64 {
+    match table {
+        Table::CallCenter => 423,
+        Table::CatalogPage => 113,
+        Table::CatalogReturns => 195,
+        Table::CatalogSales => 2391,
+        Table::Customer => 92,
+        Table::CustomerAddress => 46,
+        Table::CustomerDemographics => 9,
+        Table::DateDim => 57,
+        Table::DbgenVersion => 358,
+        Table::HouseholdDemographics => 11,
+        Table::IncomeBand => 20,
+        Table::Inventory => 3,
+        Table::Item => 197,
+        Table::Promotion => 120,
+        Table::Reason => 54,
+        Table::ShipMode => 76,
+        Table::Store => 265,
+        Table::StoreReturns => 220,
+        Table::StoreSales => 2366,
+        Table::TimeDim => 38,
+        Table::Warehouse => 206,
+        Table::WebPage => 50,
+        Table::WebReturns => 261,
+        Table::WebSales => 3119,
+        Table::WebSite => 218,
+        // Not a main table; never generated as Parquet output
+        _ => 100,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEFAULT_ROW_GROUP_BYTES: usize = 7 * 1024 * 1024;
+
+    fn plan(table: Table, scale_factor: f64, row_group_bytes: usize) -> TpcdsGenerationPlan {
+        TpcdsGenerationPlan::new(table, &Scaling::new(scale_factor), row_group_bytes)
+    }
+
+    /// Assert the ranges cover `1..=expected_source_rows` contiguously
+    fn assert_covers(plan: &TpcdsGenerationPlan, expected_source_rows: i64) {
+        let mut next_row = 1;
+        for range in &plan.ranges {
+            assert_eq!(*range.start(), next_row);
+            assert!(range.end() >= range.start());
+            next_row = range.end() + 1;
+        }
+        assert_eq!(next_row, expected_source_rows + 1);
+    }
+
+    #[test]
+    fn small_table_single_row_group() {
+        let plan = plan(Table::Reason, 1.0, DEFAULT_ROW_GROUP_BYTES);
+        assert_eq!(plan.ranges, vec![1..=35]);
+    }
+
+    #[test]
+    fn store_sales_sf1_default() {
+        let plan = plan(Table::StoreSales, 1.0, DEFAULT_ROW_GROUP_BYTES);
+        // ~568 MB estimated output in 7 MB row groups over 240k source rows
+        assert_eq!(plan.row_group_count(), 78);
+        assert_covers(&plan, 240_000);
+    }
+
+    #[test]
+    fn store_returns_ranges_use_sales_source_rows() {
+        let plan = plan(Table::StoreReturns, 1.0, DEFAULT_ROW_GROUP_BYTES);
+        // store_returns is generated from the 240k store_sales source rows
+        // (its own scaling row count is 0)
+        assert_eq!(plan.row_group_count(), 8);
+        assert_covers(&plan, 240_000);
+    }
+
+    #[test]
+    fn smaller_row_groups_make_more_row_groups() {
+        let default = plan(Table::StoreSales, 1.0, DEFAULT_ROW_GROUP_BYTES);
+        let small = plan(Table::StoreSales, 1.0, 1024 * 1024);
+        assert!(small.row_group_count() > default.row_group_count());
+        assert_covers(&small, 240_000);
+    }
+
+    #[test]
+    fn row_group_count_is_capped() {
+        let plan = plan(Table::StoreSales, 3000.0, 1024);
+        // ceiling division can leave the count just under the cap
+        assert!(plan.row_group_count() <= MAX_ROW_GROUPS as usize);
+        assert!(plan.row_group_count() > (MAX_ROW_GROUPS - 2) as usize);
+        let source_rows = Scaling::new(3000.0).get_row_count(Table::StoreSales);
+        assert_covers(&plan, source_rows);
+    }
+
+    #[test]
+    fn row_groups_never_exceed_source_rows() {
+        // 35 source rows in 1 byte row groups still yields at most 35 groups
+        let plan = plan(Table::Reason, 1.0, 1);
+        assert_eq!(plan.row_group_count(), 35);
+        assert_covers(&plan, 35);
+    }
+
+    #[test]
+    fn empty_table_gets_one_empty_range() {
+        let plan = plan(Table::Reason, 0.0, DEFAULT_ROW_GROUP_BYTES);
+        assert_eq!(plan.row_group_count(), 1);
+        assert!(plan.ranges[0].is_empty());
+    }
+}

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -141,8 +141,10 @@ fn estimated_bytes_per_source_row(table: Table) -> i64 {
         Table::CustomerAddress => 46,
         Table::CustomerDemographics => 9,
         Table::DateDim => 57,
+        // Note: this value is not performance critical as this is a 1 row table
+        // and the size depends on the command line args.
         Table::DbgenVersion => 358,
-        Table::HouseholdDemographics => 11,
+        Table::HouseholdDemographics => 10,
         Table::IncomeBand => 20,
         Table::Inventory => 3,
         Table::Item => 197,

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -80,23 +80,53 @@ impl IntoIterator for TpcdsGenerationPlan {
 ///
 /// You can verify these numbers using
 /// ```shell
-/// datafusion-cli -c "
-/// select
-///   (select sum(total_uncompressed_size) from parquet_metadata('store_sales.parquet')) as total_uncompressed_bytes,
-///   (select count(distinct ss_ticket_number) from 'store_sales.parquet') as source_rows,
-///   (select sum(total_uncompressed_size) from parquet_metadata('store_sales.parquet'))
-///     / (select count(distinct ss_ticket_number) from 'store_sales.parquet') as bytes_per_source_row
-/// "
+/// for table in call_center catalog_page catalog_returns catalog_sales customer customer_address \
+///   customer_demographics date_dim dbgen_version household_demographics income_band inventory \
+///   item promotion reason ship_mode store store_returns store_sales time_dim warehouse web_page \
+///   web_returns web_sales web_site; do
+///   case "$table" in
+///     catalog_sales|catalog_returns)
+///       source_rows="(select count(distinct cs_order_number) from 'catalog_sales.parquet')"
+///       ;;
+///     store_sales|store_returns)
+///       source_rows="(select count(distinct ss_ticket_number) from 'store_sales.parquet')"
+///       ;;
+///     web_sales|web_returns)
+///       source_rows="(select count(distinct ws_order_number) from 'web_sales.parquet')"
+///       ;;
+///     *)
+///       source_rows="(select count(*) from '$table.parquet')"
+///       ;;
+///   esac
+///
+///   datafusion-cli -q -c "
+///   select
+///     '$table' as table_name,
+///     round(
+///       cast(sum(total_uncompressed_size) as double) / cast($source_rows as double)
+///     ) as bytes_per_source_row
+///   from parquet_metadata('$table.parquet')"
+/// done
 /// ```
 ///
 /// Which results in something like
 /// ```text
-/// DataFusion CLI v54.0.0
-/// +--------------------------+-------------+----------------------+
-/// | total_uncompressed_bytes | source_rows | bytes_per_source_row |
-/// +--------------------------+-------------+----------------------+
-/// | 572780007                | 240000      | 2386                 |
-/// +--------------------------+-------------+----------------------+
+/// +-------------+----------------------+
+/// | table_name  | bytes_per_source_row |
+/// +-------------+----------------------+
+/// | call_center | 423.0                |
+/// +-------------+----------------------+
+/// ...
+/// +-----------------+----------------------+
+/// | table_name      | bytes_per_source_row |
+/// +-----------------+----------------------+
+/// | catalog_returns | 195.0                |
+/// +-----------------+----------------------+
+/// +---------------+----------------------+
+/// | table_name    | bytes_per_source_row |
+/// +---------------+----------------------+
+/// | catalog_sales | 2391.0               |
+/// +---------------+----------------------+
 /// ```
 ///
 /// Remember you have to divide by the **source** row count (which is different

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -296,6 +296,31 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_zero_row_group_bytes() {
 }
 
 #[test]
+fn test_tpcgen_cli_tpcds_parquet_rejects_zero_num_threads() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--num-threads")
+        .arg("0")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("error: invalid value '0' for '--num-threads <NUM_THREADS>'"),
+        "Expected --num-threads=0 to be rejected at argument parse time, got stderr: {stderr}"
+    );
+}
+
+#[test]
 fn test_tpcgen_cli_tpcds_parquet_unknown_table_error_lists_valid_tables() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -1,4 +1,8 @@
 use super::test_helpers::{expect_row_group_sizes, RowGroups};
+use arrow::array::RecordBatch;
+use arrow::compute::concat_batches;
+use arrow::datatypes::{DataType, TimeUnit};
+use arrow::record_batch::RecordBatchReader;
 use assert_cmd::cargo::cargo_bin_cmd;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::basic::Compression;
@@ -6,8 +10,10 @@ use parquet::file::metadata::ParquetMetaDataReader;
 use std::collections::BTreeSet;
 use std::fs;
 use std::fs::File;
+use std::path::Path;
 use tempfile::tempdir;
-use tpcdsgen::config::Table;
+use tpcdsgen::config::{Session, SessionBuilder, Table};
+use tpcdsgen_arrow::{StoreReturnsArrow, StoreSalesArrow};
 
 /// Test that TPC-DS DAT generation is quiet unless logging is explicitly enabled.
 #[test]
@@ -257,8 +263,8 @@ fn test_tpcgen_cli_tpcds_parquet_row_group_size_1mb() {
         vec![RowGroups {
             table: "customer",
             row_group_bytes: vec![
-                993810, 994593, 994898, 994188, 994197, 993716, 995067, 994680, 994676, 994498,
-                861562,
+                1074775, 1073988, 1073405, 1071992, 1073785, 1072613, 1072227, 1073264, 1073338,
+                1072748,
             ],
         }],
     );
@@ -648,4 +654,156 @@ fn test_tpcgen_cli_tpcds_csv_rejects_non_ascii_delimiter() {
         .assert()
         .failure()
         .stderr(predicates::str::contains("ASCII"));
+}
+
+/// Session matching the CLI defaults for the given scale factor.
+fn test_session(scale_factor: f64) -> Session {
+    SessionBuilder::new()
+        .with_scale_factor(scale_factor)
+        .build()
+        .expect("valid session")
+}
+
+/// Read a parquet file into a single [`RecordBatch`], also returning the
+/// number of row groups in the file.
+fn read_concatenated_parquet(path: &Path) -> (RecordBatch, usize) {
+    let file = File::open(path).expect("Failed to open Parquet file");
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(file).expect("Failed to read Parquet metadata");
+    let num_row_groups = builder.metadata().num_row_groups();
+    let schema = builder.schema().clone();
+    let batches: Vec<RecordBatch> = builder
+        .build()
+        .expect("Failed to build Parquet reader")
+        .map(|batch| batch.expect("Failed to read Parquet batch"))
+        .collect();
+    let batch = concat_batches(&schema, &batches).expect("Failed to concatenate batches");
+    (batch, num_row_groups)
+}
+
+/// Drain a [`RecordBatchReader`] into a single [`RecordBatch`].
+fn read_concatenated_reference<R: RecordBatchReader>(mut reader: R) -> RecordBatch {
+    let schema = reader.schema();
+    let batches: Vec<RecordBatch> = reader
+        .by_ref()
+        .map(|batch| batch.expect("Failed to generate reference batch"))
+        .collect();
+    concat_batches(&schema, &batches).expect("Failed to concatenate reference batches")
+}
+
+/// Parquet files are generated using multiple source row ranges. Each
+/// Row Group comes from a particular row range, potentially encoded in parallel.
+///
+/// This test ensures that the result of this row range generation is the same
+/// as generating the data in a single chunk.
+///
+/// store_returns is generated from the store_sales generator, so this also
+/// verifies that ranging over the *sales* source rows loses or duplicates no
+/// return rows at range boundaries.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_matches_single_pass_generation() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    // write parquet data using CLI
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("store_sales,store_returns")
+        // small row groups to force several source row ranges
+        .arg("--row-group-bytes")
+        .arg("1000000")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    // Parquet data
+    let (store_sales, num_row_groups) =
+        read_concatenated_parquet(&temp_dir.path().join("store_sales.parquet"));
+    assert_eq!(num_row_groups, 24);
+    let expected = read_concatenated_reference(StoreSalesArrow::new(test_session(0.001)));
+    assert_eq!(store_sales, expected);
+
+    // regenerate same data directly from arrow generator
+    let (store_returns, num_row_groups) =
+        read_concatenated_parquet(&temp_dir.path().join("store_returns.parquet"));
+    assert_eq!(num_row_groups, 3);
+    let expected = read_concatenated_reference(StoreReturnsArrow::new(test_session(0.001)));
+    assert_eq!(store_returns, expected);
+}
+
+/// Test that the number of threads does not change the generated files.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_num_threads_equivalence() {
+    let mut outputs = vec![];
+    for num_threads in ["1", "4"] {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        cargo_bin_cmd!("tpcgen-cli")
+            .arg("tpcds")
+            .arg("parquet")
+            .arg("--scale-factor")
+            .arg("0.001")
+            .arg("--tables")
+            .arg("store_sales")
+            // small row groups so multiple row groups are encoded in parallel
+            .arg("--row-group-bytes")
+            .arg("1000000")
+            .arg("--num-threads")
+            .arg(num_threads)
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .assert()
+            .success();
+
+        let path = temp_dir.path().join("store_sales.parquet");
+
+        // verify multiple row groups were actually created, so the encoding
+        // really ran in parallel with --num-threads=4
+        let file = File::open(&path).expect("Failed to open Parquet file");
+        let mut metadata_reader = ParquetMetaDataReader::new();
+        metadata_reader.try_parse(&file).unwrap();
+        let num_row_groups = metadata_reader.finish().unwrap().num_row_groups();
+        assert_eq!(num_row_groups, 24);
+
+        outputs.push(fs::read(&path).expect("Failed to read Parquet file"));
+    }
+
+    assert_eq!(
+        outputs[0], outputs[1],
+        "Expected --num-threads=1 and --num-threads=4 to produce identical files"
+    );
+}
+
+/// Test that the Arrow schema is embedded in the Parquet metadata: the
+/// dbgen_version dv_create_time column is Time32(Second), which has no exact
+/// Parquet equivalent and only survives via the embedded Arrow schema.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_preserves_arrow_schema() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("1")
+        .arg("--tables")
+        .arg("dbgen_version")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let file = File::open(temp_dir.path().join("dbgen_version.parquet"))
+        .expect("Failed to open Parquet file");
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(file).expect("Failed to read Parquet metadata");
+    let field = builder
+        .schema()
+        .field_with_name("dv_create_time")
+        .expect("dv_create_time field");
+    assert_eq!(field.data_type(), &DataType::Time32(TimeUnit::Second));
 }

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -182,7 +182,7 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
 
     let original_metadata =
         fs::metadata(&expected_file).expect("Failed to get metadata of generated file");
-    assert_eq!(original_metadata.len(), 12061);
+    assert_eq!(original_metadata.len(), 12793);
 
     // Run the tpchgen-cli command again with the same parameters and expect the
     // file to not be overwritten and a warning to be logged


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #334
- part of #218

## Rationale

I want `tpcgen-cli tpcds parquet` to be fast and to do so, we need to use all cores, the same as we do for TPCH

This PR a planning one logical chunk per row group and encoding row groups concurrently with the shared writer (#342). This PR applies the same model to TPC-DS.


## What changes

- Add `TpcdsGenerationPlan` to compute the layout of the file up front
- Complete the source row range API from #346
- Replace the TPC-DS `ArrowWriter` path with the shared parquet writer that was extracted in https://github.com/clflushopt/tpchgen-rs/pull/342

Note the shared writer now embeds the Arrow schema in the parquet metadata (as `ArrowWriter` does), so Arrow types with no exact parquet equivalent round trip (e.g. `dbgen_version`'s `Time32(Second)` column). This also makes the resulting parquet files slightly larger (by a constant amount -- the embedded arrow schema)

# Performance at SF 10

Performance is more than 10x faster  on my mac:

```shell
 hyperfine --runs 5 --prepare "rm -rf /tmp/output" "target/release/tpcgen-cli tpcds parquet --scale-factor=10 --tables=store_sales --output-dir /tmp/output"
```

This branch (2.87 s)

```
Benchmark 1: target/release/tpcgen-cli tpcds parquet --scale-factor=10 --tables=store_sales --output-dir /tmp/output
  Time (mean ± σ):      2.876 s ±  0.036 s    [User: 37.710 s, System: 0.738 s]
  Range (min … max):    2.825 s …  2.925 s    5 runs
```

Main (30s)

```
Benchmark 1: target/release/tpcgen-cli tpcds parquet --scale-factor=10 --tables=store_sales --output-dir /tmp/output
  Time (mean ± σ):     30.397 s ±  0.062 s    [User: 30.048 s, System: 0.326 s]
  Range (min … max):   30.319 s … 30.466 s    5 runs
```