### PR TITLE
Generate TPC-DS parquet tables concurrently (4.5%-35% faster)

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -232,11 +232,31 @@ impl CommonArgs {
 
         std::fs::create_dir_all(&self.output_dir)?;
 
-        for table in tables {
-            let session = self.to_session(Some(table.get_name().to_string()))?;
-            output_format
-                .generate_table(table, session, &progress)
-                .await?;
+        match output_format {
+            // Parquet generates all tables in one call so that multiple
+            // tables can be generated concurrently
+            OutputFormat::Parquet(output) => {
+                let mut table_sessions = Vec::with_capacity(tables.len());
+                for table in tables {
+                    let session = self.to_session(Some(table.get_name().to_string()))?;
+                    table_sessions.push((table, session));
+                }
+                output
+                    .generate_tables(table_sessions, Arc::clone(&progress))
+                    .await?;
+            }
+            OutputFormat::Dat(output) => {
+                for table in tables {
+                    let session = self.to_session(Some(table.get_name().to_string()))?;
+                    output.generate_table(table, &session, progress.as_ref())?;
+                }
+            }
+            OutputFormat::Csv(output) => {
+                for table in tables {
+                    let session = self.to_session(Some(table.get_name().to_string()))?;
+                    output.generate_table(table, session, progress.as_ref())?;
+                }
+            }
         }
 
         progress.finish();
@@ -302,25 +322,6 @@ impl CommonArgs {
         }
 
         Ok(builder.build()?)
-    }
-}
-
-impl OutputFormat {
-    async fn generate_table(
-        &self,
-        table: Table,
-        session: Session,
-        progress: &Arc<dyn ProgressTracker>,
-    ) -> Result<()> {
-        match self {
-            OutputFormat::Dat(output) => output.generate_table(table, &session, progress.as_ref()),
-            OutputFormat::Csv(output) => output.generate_table(table, session, progress.as_ref()),
-            OutputFormat::Parquet(output) => {
-                output
-                    .generate_table(table, session, Arc::clone(progress))
-                    .await
-            }
-        }
     }
 }
 

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -3,8 +3,10 @@
 use super::plan::TpcdsGenerationPlan;
 use crate::parquet::generate_parquet;
 use crate::progress::ProgressTracker;
+use crate::worker_queue::WorkerQueue;
 use arrow::record_batch::RecordBatchReader;
 use parquet::basic::Compression;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::PathBuf;
@@ -17,8 +19,6 @@ use tpcdsgen_arrow::{
     PromotionArrow, ReasonArrow, ShipModeArrow, StoreArrow, StoreReturnsArrow, StoreSalesArrow,
     TimeDimArrow, WarehouseArrow, WebPageArrow, WebReturnsArrow, WebSalesArrow, WebSiteArrow,
 };
-
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Parquet output generator.
 #[derive(Debug, Clone)]
@@ -44,166 +44,385 @@ impl Parquet {
         }
     }
 
-    /// Generate one TPC-DS table as a Parquet file.
-    pub(super) async fn generate_table(
+    /// Generate the given TPC-DS tables as Parquet files.
+    ///
+    /// Tables are generated concurrently: each table's plan gets as many
+    /// threads as it has row groups, within the overall `num_threads`
+    /// budget (see [`WorkerQueue`]). Scheduling the largest tables first
+    /// keeps all cores busy while the trailing row groups of each table
+    /// are encoded, instead of waiting for one table at a time.
+    pub(super) async fn generate_tables(
+        &self,
+        tables: Vec<(Table, Session)>,
+        progress: Arc<dyn ProgressTracker>,
+    ) -> io::Result<()> {
+        // Remove duplicate table selections: generating the same table
+        // twice concurrently would race on the same output file
+        let mut seen = HashSet::new();
+        let tables = tables.into_iter().filter(|(table, _)| seen.insert(*table));
+
+        // Plan each table and pre-register the row group totals so trackers
+        // can size their bars before the first increment
+        let mut work: Vec<(Table, Session, TpcdsGenerationPlan)> = tables
+            .map(|(table, session)| {
+                let plan =
+                    TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
+                progress.register(table.get_name(), plan.row_group_count() as u64);
+                (table, session, plan)
+            })
+            .collect();
+
+        // Schedule the largest tables (most row groups) first for the best
+        // thread utilization (the list is popped from the back)
+        work.sort_by_key(|(_, _, plan)| plan.row_group_count());
+
+        let mut queue = WorkerQueue::new(self.num_threads);
+        while let Some((table, session, plan)) = work.pop() {
+            let this = self.clone();
+            let progress = Arc::clone(&progress);
+            queue
+                .schedule(plan.row_group_count(), move |num_threads| async move {
+                    this.generate_table(table, session, plan, num_threads, progress)
+                        .await?;
+                    Ok(num_threads)
+                })
+                .await?;
+        }
+        queue.join_all().await
+    }
+
+    /// Generate one TPC-DS table as a Parquet file using `num_threads`
+    /// threads.
+    async fn generate_table(
         &self,
         table: Table,
         session: Session,
+        plan: TpcdsGenerationPlan,
+        num_threads: usize,
         progress: Arc<dyn ProgressTracker>,
-    ) -> Result<()> {
-        let path = self
-            .output_dir
-            .join(format!("{}.parquet", table.get_name()));
-
+    ) -> io::Result<()> {
         match table {
             Table::CallCenter => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CallCenterArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CallCenterArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::CatalogPage => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CatalogPageArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CatalogPageArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::CatalogReturns => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CatalogReturnsArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CatalogReturnsArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::CatalogSales => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CatalogSalesArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CatalogSalesArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Customer => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CustomerArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CustomerArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::CustomerAddress => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CustomerAddressArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CustomerAddressArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::CustomerDemographics => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    CustomerDemographicsArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        CustomerDemographicsArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::DateDim => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    DateDimArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        DateDimArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::DbgenVersion => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    DbgenVersionArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        DbgenVersionArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::HouseholdDemographics => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    HouseholdDemographicsArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        HouseholdDemographicsArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::IncomeBand => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    IncomeBandArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        IncomeBandArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Inventory => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    InventoryArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        InventoryArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Item => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    ItemArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| ItemArrow::new(session).with_source_row_range(start, end),
+                )
                 .await
             }
             Table::Promotion => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    PromotionArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        PromotionArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Reason => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    ReasonArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        ReasonArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::ShipMode => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    ShipModeArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        ShipModeArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Store => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    StoreArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        StoreArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::StoreReturns => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    StoreReturnsArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        StoreReturnsArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::StoreSales => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    StoreSalesArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        StoreSalesArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::TimeDim => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    TimeDimArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        TimeDimArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::Warehouse => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    WarehouseArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        WarehouseArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::WebPage => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    WebPageArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        WebPageArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::WebReturns => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    WebReturnsArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        WebReturnsArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::WebSales => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    WebSalesArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        WebSalesArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             Table::WebSite => {
-                self.write_table(path, table, session, progress, |session, start, end| {
-                    WebSiteArrow::new(session).with_source_row_range(start, end)
-                })
+                self.write_table(
+                    table,
+                    session,
+                    plan,
+                    num_threads,
+                    progress,
+                    |session, start, end| {
+                        WebSiteArrow::new(session).with_source_row_range(start, end)
+                    },
+                )
                 .await
             }
             _ => Ok(()),
@@ -216,24 +435,24 @@ impl Parquet {
     /// row range; the batches of each reader are encoded (in parallel, using
     /// up to `num_threads` threads) as one row group.
     ///
-    /// Progress is reported in row groups: the plan's row group count is
-    /// registered, then the shared writer advances by one per written row
-    /// group (the same output units as TPC-H parquet generation).
+    /// Progress is reported in row groups: the shared writer advances by
+    /// one per written row group (the same output units as TPC-H parquet
+    /// generation; the totals are registered in [`Self::generate_tables`]).
     async fn write_table<R, F>(
         &self,
-        path: PathBuf,
         table: Table,
         session: Session,
+        plan: TpcdsGenerationPlan,
+        num_threads: usize,
         progress: Arc<dyn ProgressTracker>,
         make_reader: F,
-    ) -> Result<()>
+    ) -> io::Result<()>
     where
         R: RecordBatchReader + Send + 'static,
-        F: Fn(Session, i64, i64) -> R + 'static,
+        F: Fn(Session, i64, i64) -> R + Send + 'static,
     {
         let table_name = table.get_name();
-        let plan = TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
-        progress.register(table_name, plan.row_group_count() as u64);
+        let path = self.output_dir.join(format!("{table_name}.parquet"));
         let sources = plan
             .into_iter()
             .map(move |range| make_reader(session.clone(), *range.start(), *range.end()));
@@ -246,7 +465,7 @@ impl Parquet {
         generate_parquet(
             writer,
             sources,
-            self.num_threads,
+            num_threads,
             self.compression,
             progress,
             table_name,


### PR DESCRIPTION
## Which issue does this PR close?

Follow on to #360 (part of #218)

## Rationale

After #360, TPC-DS parquet generation runs in parallel for each table, but still only processes one table at a time. This means that some cores sit idle while the trailing row groups of each table finish (and small tables run serially).

## What changes

Follow the TPCh model and convert all chunks of tables in one big stream so cores can pick up the next table when done with their current one

# Performance 
* Scale Factor 2: 20% faster

Command

I ran this on a GCP 8 core machine, testing both scale factor 1 and 10

| Branch | Scale Factor 1 (s) | Scale Factor 10 (s) 
|--------|--------|--------|
| main | 6.603 | 45.760 |
| this PR | 4.923 | 43.761 |

SF 1 speedup: 35%
SF10 speedup: 4.5%

The improvement is larger at smaller scale factor because the smaller tables take a larger proportion of the total time


```shell
hyperfine --runs 5 --prepare "rm -rf /tmp/output" "target/release/tpcgen-cli tpcds parquet --scale-factor=1  --output-dir /tmp/output" "target/release/tpcgen-cli tpcds parquet --scale-factor=10  --output-dir /tmp/output"
```

Full Results (MAIN)
```
Benchmark 1: target/release/tpcgen-cli tpcds parquet --scale-factor=1  --output-dir /tmp/output
  Time (mean ± σ):      6.603 s ±  0.166 s    [User: 31.624 s, System: 0.549 s]
  Range (min … max):    6.351 s …  6.768 s    5 runs

Benchmark 2: target/release/tpcgen-cli tpcds parquet --scale-factor=10  --output-dir /tmp/output
  Time (mean ± σ):     45.760 s ±  0.258 s    [User: 331.762 s, System: 3.823 s]
  Range (min … max):   45.384 s … 46.107 s    5 runs
```

Full results (BRANCH)
```
Benchmark 1: target/release/tpcgen-cli tpcds parquet --scale-factor=1  --output-dir /tmp/output
  Time (mean ± σ):      4.923 s ±  0.017 s    [User: 33.570 s, System: 0.861 s]
  Range (min … max):    4.907 s …  4.945 s    5 runs

Benchmark 2: target/release/tpcgen-cli tpcds parquet --scale-factor=10  --output-dir /tmp/output
  Time (mean ± σ):     43.761 s ±  0.117 s    [User: 328.248 s, System: 6.437 s]
  Range (min … max):   43.562 s … 43.837 s    5 runs
```

