### PR TITLE
[tpcgen-cli]: extract WorkerQueue into a shared module

### DIFF
--- a/tpcgen-cli/src/lib.rs
+++ b/tpcgen-cli/src/lib.rs
@@ -4,3 +4,4 @@ mod parquet;
 pub mod progress;
 pub mod tpcds_cli;
 pub mod tpch_cli;
+mod worker_queue;

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -10,13 +10,13 @@ use crate::tpch_cli::parquet::generate_parquet;
 use crate::tpch_cli::tbl::*;
 use crate::tpch_cli::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
 use crate::tpch_cli::{OutputFormat, Table, WriterSink};
+use crate::worker_queue::WorkerQueue;
 use arrow::record_batch::RecordBatchReader;
 use log::{debug, info};
 use std::collections::BTreeMap;
 use std::io;
 use std::io::BufWriter;
 use std::sync::Arc;
-use tokio::task::{JoinError, JoinSet};
 use tpchgen::generators::{
     CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
     PartSuppGenerator, RegionGenerator, SupplierGenerator,
@@ -89,114 +89,20 @@ impl PlanRunner {
         }
 
         // Do the actual work in parallel, using a worker queue
-        let mut worker_queue = WorkerQueue::new(num_threads, Arc::clone(&progress));
+        let mut worker_queue = WorkerQueue::new(num_threads);
         while let Some(plan) = plans.pop() {
-            worker_queue.schedule_plan(plan).await?;
+            debug!("scheduling plan {plan}");
+            let progress = Arc::clone(&progress);
+            worker_queue
+                .schedule(plan.chunk_count(), move |num_plan_threads| {
+                    run_plan(plan, num_plan_threads, progress)
+                })
+                .await?;
         }
         worker_queue.join_all().await?;
         progress.finish();
         Ok(())
     }
-}
-
-/// Manages worker tasks, limiting the number of total outstanding threads
-/// to some fixed number
-///
-/// The runner executes each plan with a number of threads equal to the
-/// number of parts in the plan, but no more than the total number of
-/// threads specified when creating the runner. If a plan does not need all
-/// the threads, the remaining threads are used to run other plans.
-///
-/// This is important to keep all cores busy for smaller tables that may not
-/// have sufficient parts to keep all threads busy (see [`GenerationPlan`]
-/// for more details), but not schedule more tasks than we have threads for.
-///
-/// Scheduling too many tasks requires more memory and leads to context
-/// switching overhead, which can slow down the generation process.
-///
-/// [`GenerationPlan`]: crate::tpch_cli::plan::GenerationPlan
-struct WorkerQueue {
-    join_set: JoinSet<io::Result<usize>>,
-    /// Current number of threads available to commit
-    available_threads: usize,
-    progress: Arc<dyn ProgressTracker>,
-}
-
-impl WorkerQueue {
-    pub fn new(max_threads: usize, progress: Arc<dyn ProgressTracker>) -> Self {
-        assert!(max_threads > 0);
-        Self {
-            join_set: JoinSet::new(),
-            available_threads: max_threads,
-            progress,
-        }
-    }
-
-    /// Spawns a task to run the plan with as many threads as possible
-    /// without exceeding the maximum number of threads.
-    ///
-    /// If there are no threads available, it will wait for one to finish
-    /// before spawning the new task.
-    ///
-    /// Note this algorithm does not guarantee that all threads are always busy,
-    /// but it should be good enough for most cases. For best thread utilization
-    /// spawn the largest plans first.
-    pub async fn schedule_plan(&mut self, plan: OutputPlan) -> io::Result<()> {
-        debug!("scheduling plan {plan}");
-        loop {
-            if self.available_threads == 0 {
-                debug!("no threads left, wait for one to finish");
-                let Some(result) = self.join_set.join_next().await else {
-                    return Err(io::Error::other(
-                        "Internal Error No more tasks to wait for, but had no threads",
-                    ));
-                };
-                self.available_threads += task_result(result)?;
-                continue; // look for threads again
-            }
-
-            // Check for any other jobs done so we can reuse their threads
-            if let Some(result) = self.join_set.try_join_next() {
-                self.available_threads += task_result(result)?;
-                continue;
-            }
-
-            debug_assert!(
-                self.available_threads > 0,
-                "should have at least one thread to continue"
-            );
-
-            // figure out how many threads to allocate to this plan. Each plan
-            // can use up to `part_count` threads.
-            let chunk_count = plan.chunk_count();
-
-            let num_plan_threads = self.available_threads.min(chunk_count);
-
-            // run the plan in a separate task, which returns the number of threads it used
-            debug!("Spawning plan {plan} with {num_plan_threads} threads");
-
-            let progress = Arc::clone(&self.progress);
-            self.join_set
-                .spawn(async move { run_plan(plan, num_plan_threads, progress).await });
-            self.available_threads -= num_plan_threads;
-            return Ok(());
-        }
-    }
-
-    // Wait for all tasks to finish
-    pub async fn join_all(mut self) -> io::Result<()> {
-        debug!("Waiting for tasks to finish...");
-        while let Some(result) = self.join_set.join_next().await {
-            task_result(result)?;
-        }
-        debug!("Tasks finished.");
-        Ok(())
-    }
-}
-
-/// unwraps the result of a task and converts it to an `io::Result<T>`.
-fn task_result<T>(result: Result<io::Result<T>, JoinError>) -> io::Result<T> {
-    result.map_err(|e| io::Error::other(format!("Task Panic: {e}")))?
 }
 
 /// Run a single [`OutputPlan`]

--- a/tpcgen-cli/src/worker_queue.rs
+++ b/tpcgen-cli/src/worker_queue.rs
@@ -1,0 +1,147 @@
+//! [`WorkerQueue`]: run generation tasks in parallel within a thread budget.
+
+use log::debug;
+use std::future::Future;
+use std::io;
+use tokio::task::{JoinError, JoinSet};
+
+/// Manages worker tasks, limiting the number of total outstanding threads
+/// to some fixed number
+///
+/// Each task is run with a number of threads equal to the number of chunks
+/// (e.g. parts or row groups) it will produce, but no more than the total
+/// number of threads specified when creating the queue. If a task does not
+/// need all the threads, the remaining threads are used to run other tasks.
+///
+/// This is important to keep all cores busy for smaller tables that may not
+/// have sufficient chunks to keep all threads busy, but not schedule more
+/// tasks than we have threads for.
+///
+/// Scheduling too many tasks requires more memory and leads to context
+/// switching overhead, which can slow down the generation process.
+pub(crate) struct WorkerQueue {
+    join_set: JoinSet<io::Result<usize>>,
+    /// Current number of threads available to commit
+    available_threads: usize,
+}
+
+impl WorkerQueue {
+    pub(crate) fn new(max_threads: usize) -> Self {
+        assert!(max_threads > 0);
+        Self {
+            join_set: JoinSet::new(),
+            available_threads: max_threads,
+        }
+    }
+
+    /// Spawns a task with as many threads as possible without exceeding
+    /// the maximum number of threads. The task is created by calling
+    /// `task` with the number of threads allocated to it, and must return
+    /// that number back when it completes so the threads can be reused.
+    ///
+    /// If there are no threads available, waits for a running task to
+    /// finish before spawning the new one.
+    ///
+    /// Note this algorithm does not guarantee that all threads are always busy,
+    /// but it should be good enough for most cases. For best thread utilization
+    /// spawn the largest tasks first.
+    pub(crate) async fn schedule<F, Fut>(&mut self, chunk_count: usize, task: F) -> io::Result<()>
+    where
+        F: FnOnce(usize) -> Fut,
+        Fut: Future<Output = io::Result<usize>> + Send + 'static,
+    {
+        loop {
+            if self.available_threads == 0 {
+                debug!("no threads left, wait for one to finish");
+                let Some(result) = self.join_set.join_next().await else {
+                    return Err(io::Error::other(
+                        "Internal Error No more tasks to wait for, but had no threads",
+                    ));
+                };
+                self.available_threads += task_result(result)?;
+                continue; // look for threads again
+            }
+
+            // Check for any other jobs done so we can reuse their threads
+            if let Some(result) = self.join_set.try_join_next() {
+                self.available_threads += task_result(result)?;
+                continue;
+            }
+
+            debug_assert!(
+                self.available_threads > 0,
+                "should have at least one thread to continue"
+            );
+
+            // figure out how many threads to allocate to this task. Each task
+            // can use up to `chunk_count` threads.
+            let num_task_threads = self.available_threads.min(chunk_count);
+
+            debug!("Spawning task with {num_task_threads} threads");
+            self.join_set.spawn(task(num_task_threads));
+            self.available_threads -= num_task_threads;
+            return Ok(());
+        }
+    }
+
+    /// Wait for all tasks to finish
+    pub(crate) async fn join_all(mut self) -> io::Result<()> {
+        debug!("Waiting for tasks to finish...");
+        while let Some(result) = self.join_set.join_next().await {
+            task_result(result)?;
+        }
+        debug!("Tasks finished.");
+        Ok(())
+    }
+}
+
+/// unwraps the result of a task and converts it to an `io::Result<T>`.
+fn task_result<T>(result: Result<io::Result<T>, JoinError>) -> io::Result<T> {
+    result.map_err(|e| io::Error::other(format!("Task Panic: {e}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn schedules_more_tasks_than_threads() {
+        let completed = Arc::new(AtomicUsize::new(0));
+        let mut queue = WorkerQueue::new(2);
+
+        for chunk_count in [3, 1, 1, 2, 1] {
+            let completed = Arc::clone(&completed);
+            queue
+                .schedule(chunk_count, move |num_threads| async move {
+                    // each task gets at least one thread and no more than
+                    // its chunk count or the maximum
+                    assert!(num_threads >= 1);
+                    assert!(num_threads <= chunk_count.min(2));
+                    completed.fetch_add(1, Ordering::Relaxed);
+                    Ok(num_threads)
+                })
+                .await
+                .unwrap();
+        }
+        queue.join_all().await.unwrap();
+
+        assert_eq!(completed.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test]
+    async fn task_error_is_propagated() {
+        let mut queue = WorkerQueue::new(1);
+        queue
+            .schedule(1, |num_threads| async move {
+                let _ = num_threads;
+                Err(io::Error::other("boom"))
+            })
+            .await
+            .unwrap();
+
+        let err = queue.join_all().await.unwrap_err();
+        assert!(err.to_string().contains("boom"));
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

Part of #218 (refactor split out of #361)

## Rationale

The TPC-H runner's `WorkerQueue` (schedule tasks with as many threads as they have chunks, within an overall thread budget) is exactly what TPC-DS parquet generation needs to generate multiple tables concurrently. Extract it so both can share it.

## What changes

- Move `WorkerQueue` from `tpch_cli/runner.rs` to a shared `worker_queue` module