### PR TITLE
[tpcgen-cli]: reject --num-threads=0 for TPC-H generation too

### DIFF
--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -99,7 +99,12 @@ struct CommonArgs {
     part: Option<i32>,
 
     /// The number of threads for parallel generation, defaults to the number of CPUs
-    #[arg(short, long, default_value_t = num_cpus::get())]
+    #[arg(
+        short,
+        long,
+        default_value_t = num_cpus::get(),
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
+    )]
     num_threads: usize,
 
     /// Verbose output

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -641,6 +641,29 @@ fn test_tpchgen_cli_zero_part_zero_parts() {
         ));
 }
 
+/// Test that --num-threads=0 is rejected at argument parse time
+#[test]
+fn test_tpchgen_cli_rejects_zero_num_threads() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpch")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("region")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--num-threads")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "error: invalid value '0' for '--num-threads <NUM_THREADS>'",
+        ));
+}
+
 /// Test specifying parquet options even when writing tbl output
 #[tokio::test]
 async fn test_incompatible_options_warnings() {


### PR DESCRIPTION
## Rationale

In https://github.com/clflushopt/tpchgen-rs/pull/360#discussion_r3548569445 @kevinjqliu suggested validating `--num-threads` with clap so that `--num-threads 0` is rejected at argument parse time. This PR applies the same pattern to the TPC-H `--num-threads` option, which previously accepted `0` and then panicked at runtime on an internal assertion.

## What changes

- Validate TPC-H `--num-threads` with the same pattern as in TPC-DS 
- Add an integration test that `--num-threads 0` fails with a clap parse error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)