### PR TITLE
chore:: remove TableRow::write_to and supporting code

### DIFF
--- a/tpcdsgen-arrow/tests/reparse.rs
+++ b/tpcdsgen-arrow/tests/reparse.rs
@@ -4,7 +4,7 @@
 //!
 //! Strategy:
 //! - drive the tpcdsgen RowGenerator to produce rows for each table
-//! - write rows via `TableRow::write_to()` just like the CLI does
+//! - write rows via their `fmt::Display` impls just like the CLI does
 //! - re-parse the output with the Arrow CSV reader using the same schema
 //! - assert that the reparsed and direct Arrow RecordBatches are equal
 
@@ -12,6 +12,7 @@ use arrow::array::RecordBatch;
 use arrow::compute::concat_batches;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
+use std::io::Write as _;
 use std::sync::{Arc, LazyLock};
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen::row::{
@@ -19,7 +20,7 @@ use tpcdsgen::row::{
     CustomerAddressRowGenerator, CustomerDemographicsRowGenerator, CustomerRowGenerator,
     DateDimRowGenerator, GeneratedRow, HouseholdDemographicsRowGenerator, IncomeBandRowGenerator,
     InventoryRowGenerator, ItemRowGenerator, PromotionRowGenerator, ReasonRowGenerator,
-    RowGenerator, ShipModeRowGenerator, StoreRowGenerator, StoreSalesRowGenerator, TableRow,
+    RowGenerator, ShipModeRowGenerator, StoreRowGenerator, StoreSalesRowGenerator,
     TimeDimRowGenerator, WarehouseRowGenerator, WebPageRowGenerator, WebSalesRowGenerator,
     WebSiteRowGenerator,
 };
@@ -97,10 +98,9 @@ where
             // Format the rows into `data` as pipe-delimited data.
             for row in result.get_rows() {
                 if select(row) {
-                    row.write_to(&mut data, DAT_SEPARATOR).unwrap();
-                    data.pop();
+                    write!(&mut data, "{row}").unwrap();
                     // Note: .tbl lines end with '|' which the Arrow CSV parser treats as a
-                    // delimiter for a new column, so replace the last '|' with a newline.
+                    // delimiter for a new column, so replace the trailing '|' with a newline.
                     let end_offset = data.len() - 1;
                     data[end_offset] = b'\n';
                 }

--- a/tpcdsgen/src/output.rs
+++ b/tpcdsgen/src/output.rs
@@ -18,7 +18,7 @@
 //! (Latin-1) and writes output files as ISO-8859-1 (see TableGenerator.java
 //! line 80). The C `dsdgen` outputs UTF-8.
 //!
-//! [`CompatWriter`] selects the right behavior based on [`CompatMode`].
+//! [`DatWriter`] selects the right behavior based on [`CompatMode`].
 
 use std::fmt;
 use std::io::{self, Write};
@@ -49,92 +49,6 @@ pub fn to_iso_8859_1(s: &str) -> io::Result<Vec<u8>> {
             }
         })
         .collect()
-}
-
-/// A writer wrapper that converts UTF-8 strings to ISO-8859-1 before writing.
-///
-/// This matches Trino's behavior in TableGenerator.java which writes output
-/// using StandardCharsets.ISO_8859_1.
-pub struct Iso8859Writer<W: Write> {
-    inner: W,
-}
-
-impl<W: Write> Iso8859Writer<W> {
-    pub fn new(writer: W) -> Self {
-        Iso8859Writer { inner: writer }
-    }
-
-    /// Write a string as ISO-8859-1 bytes
-    pub fn write_str(&mut self, s: &str) -> io::Result<()> {
-        let bytes = to_iso_8859_1(s)?;
-        self.inner.write_all(&bytes)
-    }
-
-    /// Write a string followed by a newline as ISO-8859-1 bytes
-    pub fn write_line(&mut self, s: &str) -> io::Result<()> {
-        self.write_str(s)?;
-        self.inner.write_all(b"\n")
-    }
-
-    /// Flush the underlying writer
-    pub fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
-
-/// Implement std::io::Write for Iso8859Writer so it can be used with write! macro
-/// and TableRow::write_to().
-///
-/// The input bytes are expected to be valid UTF-8 (as produced by write! macro).
-/// Each UTF-8 character is converted to its ISO-8859-1 equivalent.
-impl<W: Write> Write for Iso8859Writer<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // Interpret input as UTF-8, convert to ISO-8859-1
-        let s =
-            std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let iso_bytes = to_iso_8859_1(s)?;
-        self.inner.write_all(&iso_bytes)?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
-
-/// Writer that selects the output encoding based on [`CompatMode`].
-///
-/// * `Iso8859`: outputs ISO-8859-1 to match Trino.
-/// * `Utf8`: outputs UTF-8 to match unmodified C `dsdgen`.
-pub enum CompatWriter<W: Write> {
-    Iso8859(Iso8859Writer<W>),
-    Utf8(W),
-}
-
-impl<W: Write> CompatWriter<W> {
-    /// Build a writer for `compat_mode`.
-    pub fn new(writer: W, compat_mode: CompatMode) -> Self {
-        match compat_mode {
-            CompatMode::Trino => CompatWriter::Iso8859(Iso8859Writer::new(writer)),
-            CompatMode::C => CompatWriter::Utf8(writer),
-        }
-    }
-}
-
-impl<W: Write> Write for CompatWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        match self {
-            CompatWriter::Iso8859(w) => w.write(buf),
-            CompatWriter::Utf8(w) => w.write(buf),
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        match self {
-            CompatWriter::Iso8859(w) => w.flush(),
-            CompatWriter::Utf8(w) => w.flush(),
-        }
-    }
 }
 
 /// Buffered DAT row writer.
@@ -233,18 +147,6 @@ mod tests {
     }
 
     #[test]
-    fn test_iso8859_writer() {
-        let mut buffer = Vec::new();
-        {
-            let mut writer = Iso8859Writer::new(&mut buffer);
-            writer.write_line("CÔTE D'IVOIRE").unwrap();
-        }
-        // Verify Ô (U+00D4) is written as single byte 0xD4, not UTF-8 (0xC3 0x94)
-        assert_eq!(buffer[1], 0xD4);
-        assert_eq!(buffer.len(), 14); // 13 chars + newline
-    }
-
-    #[test]
     fn test_to_iso_8859_1_out_of_range() {
         // Euro sign € is U+20AC, outside ISO-8859-1 range
         let result = to_iso_8859_1("€100");
@@ -252,18 +154,6 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("outside ISO-8859-1 range"));
-    }
-
-    #[test]
-    fn test_compat_writer_trino_emits_iso_8859_1() {
-        let mut buffer = Vec::new();
-        {
-            let mut writer = CompatWriter::new(&mut buffer, CompatMode::Trino);
-            write!(writer, "CÔTE D'IVOIRE").unwrap();
-        }
-        // Trino/Java emits a single 0xD4 byte for Ô.
-        assert_eq!(buffer[1], 0xD4);
-        assert_eq!(buffer.len(), 13);
     }
 
     struct TestRow;
@@ -309,17 +199,5 @@ mod tests {
         writer.write_display_row(&EuroRow).unwrap();
         let err = writer.flush().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn test_compat_writer_c_emits_utf8() {
-        let mut buffer = Vec::new();
-        {
-            let mut writer = CompatWriter::new(&mut buffer, CompatMode::C);
-            write!(writer, "CÔTE D'IVOIRE").unwrap();
-        }
-        // C dsdgen passes the UTF-8 bytes through (Ô is 0xC3 0x94).
-        assert_eq!(&buffer[..3], &[b'C', 0xC3, 0x94]);
-        assert_eq!(buffer.len(), 14);
     }
 }

--- a/tpcdsgen/src/row/generated_row.rs
+++ b/tpcdsgen/src/row/generated_row.rs
@@ -27,7 +27,6 @@ use crate::row::{
     WebSalesRow, WebSiteRow,
 };
 use std::fmt;
-use std::io::{self, Write};
 
 /// Enum holding all possible generated row types.
 ///
@@ -124,36 +123,6 @@ impl TableRow for GeneratedRow {
             GeneratedRow::WebReturns(row) => row.get_values(),
             GeneratedRow::WebSales(row) => row.get_values(),
             GeneratedRow::WebSite(row) => row.get_values(),
-        }
-    }
-
-    fn write_to(&self, writer: &mut dyn Write, separator: char) -> io::Result<()> {
-        match self {
-            GeneratedRow::CallCenter(row) => row.write_to(writer, separator),
-            GeneratedRow::CatalogPage(row) => row.write_to(writer, separator),
-            GeneratedRow::CatalogReturns(row) => row.write_to(writer, separator),
-            GeneratedRow::CatalogSales(row) => row.write_to(writer, separator),
-            GeneratedRow::Customer(row) => row.write_to(writer, separator),
-            GeneratedRow::CustomerAddress(row) => row.write_to(writer, separator),
-            GeneratedRow::CustomerDemographics(row) => row.write_to(writer, separator),
-            GeneratedRow::DateDim(row) => row.write_to(writer, separator),
-            GeneratedRow::DbgenVersion(row) => row.write_to(writer, separator),
-            GeneratedRow::HouseholdDemographics(row) => row.write_to(writer, separator),
-            GeneratedRow::IncomeBand(row) => row.write_to(writer, separator),
-            GeneratedRow::Inventory(row) => row.write_to(writer, separator),
-            GeneratedRow::Item(row) => row.write_to(writer, separator),
-            GeneratedRow::Promotion(row) => row.write_to(writer, separator),
-            GeneratedRow::Reason(row) => row.write_to(writer, separator),
-            GeneratedRow::ShipMode(row) => row.write_to(writer, separator),
-            GeneratedRow::Store(row) => row.write_to(writer, separator),
-            GeneratedRow::StoreReturns(row) => row.write_to(writer, separator),
-            GeneratedRow::StoreSales(row) => row.write_to(writer, separator),
-            GeneratedRow::TimeDim(row) => row.write_to(writer, separator),
-            GeneratedRow::Warehouse(row) => row.write_to(writer, separator),
-            GeneratedRow::WebPage(row) => row.write_to(writer, separator),
-            GeneratedRow::WebReturns(row) => row.write_to(writer, separator),
-            GeneratedRow::WebSales(row) => row.write_to(writer, separator),
-            GeneratedRow::WebSite(row) => row.write_to(writer, separator),
         }
     }
 }
@@ -330,28 +299,11 @@ mod tests {
     }
 
     #[test]
-    fn test_generated_row_display_matches_write_to() {
-        let row = CallCenterRow::builder().build();
-        let generated: GeneratedRow = row.into();
-
-        let mut legacy = Vec::new();
-        generated.write_to(&mut legacy, '|').unwrap();
-
-        // Display emits the same DAT line write_to does, minus the newline.
-        assert_eq!(format!("{generated}\n").as_bytes(), &legacy[..]);
-    }
-
-    #[test]
-    fn test_generated_row_write_to() {
+    fn test_generated_row_display_matches_row_display() {
         let row = CallCenterRow::builder().build();
         let generated: GeneratedRow = row.clone().into();
 
-        let mut buf1 = Vec::new();
-        let mut buf2 = Vec::new();
-
-        row.write_to(&mut buf1, '|').unwrap();
-        generated.write_to(&mut buf2, '|').unwrap();
-
-        assert_eq!(buf1, buf2);
+        // The enum's Display delegates to the variant's Display.
+        assert_eq!(row.to_string(), generated.to_string());
     }
 }

--- a/tpcdsgen/src/row/table_row.rs
+++ b/tpcdsgen/src/row/table_row.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::io::{self, Write};
 
 /// A single DAT-format field: formats the value, or nothing when the column
 /// is NULL.
@@ -78,33 +77,13 @@ pub trait TableRow: Send + Sync {
     /// Get all values as strings for output (getValues())
     ///
     /// Note: This method allocates a `Vec<String>`. For performance-critical code,
-    /// prefer using `write_to()` which writes directly to a buffer.
+    /// prefer using the row's `fmt::Display` impl which formats directly into a
+    /// buffer.
     fn get_values(&self) -> Vec<String>;
 
     /// Get the number of columns in this row
     fn get_column_count(&self) -> usize {
         self.get_values().len()
-    }
-
-    /// Write the row directly to a writer, avoiding intermediate allocations.
-    ///
-    /// Each column value is separated by `separator`, and the row ends with
-    /// a trailing separator followed by a newline.
-    ///
-    /// Default implementation calls `get_values()` - override for better performance.
-    ///
-    /// Note: Uses `dyn Write` for trait object compatibility. The dynamic dispatch
-    /// overhead is negligible compared to I/O costs.
-    fn write_to(&self, writer: &mut dyn Write, separator: char) -> io::Result<()> {
-        let values = self.get_values();
-        for (i, value) in values.iter().enumerate() {
-            if i > 0 {
-                write!(writer, "{}", separator)?;
-            }
-            write!(writer, "{}", value)?;
-        }
-        write!(writer, "{}", separator)?;
-        writeln!(writer)
     }
 }
 
@@ -135,29 +114,5 @@ mod tests {
         assert_eq!(values[1], "test");
         assert_eq!(values[2], "123.45");
         assert_eq!(test_row.get_column_count(), 3);
-    }
-
-    #[test]
-    fn test_write_to() {
-        let test_row = TestTableRow {
-            values: vec!["1".to_string(), "test".to_string(), "123.45".to_string()],
-        };
-
-        let mut buffer = Vec::new();
-        test_row.write_to(&mut buffer, '|').unwrap();
-        let output = String::from_utf8(buffer).unwrap();
-        assert_eq!(output, "1|test|123.45|\n");
-    }
-
-    #[test]
-    fn test_write_to_empty_values() {
-        let test_row = TestTableRow {
-            values: vec!["".to_string(), "test".to_string(), "".to_string()],
-        };
-
-        let mut buffer = Vec::new();
-        test_row.write_to(&mut buffer, '|').unwrap();
-        let output = String::from_utf8(buffer).unwrap();
-        assert_eq!(output, "|test||\n");
     }
 }


### PR DESCRIPTION
- Follow up to #370: 

With the standalone benchmark binary gone, we can remove `TableRow::write_to` which has now been replaced by a `Display` impl by @clflushopt  in https://github.com/clflushopt/tpchgen-rs/pull/365

