### PR TITLE
fix: remove invalid Maven cache setup

### DIFF
--- a/.github/workflows/full-conformance.yml
+++ b/.github/workflows/full-conformance.yml
@@ -124,7 +124,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-          cache: maven
 
       - name: Cache Rust dependencies
         uses: actions/cache@v6


### PR DESCRIPTION
Fixes #374.

Remove Maven caching from `setup-java` in the Trino full-conformance job. The repository has no Maven metadata at that point—the Trino `pom.xml` is cloned later—so cache initialization fails before the build starts. Caching is optional and never initialized successfully, so removing it restores the intended job without changing conformance behavior.

Validation:
- `actionlint .github/workflows/full-conformance.yml`
- Ran ["Full Conformance" using this branch via my fork](https://github.com/kevinjqliu/tpchgen-rs/actions/runs/29560819915) succesfully ✅ 
