### PR TITLE
fix TPC-DS conformance script validation

### DIFF
--- a/tpcgen-cli/scripts/tpcds/compare-all-tables.sh
+++ b/tpcgen-cli/scripts/tpcds/compare-all-tables.sh
@@ -62,7 +62,6 @@ Exit codes:
 
 See scripts/README.md for the full conformance-testing workflow.
 EOF
-    exit 0
 }
 
 # Colors for output
@@ -183,10 +182,12 @@ main() {
                 ;;
             --help)
                 print_usage
+                exit 0
                 ;;
             *)
                 log_error "Unknown option: $1"
                 print_usage
+                exit 1
                 ;;
         esac
     done

--- a/tpcgen-cli/scripts/tpcds/generate-fixtures.sh
+++ b/tpcgen-cli/scripts/tpcds/generate-fixtures.sh
@@ -75,7 +75,6 @@ Examples:
 
 See scripts/README.md for the full conformance-testing workflow.
 EOF
-    exit 0
 }
 
 # Colors
@@ -292,18 +291,18 @@ check_c_prerequisites() {
     return 0
 }
 
-# Sanity check the extracted fixtures.
-# At minimum, a handful of expected tables must be present and non-empty.
+# Verify that the extracted fixture set is complete.
 verify_c_fixtures() {
     local fixture_dir=$1
-    local required=(store_sales.dat catalog_sales.dat web_sales.dat reason.dat call_center.dat)
 
     if [[ ! -d "$fixture_dir" ]]; then
         log_error "Fixture directory does not exist: $fixture_dir"
         return 1
     fi
 
-    for f in "${required[@]}"; do
+    local table f
+    for table in "${ALL_TABLES[@]}"; do
+        f="${table}.dat"
         if [[ ! -s "$fixture_dir/$f" ]]; then
             log_error "Missing or empty fixture: $fixture_dir/$f"
             return 1
@@ -457,6 +456,7 @@ main() {
                 ;;
             --help)
                 print_usage
+                exit 0
                 ;;
             --*)
                 log_error "Unknown flag: $1"


### PR DESCRIPTION
## Summary

- return failure for invalid TPC-DS script options while keeping `--help` successful
- require all 25 non-empty C fixtures before treating a fixture set as complete

## Why

- Invalid options previously printed an error but exited successfully, so a typo such as `--ful` instead of `--full` could skip conformance checks without failing the caller. 
- The C fixture readiness check inspected only five representative files, even though its result determines whether downloading can be skipped. Checking every expected table ensures an incomplete fixture set is repaired before comparison starts.

## Validation

- `bash -n` on both scripts
- `shellcheck` on both scripts
- focused exit-code and partial/full fixture-set probes
