### PR TITLE
feat: introduce `ProgressHandle` for easier plumbing 

### DIFF
--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::progress::ProgressTracker;
+use crate::progress::ProgressHandle;
 use crate::tpch_cli::statistics::WriteStatistics;
 
 pub trait IntoSize {
@@ -34,8 +34,7 @@ pub async fn generate_parquet<W, I>(
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
-    progress: Arc<dyn ProgressTracker>,
-    table_name: &'static str,
+    progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
     W: Write + Send + IntoSize + 'static,
@@ -111,7 +110,7 @@ where
             }
             row_group_writer.close().unwrap();
             statistics.increment_chunks(1);
-            progress.increment(table_name, 1);
+            progress.increment(1);
         }
         let size = writer.into_inner()?.into_size()?;
         statistics.increment_bytes(size);
@@ -185,7 +184,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::progress::ProgressTracker;
+    use crate::progress::{ProgressHandle, ProgressTracker};
     use std::fs::File;
     use std::io::BufWriter;
     use std::sync::{
@@ -218,6 +217,7 @@ mod tests {
 
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = ProgressHandle::new(progress, "ignored");
 
         generate_parquet(
             writer,
@@ -225,7 +225,6 @@ mod tests {
             1,
             Compression::UNCOMPRESSED,
             progress,
-            "ignored",
         )
         .await
         .unwrap();

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -66,9 +66,9 @@ use std::sync::Arc;
 /// Receives generation-progress events for one generation run.
 ///
 /// See the [module-level documentation](self) for the call-order
-/// contract. Trackers are passed through generation code as an
-/// [`std::sync::Arc`] and shared across concurrent generation tasks, so
-/// they must be `Send + Sync`.
+/// contract. Trackers are held in a [`std::sync::Arc`] and shared across
+/// concurrent generation tasks through [`ProgressHandle`]s, so they must be
+/// `Send + Sync`.
 /// They must also be `Debug` so containing types can derive `Debug`.
 pub trait ProgressTracker: Send + Sync + fmt::Debug {
     /// Pre-register a progress item with its total expected output-unit count.
@@ -99,6 +99,30 @@ pub trait ProgressTracker: Send + Sync + fmt::Debug {
     /// and `Drop` only as an error or panic fallback. The default does
     /// nothing.
     fn finish(&self) {}
+}
+
+/// A cloneable handle for reporting progress for one registered item.
+///
+/// This binds a [`ProgressTracker`] to a stable item identifier so generation
+/// code only needs to carry one value and call [`Self::increment`]. Run-level
+/// lifecycle operations such as registration, startup, and completion remain
+/// the responsibility of the tracker owner.
+#[derive(Clone, Debug)]
+pub struct ProgressHandle {
+    tracker: Arc<dyn ProgressTracker>,
+    item: &'static str,
+}
+
+impl ProgressHandle {
+    /// Create a handle for `item` backed by `tracker`.
+    pub fn new(tracker: Arc<dyn ProgressTracker>, item: &'static str) -> Self {
+        Self { tracker, item }
+    }
+
+    /// Advance this item's counter by `units` output units.
+    pub fn increment(&self, units: u64) {
+        self.tracker.increment(self.item, units);
+    }
 }
 
 /// Default tracker used when no progress backend is installed.
@@ -353,7 +377,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct MockTracker {
         registered: Mutex<Vec<(String, u64)>>,
-        total_increments: AtomicU64,
+        increments: Mutex<Vec<(String, u64)>>,
         finished: AtomicU64,
     }
 
@@ -364,8 +388,11 @@ mod tests {
                 .unwrap()
                 .push((item.to_owned(), total_units));
         }
-        fn increment(&self, _item: &str, units: u64) {
-            self.total_increments.fetch_add(units, Ordering::Relaxed);
+        fn increment(&self, item: &str, units: u64) {
+            self.increments
+                .lock()
+                .unwrap()
+                .push((item.to_owned(), units));
         }
         fn finish(&self) {
             self.finished.fetch_add(1, Ordering::Relaxed);
@@ -373,13 +400,15 @@ mod tests {
     }
 
     #[test]
-    fn mock_tracker_works_through_arc_dyn() {
+    fn mock_tracker_works_through_progress_handles() {
         let mock = Arc::new(MockTracker::default());
         let dynamic: Arc<dyn ProgressTracker> = mock.clone();
         dynamic.register("store_sales", 10);
         dynamic.register("catalog_returns", 4);
-        dynamic.increment("store_sales", 3);
-        dynamic.increment("catalog_returns", 1);
+        let store_sales = ProgressHandle::new(Arc::clone(&dynamic), "store_sales");
+        let catalog_returns = ProgressHandle::new(Arc::clone(&dynamic), "catalog_returns");
+        store_sales.increment(3);
+        catalog_returns.increment(1);
         dynamic.finish();
 
         assert_eq!(
@@ -389,7 +418,13 @@ mod tests {
                 ("catalog_returns".to_owned(), 4)
             ]
         );
-        assert_eq!(mock.total_increments.load(Ordering::Relaxed), 4);
+        assert_eq!(
+            *mock.increments.lock().unwrap(),
+            vec![
+                ("store_sales".to_owned(), 3),
+                ("catalog_returns".to_owned(), 1)
+            ]
+        );
         assert_eq!(mock.finished.load(Ordering::Relaxed), 1);
     }
 

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -2,7 +2,7 @@
 use crate::logging::configure_logging;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
-use crate::progress::{no_op_progress_tracker, ProgressTracker};
+use crate::progress::{no_op_progress_tracker, ProgressHandle, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
 use std::io;
@@ -266,7 +266,8 @@ impl CommonArgs {
                 }
                 progress.start();
                 for (table, session) in table_sessions {
-                    output.generate_table(table, session, progress.as_ref())?;
+                    let handle = ProgressHandle::new(Arc::clone(&progress), table.get_name());
+                    output.generate_table(table, session, handle)?;
                 }
             }
         }

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -1,6 +1,6 @@
 //! TPC-DS CSV output.
 
-use crate::progress::ProgressTracker;
+use crate::progress::{ProgressHandle, ProgressTracker};
 use arrow::array::RecordBatch;
 use arrow::record_batch::RecordBatchReader;
 use arrow_csv::writer::WriterBuilder;
@@ -52,97 +52,52 @@ impl Csv {
         &self,
         table: Table,
         session: Session,
-        progress: &dyn ProgressTracker,
+        progress: ProgressHandle,
     ) -> Result<()> {
         let path = self.output_dir.join(format!("{}.csv", table.get_name()));
-        let table_name = table.get_name();
 
         match table {
-            Table::CallCenter => {
-                self.write_batches(path, CallCenterArrow::new(session), progress, table_name)
-            }
+            Table::CallCenter => self.write_batches(path, CallCenterArrow::new(session), &progress),
             Table::CatalogPage => {
-                self.write_batches(path, CatalogPageArrow::new(session), progress, table_name)
+                self.write_batches(path, CatalogPageArrow::new(session), &progress)
             }
-            Table::CatalogReturns => self.write_batches(
-                path,
-                CatalogReturnsArrow::new(session),
-                progress,
-                table_name,
-            ),
+            Table::CatalogReturns => {
+                self.write_batches(path, CatalogReturnsArrow::new(session), &progress)
+            }
             Table::CatalogSales => {
-                self.write_batches(path, CatalogSalesArrow::new(session), progress, table_name)
+                self.write_batches(path, CatalogSalesArrow::new(session), &progress)
             }
-            Table::Customer => {
-                self.write_batches(path, CustomerArrow::new(session), progress, table_name)
+            Table::Customer => self.write_batches(path, CustomerArrow::new(session), &progress),
+            Table::CustomerAddress => {
+                self.write_batches(path, CustomerAddressArrow::new(session), &progress)
             }
-            Table::CustomerAddress => self.write_batches(
-                path,
-                CustomerAddressArrow::new(session),
-                progress,
-                table_name,
-            ),
-            Table::CustomerDemographics => self.write_batches(
-                path,
-                CustomerDemographicsArrow::new(session),
-                progress,
-                table_name,
-            ),
-            Table::DateDim => {
-                self.write_batches(path, DateDimArrow::new(session), progress, table_name)
+            Table::CustomerDemographics => {
+                self.write_batches(path, CustomerDemographicsArrow::new(session), &progress)
             }
+            Table::DateDim => self.write_batches(path, DateDimArrow::new(session), &progress),
             Table::DbgenVersion => {
-                self.write_batches(path, DbgenVersionArrow::new(session), progress, table_name)
+                self.write_batches(path, DbgenVersionArrow::new(session), &progress)
             }
-            Table::HouseholdDemographics => self.write_batches(
-                path,
-                HouseholdDemographicsArrow::new(session),
-                progress,
-                table_name,
-            ),
-            Table::IncomeBand => {
-                self.write_batches(path, IncomeBandArrow::new(session), progress, table_name)
+            Table::HouseholdDemographics => {
+                self.write_batches(path, HouseholdDemographicsArrow::new(session), &progress)
             }
-            Table::Inventory => {
-                self.write_batches(path, InventoryArrow::new(session), progress, table_name)
-            }
-            Table::Item => self.write_batches(path, ItemArrow::new(session), progress, table_name),
-            Table::Promotion => {
-                self.write_batches(path, PromotionArrow::new(session), progress, table_name)
-            }
-            Table::Reason => {
-                self.write_batches(path, ReasonArrow::new(session), progress, table_name)
-            }
-            Table::ShipMode => {
-                self.write_batches(path, ShipModeArrow::new(session), progress, table_name)
-            }
-            Table::Store => {
-                self.write_batches(path, StoreArrow::new(session), progress, table_name)
-            }
+            Table::IncomeBand => self.write_batches(path, IncomeBandArrow::new(session), &progress),
+            Table::Inventory => self.write_batches(path, InventoryArrow::new(session), &progress),
+            Table::Item => self.write_batches(path, ItemArrow::new(session), &progress),
+            Table::Promotion => self.write_batches(path, PromotionArrow::new(session), &progress),
+            Table::Reason => self.write_batches(path, ReasonArrow::new(session), &progress),
+            Table::ShipMode => self.write_batches(path, ShipModeArrow::new(session), &progress),
+            Table::Store => self.write_batches(path, StoreArrow::new(session), &progress),
             Table::StoreReturns => {
-                self.write_batches(path, StoreReturnsArrow::new(session), progress, table_name)
+                self.write_batches(path, StoreReturnsArrow::new(session), &progress)
             }
-            Table::StoreSales => {
-                self.write_batches(path, StoreSalesArrow::new(session), progress, table_name)
-            }
-            Table::TimeDim => {
-                self.write_batches(path, TimeDimArrow::new(session), progress, table_name)
-            }
-            Table::Warehouse => {
-                self.write_batches(path, WarehouseArrow::new(session), progress, table_name)
-            }
-            Table::WebPage => {
-                self.write_batches(path, WebPageArrow::new(session), progress, table_name)
-            }
-            Table::WebReturns => {
-                self.write_batches(path, WebReturnsArrow::new(session), progress, table_name)
-            }
-            Table::WebSales => {
-                self.write_batches(path, WebSalesArrow::new(session), progress, table_name)
-            }
-            Table::WebSite => {
-                self.write_batches(path, WebSiteArrow::new(session), progress, table_name)
-            }
+            Table::StoreSales => self.write_batches(path, StoreSalesArrow::new(session), &progress),
+            Table::TimeDim => self.write_batches(path, TimeDimArrow::new(session), &progress),
+            Table::Warehouse => self.write_batches(path, WarehouseArrow::new(session), &progress),
+            Table::WebPage => self.write_batches(path, WebPageArrow::new(session), &progress),
+            Table::WebReturns => self.write_batches(path, WebReturnsArrow::new(session), &progress),
+            Table::WebSales => self.write_batches(path, WebSalesArrow::new(session), &progress),
+            Table::WebSite => self.write_batches(path, WebSiteArrow::new(session), &progress),
             _ => Ok(()),
         }
     }
@@ -152,8 +107,7 @@ impl Csv {
         &self,
         path: PathBuf,
         mut batches: I,
-        progress: &dyn ProgressTracker,
-        table_name: &'static str,
+        progress: &ProgressHandle,
     ) -> Result<()>
     where
         I: RecordBatchReader,
@@ -174,7 +128,7 @@ impl Csv {
         for batch in &mut batches {
             let batch = batch?;
             writer.write(&batch)?;
-            progress.increment(table_name, batch.num_rows() as u64);
+            progress.increment(batch.num_rows() as u64);
         }
 
         let mut writer = writer.into_inner();

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -2,7 +2,7 @@
 
 use super::plan::TpcdsGenerationPlan;
 use crate::parquet::generate_parquet;
-use crate::progress::ProgressTracker;
+use crate::progress::{ProgressHandle, ProgressTracker};
 use crate::worker_queue::WorkerQueue;
 use arrow::record_batch::RecordBatchReader;
 use parquet::basic::Compression;
@@ -80,7 +80,7 @@ impl Parquet {
         let mut queue = WorkerQueue::new(self.num_threads);
         while let Some((table, session, plan)) = work.pop() {
             let this = self.clone();
-            let progress = Arc::clone(&progress);
+            let progress = ProgressHandle::new(Arc::clone(&progress), table.get_name());
             queue
                 .schedule(plan.row_group_count(), move |num_threads| async move {
                     this.generate_table(table, session, plan, num_threads, progress)
@@ -100,7 +100,7 @@ impl Parquet {
         session: Session,
         plan: TpcdsGenerationPlan,
         num_threads: usize,
-        progress: Arc<dyn ProgressTracker>,
+        progress: ProgressHandle,
     ) -> io::Result<()> {
         match table {
             Table::CallCenter => {
@@ -445,7 +445,7 @@ impl Parquet {
         session: Session,
         plan: TpcdsGenerationPlan,
         num_threads: usize,
-        progress: Arc<dyn ProgressTracker>,
+        progress: ProgressHandle,
         make_reader: F,
     ) -> io::Result<()>
     where
@@ -463,15 +463,7 @@ impl Parquet {
         let file = File::create(&temp_path)
             .map_err(|err| io::Error::other(format!("Failed to create {temp_path:?}: {err}")))?;
         let writer = BufWriter::with_capacity(32 * 1024 * 1024, file);
-        generate_parquet(
-            writer,
-            sources,
-            num_threads,
-            self.compression,
-            progress,
-            table_name,
-        )
-        .await?;
+        generate_parquet(writer, sources, num_threads, self.compression, progress).await?;
         std::fs::rename(&temp_path, &path).map_err(|err| {
             io::Error::other(format!(
                 "Failed to rename {temp_path:?} to {path:?} file: {err}"

--- a/tpcgen-cli/src/tpch_cli/generate.rs
+++ b/tpcgen-cli/src/tpch_cli/generate.rs
@@ -3,7 +3,7 @@
 //! These traits and function are used to generate data in parallel and write it to a sink
 //! in streaming fashion (chunks). This is useful for generating large datasets that don't fit in memory.
 
-use crate::progress::ProgressTracker;
+use crate::progress::ProgressHandle;
 use futures::StreamExt;
 use log::debug;
 use std::collections::VecDeque;
@@ -54,8 +54,7 @@ pub async fn generate_in_chunks<G, I, S>(
     mut sink: S,
     sources: I,
     num_threads: usize,
-    progress: Arc<dyn ProgressTracker>,
-    table_name: &'static str,
+    progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
     G: Source + 'static,
@@ -115,7 +114,7 @@ where
         while let Some(buffer) = rx.blocking_recv() {
             sink.sink(&buffer)?;
             captured_recycler.return_buffer(buffer);
-            progress.increment(table_name, 1);
+            progress.increment(1);
         }
         // No more input, flush the sink and return
         sink.flush()
@@ -175,7 +174,7 @@ impl BufferRecycler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::progress::ProgressTracker;
+    use crate::progress::{ProgressHandle, ProgressTracker};
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Mutex,
@@ -229,6 +228,7 @@ mod tests {
         let writes = Arc::new(Mutex::new(Vec::new()));
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = ProgressHandle::new(progress, "ignored");
 
         let sources = vec![
             TestSource {
@@ -248,7 +248,6 @@ mod tests {
             sources.into_iter(),
             1,
             progress,
-            "ignored",
         )
         .await
         .unwrap();

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -2,7 +2,7 @@
 
 use crate::parquet::generate_parquet;
 use crate::progress::no_op_progress_tracker;
-use crate::progress::ProgressTracker;
+use crate::progress::{ProgressHandle, ProgressTracker};
 use crate::tpch_cli::csv::*;
 use crate::tpch_cli::generate::generate_in_chunks;
 use crate::tpch_cli::generate::Source;
@@ -112,6 +112,7 @@ async fn run_plan(
     num_threads: usize,
     progress: Arc<dyn ProgressTracker>,
 ) -> io::Result<usize> {
+    let progress = ProgressHandle::new(progress, plan.table().name());
     match plan.table() {
         Table::Nation => run_nation_plan(plan, num_threads, progress).await,
         Table::Region => run_region_plan(plan, num_threads, progress).await,
@@ -130,13 +131,13 @@ async fn run_plan(
 fn maybe_skip_existing(
     path: &std::path::Path,
     plan: &OutputPlan,
-    progress: &dyn ProgressTracker,
+    progress: &ProgressHandle,
 ) -> bool {
     if !path.exists() {
         return false;
     }
     log::warn!("{} already exists, skipping generation", path.display());
-    progress.increment(plan.table().name(), plan.chunk_count() as u64);
+    progress.increment(plan.chunk_count() as u64);
     true
 }
 
@@ -145,21 +146,20 @@ async fn write_file<I>(
     plan: OutputPlan,
     num_threads: usize,
     sources: I,
-    progress: Arc<dyn ProgressTracker>,
+    progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
     I: Iterator<Item: Source> + 'static,
 {
-    let table_name = plan.table().name();
     // Since generate_in_chunks already buffers, there is no need to buffer
     // again (aka don't use BufWriter here)
     match plan.output_location() {
         OutputLocation::Stdout => {
             let sink = WriterSink::new(io::stdout());
-            generate_in_chunks(sink, sources, num_threads, progress, table_name).await
+            generate_in_chunks(sink, sources, num_threads, progress).await
         }
         OutputLocation::File(path) => {
-            if maybe_skip_existing(path, &plan, progress.as_ref()) {
+            if maybe_skip_existing(path, &plan, &progress) {
                 return Ok(());
             }
             // write to a temp file and then rename to avoid partial files
@@ -168,7 +168,7 @@ where
                 io::Error::other(format!("Failed to create {temp_path:?}: {err}"))
             })?;
             let sink = WriterSink::new(file);
-            generate_in_chunks(sink, sources, num_threads, progress, table_name).await?;
+            generate_in_chunks(sink, sources, num_threads, progress).await?;
             // rename the temp file to the final path
             std::fs::rename(&temp_path, path).map_err(|e| {
                 io::Error::other(format!(
@@ -185,13 +185,12 @@ async fn write_parquet<I>(
     plan: OutputPlan,
     num_threads: usize,
     sources: I,
-    progress: Arc<dyn ProgressTracker>,
+    progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
     I: Iterator + 'static,
     I::Item: RecordBatchReader + Send,
 {
-    let table_name = plan.table().name();
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
@@ -201,12 +200,11 @@ where
                 num_threads,
                 plan.parquet_compression(),
                 progress,
-                table_name,
             )
             .await
         }
         OutputLocation::File(path) => {
-            if maybe_skip_existing(path, &plan, progress.as_ref()) {
+            if maybe_skip_existing(path, &plan, &progress) {
                 return Ok(());
             }
             // write to a temp file and then rename to avoid partial files
@@ -221,7 +219,6 @@ where
                 num_threads,
                 plan.parquet_compression(),
                 progress,
-                table_name,
             )
             .await?;
             // rename the temp file to the final path
@@ -248,7 +245,7 @@ macro_rules! define_run {
         async fn $FUN_NAME(
             plan: OutputPlan,
             num_threads: usize,
-            progress: Arc<dyn ProgressTracker>,
+            progress: ProgressHandle,
         ) -> io::Result<usize> {
             use crate::tpch_cli::GenerationPlan;
             let scale_factor = plan.scale_factor();
@@ -430,8 +427,9 @@ mod tests {
 
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
+        let progress = ProgressHandle::new(progress, plan.table().name());
 
-        assert!(maybe_skip_existing(&output_path, &plan, progress.as_ref()));
+        assert!(maybe_skip_existing(&output_path, &plan, &progress));
         assert_eq!(tracker.increments.load(Ordering::Relaxed), expected_units);
     }
 }


### PR DESCRIPTION
Part of #355

Previously, we had to plumb both `progress: Arc<dyn ProgressTracker>` and `table_name: &'static str` all the way down the stack so we can do `progress.increment(table_name, 1)` to increment the progress tracker. 

This is now all handled in the new `ProgressHandle`, and we just need to create it per table and plumb it through.