### PR TITLE
refactor: let `ProgressHandle` handle increments

### DIFF
--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -200,8 +200,10 @@ mod tests {
     }
 
     impl ProgressTracker for CountingProgress {
-        fn increment(&self, _item: &str, row_groups: u64) {
-            self.increments.fetch_add(row_groups, Ordering::Relaxed);
+        fn register(self: Arc<Self>, _item: &str, _total_units: u64) -> ProgressHandle {
+            ProgressHandle::new(move |row_groups| {
+                self.increments.fetch_add(row_groups, Ordering::Relaxed);
+            })
         }
     }
 
@@ -217,7 +219,7 @@ mod tests {
 
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
-        let progress = ProgressHandle::new(progress, "ignored");
+        let progress = progress.register("ignored", 2);
 
         generate_parquet(
             writer,

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -2,24 +2,25 @@
 //!
 //! # Overview
 //!
-//! [`ProgressTracker`] is a small, dyn-compatible trait that receives
-//! generation events. Generation code emits these events as applicable:
+//! [`ProgressTracker`] is a small, dyn-compatible trait that owns run-level
+//! progress lifecycle. Generation code uses it as follows:
 //!
 //! 1. [`ProgressTracker::register`] once per progress item, before work
 //!    starts, with the total number of output units the item will produce
-//!    (chunks for TBL/CSV, row groups for Parquet).
+//!    (chunks for TBL/CSV, row groups for Parquet). Registration returns a
+//!    [`ProgressHandle`] bound to that item.
 //! 2. [`ProgressTracker::start`] once after all known progress items have
 //!    been registered and before work starts. This hook is optional for
 //!    paths that register items lazily.
-//! 3. [`ProgressTracker::increment`] after output units are written.
-//!    Multiple generation tasks may call it concurrently, so impls
-//!    must be `Send + Sync` and `increment` itself should be lightweight.
+//! 3. [`ProgressHandle::increment`] after output units are written.
+//!    Multiple generation tasks may call handles concurrently, so their
+//!    callbacks must be `Send + Sync` and lightweight.
 //! 4. [`ProgressTracker::finish`] once on the success path when the
 //!    generation run exits. Implementations should use `finish` for normal
 //!    success cleanup and `Drop` only as an error or panic fallback.
 //!
-//! When invoked, `register`, `start`, and `finish` are serial and may
-//! do bookkeeping or I/O; `increment` may run concurrently while output
+//! When invoked, `register`, `start`, and `finish` are serial and may do
+//! bookkeeping or I/O; handles may be incremented concurrently while output
 //! is being written.
 //!
 //! Implementations must not panic and must not propagate I/O errors —
@@ -40,7 +41,8 @@
 //!
 //! ```
 //! use std::sync::atomic::{AtomicU64, Ordering};
-//! use tpcgen_cli::progress::ProgressTracker;
+//! use std::sync::Arc;
+//! use tpcgen_cli::progress::{ProgressHandle, ProgressTracker};
 //!
 //! #[derive(Debug)]
 //! struct LoggingTracker {
@@ -48,11 +50,11 @@
 //! }
 //!
 //! impl ProgressTracker for LoggingTracker {
-//!     fn register(&self, item: &str, total: u64) {
+//!     fn register(self: Arc<Self>, item: &str, total: u64) -> ProgressHandle {
 //!         eprintln!("plan: {item} -> {total} output units");
-//!     }
-//!     fn increment(&self, _item: &str, units: u64) {
-//!         self.written.fetch_add(units, Ordering::Relaxed);
+//!         ProgressHandle::new(move |units| {
+//!             self.written.fetch_add(units, Ordering::Relaxed);
+//!         })
 //!     }
 //!     fn finish(&self) {
 //!         eprintln!("done: {} output units", self.written.load(Ordering::Relaxed));
@@ -67,34 +69,28 @@ use std::sync::Arc;
 ///
 /// See the [module-level documentation](self) for the call-order
 /// contract. Trackers are held in a [`std::sync::Arc`] and shared across
-/// concurrent generation tasks through [`ProgressHandle`]s, so they must be
-/// `Send + Sync`.
+/// concurrent generation tasks through the [`ProgressHandle`]s returned by
+/// [`Self::register`], so they must be `Send + Sync`.
 /// They must also be `Debug` so containing types can derive `Debug`.
 pub trait ProgressTracker: Send + Sync + fmt::Debug {
     /// Pre-register a progress item with its total expected output-unit count.
     ///
     /// Called once per item before work starts. The `item` is a stable
-    /// identifier, usually a table name. Implementations
-    /// that need to know totals up front (e.g. to render a progress bar
-    /// or compute an ETA) should override this; the default does
-    /// nothing.
-    fn register(&self, _item: &str, _total_units: u64) {}
+    /// identifier, usually a table name. The returned handle is the only
+    /// capability generation tasks need to advance that item.
+    ///
+    /// The [`Arc`] receiver lets implementations return a `'static` handle
+    /// that shares tracker state with concurrent generation tasks.
+    fn register(self: Arc<Self>, item: &str, total_units: u64) -> ProgressHandle;
 
     /// Optional hook called after all known progress items have been
-    /// registered and before the first [`Self::increment`].
+    /// registered and before the first [`ProgressHandle::increment`].
     ///
     /// Implementations can use this to finalize setup that depends on the
     /// registered item set. The default does nothing.
     fn start(&self) {}
 
-    /// Advance the counter for `item` by `units` output units.
-    ///
-    /// Called after generated output units are written. Multiple
-    /// generation tasks may call this concurrently, so implementations
-    /// should be lightweight and must never panic.
-    fn increment(&self, item: &str, units: u64);
-
-    /// Called once after the last [`Self::increment`] on the success
+    /// Called once after the last [`ProgressHandle::increment`] on the success
     /// path. Implementations should use this for normal success cleanup
     /// and `Drop` only as an error or panic fallback. The default does
     /// nothing.
@@ -103,25 +99,38 @@ pub trait ProgressTracker: Send + Sync + fmt::Debug {
 
 /// A cloneable handle for reporting progress for one registered item.
 ///
-/// This binds a [`ProgressTracker`] to a stable item identifier so generation
-/// code only needs to carry one value and call [`Self::increment`]. Run-level
-/// lifecycle operations such as registration, startup, and completion remain
-/// the responsibility of the tracker owner.
-#[derive(Clone, Debug)]
+/// Handles are created by [`ProgressTracker::register`] and directly own the
+/// item-specific increment behavior. Run-level lifecycle operations remain the
+/// responsibility of the tracker owner.
+#[derive(Clone)]
 pub struct ProgressHandle {
-    tracker: Arc<dyn ProgressTracker>,
-    item: &'static str,
+    increment: Arc<dyn Fn(u64) + Send + Sync>,
 }
 
 impl ProgressHandle {
-    /// Create a handle for `item` backed by `tracker`.
-    pub fn new(tracker: Arc<dyn ProgressTracker>, item: &'static str) -> Self {
-        Self { tracker, item }
+    /// Create a handle backed by `increment`.
+    pub fn new<F>(increment: F) -> Self
+    where
+        F: Fn(u64) + Send + Sync + 'static,
+    {
+        Self {
+            increment: Arc::new(increment),
+        }
     }
 
     /// Advance this item's counter by `units` output units.
     pub fn increment(&self, units: u64) {
-        self.tracker.increment(self.item, units);
+        (self.increment)(units);
+    }
+
+    fn no_op() -> Self {
+        Self::new(|_| {})
+    }
+}
+
+impl fmt::Debug for ProgressHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProgressHandle").finish_non_exhaustive()
     }
 }
 
@@ -133,7 +142,9 @@ impl ProgressHandle {
 struct NoOpProgressTracker;
 
 impl ProgressTracker for NoOpProgressTracker {
-    fn increment(&self, _item: &str, _units: u64) {}
+    fn register(self: Arc<Self>, _item: &str, _total_units: u64) -> ProgressHandle {
+        ProgressHandle::no_op()
+    }
 }
 
 pub(crate) fn no_op_progress_tracker() -> Arc<dyn ProgressTracker> {
@@ -145,12 +156,12 @@ pub use indicatif_impl::IndicatifProgress;
 
 #[cfg(feature = "indicatif-progress")]
 mod indicatif_impl {
-    use super::ProgressTracker;
+    use super::{ProgressHandle, ProgressTracker};
     use indicatif::ProgressDrawTarget;
     use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
     use std::collections::BTreeMap;
     use std::io::{self, Write};
-    use std::sync::{OnceLock, RwLock};
+    use std::sync::{Arc, OnceLock, RwLock};
 
     const LABEL_WIDTH: usize = 22;
     const BAR_WIDTH: usize = 18;
@@ -163,8 +174,8 @@ mod indicatif_impl {
     ///
     /// Renders one compact progress bar per progress item on stderr.
     ///
-    /// Items are added in [`ProgressTracker::register`] and looked up by item
-    /// identifier on each [`ProgressTracker::increment`] call.
+    /// Items are added in [`ProgressTracker::register`], which returns a handle
+    /// that advances its progress bar directly.
     #[derive(Debug)]
     pub struct IndicatifProgress {
         multi: MultiProgress,
@@ -207,9 +218,9 @@ mod indicatif_impl {
     }
 
     impl ProgressTracker for IndicatifProgress {
-        fn register(&self, item: &str, total_units: u64) {
+        fn register(self: Arc<Self>, item: &str, total_units: u64) -> ProgressHandle {
             let Ok(mut items) = self.items.write() else {
-                return;
+                return ProgressHandle::no_op();
             };
 
             // Indicatif treats zero-length items as complete.
@@ -221,7 +232,8 @@ mod indicatif_impl {
                     .with_message(item_key.clone())
                     .with_finish(ProgressFinish::AndLeave),
             );
-            items.insert(item_key, pb);
+            items.insert(item_key, pb.clone());
+            ProgressHandle::new(move |units| pb.inc(units))
         }
 
         fn start(&self) {
@@ -238,19 +250,6 @@ mod indicatif_impl {
             }
             // Reduce flicker by moving the cursor instead of clearing lines once the item set is stable.
             self.multi.set_move_cursor(true);
-        }
-
-        fn increment(&self, item: &str, units: u64) {
-            let bar = {
-                let Ok(items) = self.items.read() else {
-                    return;
-                };
-                items.get(item).cloned()
-            };
-
-            if let Some(bar) = bar {
-                bar.inc(units);
-            }
         }
 
         fn finish(&self) {
@@ -308,11 +307,11 @@ mod indicatif_impl {
 
         #[test]
         fn registers_and_increments() {
-            let t = IndicatifProgress::hidden();
-            t.register("lineitem", 60);
-            t.register("orders", 15);
-            t.increment("lineitem", 1);
-            t.increment("orders", 5);
+            let t = Arc::new(IndicatifProgress::hidden());
+            let lineitem = Arc::clone(&t).register("lineitem", 60);
+            let orders = Arc::clone(&t).register("orders", 15);
+            lineitem.increment(1);
+            orders.increment(5);
 
             let items = t.items.read().unwrap();
             assert_eq!(items["lineitem"].position(), 1);
@@ -321,8 +320,8 @@ mod indicatif_impl {
 
         #[test]
         fn zero_total_items_start_at_zero() {
-            let t = IndicatifProgress::hidden();
-            t.register("store_returns", 0);
+            let t = Arc::new(IndicatifProgress::hidden());
+            Arc::clone(&t).register("store_returns", 0);
 
             let items = t.items.read().unwrap();
             assert_eq!(items["store_returns"].position(), 0);
@@ -332,10 +331,10 @@ mod indicatif_impl {
 
         #[test]
         fn reaches_total() {
-            let t = IndicatifProgress::hidden();
-            t.register("orders", 5);
+            let t = Arc::new(IndicatifProgress::hidden());
+            let orders = Arc::clone(&t).register("orders", 5);
             for _ in 0..5 {
-                t.increment("orders", 1);
+                orders.increment(1);
             }
             let items = t.items.read().unwrap();
             assert_eq!(items["orders"].position(), 5);
@@ -343,19 +342,10 @@ mod indicatif_impl {
         }
 
         #[test]
-        fn unknown_item_is_no_op() {
-            // Incrementing an item not registered must not panic.
-            let t = IndicatifProgress::hidden();
-            t.register("orders", 1);
-            t.increment("lineitem", 1);
-            assert_eq!(t.items.read().unwrap()["orders"].position(), 0);
-        }
-
-        #[test]
         fn finish_marks_registered_items_finished() {
-            let t = IndicatifProgress::hidden();
-            t.register("orders", 2);
-            t.increment("orders", 2);
+            let t = Arc::new(IndicatifProgress::hidden());
+            let orders = Arc::clone(&t).register("orders", 2);
+            orders.increment(2);
             t.finish();
 
             assert!(t.items.read().unwrap()["orders"].is_finished());
@@ -382,17 +372,15 @@ mod tests {
     }
 
     impl ProgressTracker for MockTracker {
-        fn register(&self, item: &str, total_units: u64) {
+        fn register(self: Arc<Self>, item: &str, total_units: u64) -> ProgressHandle {
+            let item = item.to_owned();
             self.registered
                 .lock()
                 .unwrap()
-                .push((item.to_owned(), total_units));
-        }
-        fn increment(&self, item: &str, units: u64) {
-            self.increments
-                .lock()
-                .unwrap()
-                .push((item.to_owned(), units));
+                .push((item.clone(), total_units));
+            ProgressHandle::new(move |units| {
+                self.increments.lock().unwrap().push((item.clone(), units));
+            })
         }
         fn finish(&self) {
             self.finished.fetch_add(1, Ordering::Relaxed);
@@ -403,10 +391,8 @@ mod tests {
     fn mock_tracker_works_through_progress_handles() {
         let mock = Arc::new(MockTracker::default());
         let dynamic: Arc<dyn ProgressTracker> = mock.clone();
-        dynamic.register("store_sales", 10);
-        dynamic.register("catalog_returns", 4);
-        let store_sales = ProgressHandle::new(Arc::clone(&dynamic), "store_sales");
-        let catalog_returns = ProgressHandle::new(Arc::clone(&dynamic), "catalog_returns");
+        let store_sales = Arc::clone(&dynamic).register("store_sales", 10);
+        let catalog_returns = Arc::clone(&dynamic).register("catalog_returns", 4);
         store_sales.increment(3);
         catalog_returns.increment(1);
         dynamic.finish();
@@ -429,18 +415,20 @@ mod tests {
     }
 
     #[test]
-    fn default_register_and_finish_are_noops() {
-        // An impl that only overrides `increment` should compile and run.
+    fn default_start_and_finish_are_noops() {
         #[derive(Debug)]
         struct Minimal(AtomicU64);
         impl ProgressTracker for Minimal {
-            fn increment(&self, _item: &str, units: u64) {
-                self.0.fetch_add(units, Ordering::Relaxed);
+            fn register(self: Arc<Self>, _item: &str, _total_units: u64) -> ProgressHandle {
+                ProgressHandle::new(move |units| {
+                    self.0.fetch_add(units, Ordering::Relaxed);
+                })
             }
         }
-        let m = Minimal(AtomicU64::new(0));
-        m.register("region", 99); // no-op default
-        m.increment("region", 7);
+        let m = Arc::new(Minimal(AtomicU64::new(0)));
+        let region = Arc::clone(&m).register("region", 99);
+        m.start(); // no-op default
+        region.increment(7);
         m.finish(); // no-op default
         assert_eq!(m.0.load(Ordering::Relaxed), 7);
     }

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -298,10 +298,12 @@ mod indicatif_impl {
         #[test]
         fn registers_and_increments() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let progress = t.clone().register("lineitem", 60);
-            progress.increment(1);
-            let progress = t.clone().register("orders", 15);
-            progress.increment(5);
+            let progress = [
+                t.clone().register("lineitem", 60),
+                t.clone().register("orders", 15),
+            ];
+            progress[0].increment(1);
+            progress[1].increment(5);
 
             let bars = t.bars.lock().unwrap();
             assert_eq!(bars[0].position(), 1);
@@ -381,10 +383,12 @@ mod tests {
     fn mock_tracker_works_through_progress_handles() {
         let mock = Arc::new(MockTracker::default());
         let dynamic: Arc<dyn ProgressTracker> = mock.clone();
-        let progress = dynamic.clone().register("store_sales", 10);
-        progress.increment(3);
-        let progress = dynamic.clone().register("catalog_returns", 4);
-        progress.increment(1);
+        let progress = [
+            dynamic.clone().register("store_sales", 10),
+            dynamic.clone().register("catalog_returns", 4),
+        ];
+        progress[0].increment(3);
+        progress[1].increment(1);
         dynamic.finish();
 
         assert_eq!(

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -298,10 +298,10 @@ mod indicatif_impl {
         #[test]
         fn registers_and_increments() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let lineitem = t.clone().register("lineitem", 60);
-            let orders = t.clone().register("orders", 15);
-            lineitem.increment(1);
-            orders.increment(5);
+            let progress = t.clone().register("lineitem", 60);
+            progress.increment(1);
+            let progress = t.clone().register("orders", 15);
+            progress.increment(5);
 
             let bars = t.bars.lock().unwrap();
             assert_eq!(bars[0].position(), 1);
@@ -322,9 +322,9 @@ mod indicatif_impl {
         #[test]
         fn reaches_total() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let orders = t.clone().register("orders", 5);
+            let progress = t.clone().register("orders", 5);
             for _ in 0..5 {
-                orders.increment(1);
+                progress.increment(1);
             }
             let bars = t.bars.lock().unwrap();
             assert_eq!(bars[0].position(), 5);
@@ -334,8 +334,8 @@ mod indicatif_impl {
         #[test]
         fn finish_marks_registered_items_finished() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let orders = t.clone().register("orders", 2);
-            orders.increment(2);
+            let progress = t.clone().register("orders", 2);
+            progress.increment(2);
             t.finish();
 
             assert!(t.bars.lock().unwrap()[0].is_finished());
@@ -381,10 +381,10 @@ mod tests {
     fn mock_tracker_works_through_progress_handles() {
         let mock = Arc::new(MockTracker::default());
         let dynamic: Arc<dyn ProgressTracker> = mock.clone();
-        let store_sales = dynamic.clone().register("store_sales", 10);
-        let catalog_returns = dynamic.clone().register("catalog_returns", 4);
-        store_sales.increment(3);
-        catalog_returns.increment(1);
+        let progress = dynamic.clone().register("store_sales", 10);
+        progress.increment(3);
+        let progress = dynamic.clone().register("catalog_returns", 4);
+        progress.increment(1);
         dynamic.finish();
 
         assert_eq!(
@@ -416,9 +416,9 @@ mod tests {
             }
         }
         let m = Arc::new(Minimal(AtomicU64::new(0)));
-        let region = m.clone().register("region", 99);
+        let progress = m.clone().register("region", 99);
         m.start(); // no-op default
-        region.increment(7);
+        progress.increment(7);
         m.finish(); // no-op default
         assert_eq!(m.0.load(Ordering::Relaxed), 7);
     }

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -298,8 +298,8 @@ mod indicatif_impl {
         #[test]
         fn registers_and_increments() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let lineitem = Arc::clone(&t).register("lineitem", 60);
-            let orders = Arc::clone(&t).register("orders", 15);
+            let lineitem = t.clone().register("lineitem", 60);
+            let orders = t.clone().register("orders", 15);
             lineitem.increment(1);
             orders.increment(5);
 
@@ -311,7 +311,7 @@ mod indicatif_impl {
         #[test]
         fn zero_total_items_start_at_zero() {
             let t = Arc::new(IndicatifProgress::hidden());
-            Arc::clone(&t).register("store_returns", 0);
+            t.clone().register("store_returns", 0);
 
             let bars = t.bars.lock().unwrap();
             assert_eq!(bars[0].position(), 0);
@@ -322,7 +322,7 @@ mod indicatif_impl {
         #[test]
         fn reaches_total() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let orders = Arc::clone(&t).register("orders", 5);
+            let orders = t.clone().register("orders", 5);
             for _ in 0..5 {
                 orders.increment(1);
             }
@@ -334,7 +334,7 @@ mod indicatif_impl {
         #[test]
         fn finish_marks_registered_items_finished() {
             let t = Arc::new(IndicatifProgress::hidden());
-            let orders = Arc::clone(&t).register("orders", 2);
+            let orders = t.clone().register("orders", 2);
             orders.increment(2);
             t.finish();
 
@@ -381,8 +381,8 @@ mod tests {
     fn mock_tracker_works_through_progress_handles() {
         let mock = Arc::new(MockTracker::default());
         let dynamic: Arc<dyn ProgressTracker> = mock.clone();
-        let store_sales = Arc::clone(&dynamic).register("store_sales", 10);
-        let catalog_returns = Arc::clone(&dynamic).register("catalog_returns", 4);
+        let store_sales = dynamic.clone().register("store_sales", 10);
+        let catalog_returns = dynamic.clone().register("catalog_returns", 4);
         store_sales.increment(3);
         catalog_returns.increment(1);
         dynamic.finish();
@@ -416,7 +416,7 @@ mod tests {
             }
         }
         let m = Arc::new(Minimal(AtomicU64::new(0)));
-        let region = Arc::clone(&m).register("region", 99);
+        let region = m.clone().register("region", 99);
         m.start(); // no-op default
         region.increment(7);
         m.finish(); // no-op default

--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -159,9 +159,8 @@ mod indicatif_impl {
     use super::{ProgressHandle, ProgressTracker};
     use indicatif::ProgressDrawTarget;
     use indicatif::{MultiProgress, ProgressBar, ProgressFinish, ProgressStyle};
-    use std::collections::BTreeMap;
     use std::io::{self, Write};
-    use std::sync::{Arc, OnceLock, RwLock};
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
     const LABEL_WIDTH: usize = 22;
     const BAR_WIDTH: usize = 18;
@@ -179,7 +178,7 @@ mod indicatif_impl {
     #[derive(Debug)]
     pub struct IndicatifProgress {
         multi: MultiProgress,
-        items: RwLock<BTreeMap<String, ProgressBar>>,
+        bars: Mutex<Vec<ProgressBar>>,
     }
 
     impl IndicatifProgress {
@@ -190,7 +189,7 @@ mod indicatif_impl {
                 multi: MultiProgress::with_draw_target(ProgressDrawTarget::stderr_with_hz(
                     PROGRESS_REFRESH_HZ,
                 )),
-                items: RwLock::new(BTreeMap::new()),
+                bars: Mutex::new(Vec::new()),
             }
         }
 
@@ -202,11 +201,17 @@ mod indicatif_impl {
             })
         }
 
+        fn lock_bars(&self) -> MutexGuard<'_, Vec<ProgressBar>> {
+            self.bars
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        }
+
         #[cfg(test)]
         fn hidden() -> Self {
             Self {
                 multi: MultiProgress::with_draw_target(ProgressDrawTarget::hidden()),
-                items: RwLock::new(BTreeMap::new()),
+                bars: Mutex::new(Vec::new()),
             }
         }
     }
@@ -219,30 +224,20 @@ mod indicatif_impl {
 
     impl ProgressTracker for IndicatifProgress {
         fn register(self: Arc<Self>, item: &str, total_units: u64) -> ProgressHandle {
-            let Ok(mut items) = self.items.write() else {
-                return ProgressHandle::no_op();
-            };
-
             // Indicatif treats zero-length items as complete.
             let bar_len = total_units.max(1);
-            let item_key = item.to_owned();
             let pb = self.multi.add(
                 ProgressBar::new(bar_len)
                     .with_style(bar_style())
-                    .with_message(item_key.clone())
+                    .with_message(item.to_owned())
                     .with_finish(ProgressFinish::AndLeave),
             );
-            items.insert(item_key, pb.clone());
+            self.lock_bars().push(pb.clone());
             ProgressHandle::new(move |units| pb.inc(units))
         }
 
         fn start(&self) {
-            let bars = {
-                let Ok(items) = self.items.read() else {
-                    return;
-                };
-                items.values().cloned().collect::<Vec<_>>()
-            };
+            let bars = self.lock_bars().clone();
 
             // Draw each registered item at 0% before work starts.
             for bar in bars {
@@ -253,12 +248,7 @@ mod indicatif_impl {
         }
 
         fn finish(&self) {
-            let bars = {
-                let Ok(items) = self.items.read() else {
-                    return;
-                };
-                items.values().cloned().collect::<Vec<_>>()
-            };
+            let bars = self.lock_bars().clone();
 
             for bar in bars {
                 bar.finish_using_style();
@@ -313,9 +303,9 @@ mod indicatif_impl {
             lineitem.increment(1);
             orders.increment(5);
 
-            let items = t.items.read().unwrap();
-            assert_eq!(items["lineitem"].position(), 1);
-            assert_eq!(items["orders"].position(), 5);
+            let bars = t.bars.lock().unwrap();
+            assert_eq!(bars[0].position(), 1);
+            assert_eq!(bars[1].position(), 5);
         }
 
         #[test]
@@ -323,10 +313,10 @@ mod indicatif_impl {
             let t = Arc::new(IndicatifProgress::hidden());
             Arc::clone(&t).register("store_returns", 0);
 
-            let items = t.items.read().unwrap();
-            assert_eq!(items["store_returns"].position(), 0);
-            assert_eq!(items["store_returns"].length(), Some(1));
-            assert!(!items["store_returns"].is_finished());
+            let bars = t.bars.lock().unwrap();
+            assert_eq!(bars[0].position(), 0);
+            assert_eq!(bars[0].length(), Some(1));
+            assert!(!bars[0].is_finished());
         }
 
         #[test]
@@ -336,9 +326,9 @@ mod indicatif_impl {
             for _ in 0..5 {
                 orders.increment(1);
             }
-            let items = t.items.read().unwrap();
-            assert_eq!(items["orders"].position(), 5);
-            assert!(!items["orders"].is_finished());
+            let bars = t.bars.lock().unwrap();
+            assert_eq!(bars[0].position(), 5);
+            assert!(!bars[0].is_finished());
         }
 
         #[test]
@@ -348,7 +338,7 @@ mod indicatif_impl {
             orders.increment(2);
             t.finish();
 
-            assert!(t.items.read().unwrap()["orders"].is_finished());
+            assert!(t.bars.lock().unwrap()[0].is_finished());
         }
     }
 }

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -249,12 +249,13 @@ impl CommonArgs {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    let handles = output.register_table(table, &session, Arc::clone(&progress));
-                    table_sessions.push((table, session, handles));
+                    let dat_progress =
+                        output.register_table(table, &session, Arc::clone(&progress));
+                    table_sessions.push((table, session, dat_progress));
                 }
                 progress.start();
-                for (table, session, handles) in table_sessions {
-                    output.generate_table(table, &session, handles)?;
+                for (table, session, dat_progress) in table_sessions {
+                    output.generate_table(table, &session, dat_progress)?;
                 }
             }
             OutputFormat::Csv(output) => {

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -249,25 +249,24 @@ impl CommonArgs {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    let dat_progress =
-                        output.register_table(table, &session, Arc::clone(&progress));
-                    table_sessions.push((table, session, dat_progress));
+                    let progress = output.register_table(table, &session, Arc::clone(&progress));
+                    table_sessions.push((table, session, progress));
                 }
                 progress.start();
-                for (table, session, dat_progress) in table_sessions {
-                    output.generate_table(table, &session, dat_progress)?;
+                for (table, session, progress) in table_sessions {
+                    output.generate_table(table, &session, progress)?;
                 }
             }
             OutputFormat::Csv(output) => {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    let handle = output.register_table(table, &session, Arc::clone(&progress));
-                    table_sessions.push((table, session, handle));
+                    let progress = output.register_table(table, &session, Arc::clone(&progress));
+                    table_sessions.push((table, session, progress));
                 }
                 progress.start();
-                for (table, session, handle) in table_sessions {
-                    output.generate_table(table, session, handle)?;
+                for (table, session, progress) in table_sessions {
+                    output.generate_table(table, session, progress)?;
                 }
             }
         }

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -2,7 +2,7 @@
 use crate::logging::configure_logging;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
-use crate::progress::{no_op_progress_tracker, ProgressHandle, ProgressTracker};
+use crate::progress::{no_op_progress_tracker, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::{ArgAction, Args, Subcommand};
 use std::io;
@@ -249,24 +249,23 @@ impl CommonArgs {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    output.register_table(table, &session, progress.as_ref());
-                    table_sessions.push((table, session));
+                    let handles = output.register_table(table, &session, Arc::clone(&progress));
+                    table_sessions.push((table, session, handles));
                 }
                 progress.start();
-                for (table, session) in table_sessions {
-                    output.generate_table(table, &session, progress.as_ref())?;
+                for (table, session, handles) in table_sessions {
+                    output.generate_table(table, &session, handles)?;
                 }
             }
             OutputFormat::Csv(output) => {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    output.register_table(table, &session, progress.as_ref());
-                    table_sessions.push((table, session));
+                    let handle = output.register_table(table, &session, Arc::clone(&progress));
+                    table_sessions.push((table, session, handle));
                 }
                 progress.start();
-                for (table, session) in table_sessions {
-                    let handle = ProgressHandle::new(Arc::clone(&progress), table.get_name());
+                for (table, session, handle) in table_sessions {
                     output.generate_table(table, session, handle)?;
                 }
             }

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -242,14 +242,14 @@ impl CommonArgs {
                     table_sessions.push((table, session));
                 }
                 output
-                    .generate_tables(table_sessions, Arc::clone(&progress))
+                    .generate_tables(table_sessions, progress.clone())
                     .await?;
             }
             OutputFormat::Dat(output) => {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    let progress = output.register_table(table, &session, Arc::clone(&progress));
+                    let progress = output.register_table(table, &session, progress.clone());
                     table_sessions.push((table, session, progress));
                 }
                 progress.start();
@@ -261,7 +261,7 @@ impl CommonArgs {
                 let mut table_sessions = Vec::with_capacity(tables.len());
                 for table in tables {
                     let session = self.to_session(Some(table.get_name().to_string()))?;
-                    let progress = output.register_table(table, &session, Arc::clone(&progress));
+                    let progress = output.register_table(table, &session, progress.clone());
                     table_sessions.push((table, session, progress));
                 }
                 progress.start();

--- a/tpcgen-cli/src/tpcds_cli/csv.rs
+++ b/tpcgen-cli/src/tpcds_cli/csv.rs
@@ -7,6 +7,7 @@ use arrow_csv::writer::WriterBuilder;
 use std::fs::File;
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tpcdsgen::config::{Session, Table};
 use tpcdsgen_arrow::{
     CallCenterArrow, CatalogPageArrow, CatalogReturnsArrow, CatalogSalesArrow,
@@ -37,14 +38,14 @@ impl Csv {
         &self,
         table: Table,
         session: &Session,
-        progress: &dyn ProgressTracker,
-    ) {
+        progress: Arc<dyn ProgressTracker>,
+    ) -> ProgressHandle {
         let rows: u64 = session
             .get_scaling()
             .get_row_count(table)
             .try_into()
             .unwrap_or(0);
-        progress.register(table.get_name(), rows);
+        progress.register(table.get_name(), rows)
     }
 
     /// Generate one TPC-DS table as a CSV file.

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -49,22 +49,6 @@ pub(super) enum DatProgress {
     },
 }
 
-impl DatProgress {
-    fn into_single(self) -> ProgressHandle {
-        let Self::Single(progress) = self else {
-            unreachable!("simple DAT table must have one progress handle")
-        };
-        progress
-    }
-
-    fn into_pair(self) -> (ProgressHandle, ProgressHandle) {
-        let Self::Paired { sales, returns } = self else {
-            unreachable!("sales DAT table must have sales and returns progress handles")
-        };
-        (sales, returns)
-    }
-}
-
 impl Dat {
     pub(super) fn new(output_dir: PathBuf) -> Result<Self> {
         if output_dir.as_os_str().is_empty() {
@@ -260,7 +244,9 @@ fn generate_simple<G: RowGeneratorFactory>(
     output_dir: &Path,
     progress: DatProgress,
 ) -> Result<()> {
-    let progress = progress.into_single();
+    let DatProgress::Single(progress) = progress else {
+        unreachable!("simple DAT table must have one progress handle")
+    };
     let mut generator = G::create();
     let row_count = session.get_scaling().get_row_count(table);
 
@@ -340,7 +326,13 @@ fn generate_sales_and_returns<G: RowGeneratorFactory>(
     output_dir: &Path,
     progress: DatProgress,
 ) -> Result<()> {
-    let (sales_progress, returns_progress) = progress.into_pair();
+    let DatProgress::Paired {
+        sales: sales_progress,
+        returns: returns_progress,
+    } = progress
+    else {
+        unreachable!("sales DAT table must have sales and returns progress handles")
+    };
     let mut generator = G::create();
     let source_row_count = session.get_scaling().get_row_count(sales_table);
 

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -70,7 +70,9 @@ impl Dat {
     ) -> DatProgress {
         let register = |table: Table| {
             let row_count = session.get_scaling().get_row_count(table);
-            Arc::clone(&progress).register(table.get_name(), row_count.try_into().unwrap_or(0))
+            progress
+                .clone()
+                .register(table.get_name(), row_count.try_into().unwrap_or(0))
         };
 
         match table {

--- a/tpcgen-cli/src/tpcds_cli/dat.rs
+++ b/tpcgen-cli/src/tpcds_cli/dat.rs
@@ -16,9 +16,10 @@
 //!
 //! Generates TPC-DS benchmark data with byte-for-byte compatibility with the Java reference.
 
-use crate::progress::ProgressTracker;
+use crate::progress::{ProgressHandle, ProgressTracker};
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use log::info;
 use tpcdsgen::config::{Session, Table};
@@ -38,6 +39,32 @@ pub(super) struct Dat {
     output_dir: PathBuf,
 }
 
+#[derive(Debug)]
+pub(super) enum DatProgress {
+    None,
+    Single(ProgressHandle),
+    Paired {
+        sales: ProgressHandle,
+        returns: ProgressHandle,
+    },
+}
+
+impl DatProgress {
+    fn into_single(self) -> ProgressHandle {
+        let Self::Single(progress) = self else {
+            unreachable!("simple DAT table must have one progress handle")
+        };
+        progress
+    }
+
+    fn into_pair(self) -> (ProgressHandle, ProgressHandle) {
+        let Self::Paired { sales, returns } = self else {
+            unreachable!("sales DAT table must have sales and returns progress handles")
+        };
+        (sales, returns)
+    }
+}
+
 impl Dat {
     pub(super) fn new(output_dir: PathBuf) -> Result<Self> {
         if output_dir.as_os_str().is_empty() {
@@ -55,28 +82,28 @@ impl Dat {
         &self,
         table: Table,
         session: &Session,
-        progress: &dyn ProgressTracker,
-    ) {
+        progress: Arc<dyn ProgressTracker>,
+    ) -> DatProgress {
         let register = |table: Table| {
             let row_count = session.get_scaling().get_row_count(table);
-            progress.register(table.get_name(), row_count.try_into().unwrap_or(0));
+            Arc::clone(&progress).register(table.get_name(), row_count.try_into().unwrap_or(0))
         };
 
         match table {
-            Table::StoreSales => {
-                register(Table::StoreSales);
-                register(Table::StoreReturns);
-            }
-            Table::CatalogSales => {
-                register(Table::CatalogSales);
-                register(Table::CatalogReturns);
-            }
-            Table::WebSales => {
-                register(Table::WebSales);
-                register(Table::WebReturns);
-            }
-            Table::StoreReturns | Table::CatalogReturns | Table::WebReturns => {}
-            _ => register(table),
+            Table::StoreSales => DatProgress::Paired {
+                sales: register(Table::StoreSales),
+                returns: register(Table::StoreReturns),
+            },
+            Table::CatalogSales => DatProgress::Paired {
+                sales: register(Table::CatalogSales),
+                returns: register(Table::CatalogReturns),
+            },
+            Table::WebSales => DatProgress::Paired {
+                sales: register(Table::WebSales),
+                returns: register(Table::WebReturns),
+            },
+            Table::StoreReturns | Table::CatalogReturns | Table::WebReturns => DatProgress::None,
+            _ => DatProgress::Single(register(table)),
         }
     }
 
@@ -84,7 +111,7 @@ impl Dat {
         &self,
         table: Table,
         session: &Session,
-        progress: &dyn ProgressTracker,
+        progress: DatProgress,
     ) -> Result<()> {
         match table {
             // Simple dimension tables
@@ -231,11 +258,11 @@ fn generate_simple<G: RowGeneratorFactory>(
     table: Table,
     session: &Session,
     output_dir: &Path,
-    progress: &dyn ProgressTracker,
+    progress: DatProgress,
 ) -> Result<()> {
+    let progress = progress.into_single();
     let mut generator = G::create();
     let row_count = session.get_scaling().get_row_count(table);
-    let table_name = table.get_name();
 
     let path = get_output_path(table, output_dir);
     let file = File::create(&path)?;
@@ -251,7 +278,7 @@ fn generate_simple<G: RowGeneratorFactory>(
         }
 
         generator.consume_remaining_seeds_for_row();
-        progress.increment(table_name, 1);
+        progress.increment(1);
     }
 
     writer.flush()?;
@@ -266,11 +293,7 @@ fn generate_simple<G: RowGeneratorFactory>(
 }
 
 /// Generate store_sales and store_returns together
-fn generate_store_sales(
-    session: &Session,
-    output_dir: &Path,
-    progress: &dyn ProgressTracker,
-) -> Result<()> {
+fn generate_store_sales(session: &Session, output_dir: &Path, progress: DatProgress) -> Result<()> {
     generate_sales_and_returns::<StoreSalesRowGenerator>(
         Table::StoreSales,
         Table::StoreReturns,
@@ -284,7 +307,7 @@ fn generate_store_sales(
 fn generate_catalog_sales(
     session: &Session,
     output_dir: &Path,
-    progress: &dyn ProgressTracker,
+    progress: DatProgress,
 ) -> Result<()> {
     generate_sales_and_returns::<CatalogSalesRowGenerator>(
         Table::CatalogSales,
@@ -296,11 +319,7 @@ fn generate_catalog_sales(
 }
 
 /// Generate web_sales and web_returns together
-fn generate_web_sales(
-    session: &Session,
-    output_dir: &Path,
-    progress: &dyn ProgressTracker,
-) -> Result<()> {
+fn generate_web_sales(session: &Session, output_dir: &Path, progress: DatProgress) -> Result<()> {
     generate_sales_and_returns::<WebSalesRowGenerator>(
         Table::WebSales,
         Table::WebReturns,
@@ -319,12 +338,11 @@ fn generate_sales_and_returns<G: RowGeneratorFactory>(
     returns_table: Table,
     session: &Session,
     output_dir: &Path,
-    progress: &dyn ProgressTracker,
+    progress: DatProgress,
 ) -> Result<()> {
+    let (sales_progress, returns_progress) = progress.into_pair();
     let mut generator = G::create();
     let source_row_count = session.get_scaling().get_row_count(sales_table);
-    let sales_name = sales_table.get_name();
-    let returns_name = returns_table.get_name();
 
     let sales_path = get_output_path(sales_table, output_dir);
     let returns_path = get_output_path(returns_table, output_dir);
@@ -355,13 +373,13 @@ fn generate_sales_and_returns<G: RowGeneratorFactory>(
         if rows.len() > 1 {
             returns_writer.write_display_row(&rows[1])?;
             returns_count += 1;
-            progress.increment(returns_name, 1);
+            returns_progress.increment(1);
         }
 
         if result.should_end_row() {
             generator.consume_remaining_seeds_for_row();
             row_number += 1;
-            progress.increment(sales_name, 1);
+            sales_progress.increment(1);
         }
     }
 

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -67,9 +67,9 @@ impl Parquet {
             .map(|(table, session)| {
                 let plan =
                     TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
-                let handle =
+                let progress =
                     Arc::clone(&progress).register(table.get_name(), plan.row_group_count() as u64);
-                (table, session, plan, handle)
+                (table, session, plan, progress)
             })
             .collect();
         progress.start();
@@ -79,11 +79,11 @@ impl Parquet {
         work.sort_by_key(|(_, _, plan, _)| plan.row_group_count());
 
         let mut queue = WorkerQueue::new(self.num_threads);
-        while let Some((table, session, plan, progress_handle)) = work.pop() {
+        while let Some((table, session, plan, progress)) = work.pop() {
             let this = self.clone();
             queue
                 .schedule(plan.row_group_count(), move |num_threads| async move {
-                    this.generate_table(table, session, plan, num_threads, progress_handle)
+                    this.generate_table(table, session, plan, num_threads, progress)
                         .await?;
                     Ok(num_threads)
                 })

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -63,24 +63,24 @@ impl Parquet {
 
         // Plan each table and pre-register the row group totals so trackers
         // can size their bars before the first increment
-        let mut work: Vec<(Table, Session, TpcdsGenerationPlan)> = tables
+        let mut work: Vec<(Table, Session, TpcdsGenerationPlan, ProgressHandle)> = tables
             .map(|(table, session)| {
                 let plan =
                     TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
-                progress.register(table.get_name(), plan.row_group_count() as u64);
-                (table, session, plan)
+                let handle =
+                    Arc::clone(&progress).register(table.get_name(), plan.row_group_count() as u64);
+                (table, session, plan, handle)
             })
             .collect();
         progress.start();
 
         // Schedule the largest tables (most row groups) first for the best
         // thread utilization (the list is popped from the back)
-        work.sort_by_key(|(_, _, plan)| plan.row_group_count());
+        work.sort_by_key(|(_, _, plan, _)| plan.row_group_count());
 
         let mut queue = WorkerQueue::new(self.num_threads);
-        while let Some((table, session, plan)) = work.pop() {
+        while let Some((table, session, plan, progress)) = work.pop() {
             let this = self.clone();
-            let progress = ProgressHandle::new(Arc::clone(&progress), table.get_name());
             queue
                 .schedule(plan.row_group_count(), move |num_threads| async move {
                     this.generate_table(table, session, plan, num_threads, progress)

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -79,11 +79,11 @@ impl Parquet {
         work.sort_by_key(|(_, _, plan, _)| plan.row_group_count());
 
         let mut queue = WorkerQueue::new(self.num_threads);
-        while let Some((table, session, plan, progress)) = work.pop() {
+        while let Some((table, session, plan, progress_handle)) = work.pop() {
             let this = self.clone();
             queue
                 .schedule(plan.row_group_count(), move |num_threads| async move {
-                    this.generate_table(table, session, plan, num_threads, progress)
+                    this.generate_table(table, session, plan, num_threads, progress_handle)
                         .await?;
                     Ok(num_threads)
                 })

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -67,8 +67,9 @@ impl Parquet {
             .map(|(table, session)| {
                 let plan =
                     TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);
-                let progress =
-                    Arc::clone(&progress).register(table.get_name(), plan.row_group_count() as u64);
+                let progress = progress
+                    .clone()
+                    .register(table.get_name(), plan.row_group_count() as u64);
                 (table, session, plan, progress)
             })
             .collect();

--- a/tpcgen-cli/src/tpch_cli/generate.rs
+++ b/tpcgen-cli/src/tpch_cli/generate.rs
@@ -186,8 +186,10 @@ mod tests {
     }
 
     impl ProgressTracker for CountingProgress {
-        fn increment(&self, _item: &str, units: u64) {
-            self.increments.fetch_add(units, Ordering::Relaxed);
+        fn register(self: Arc<Self>, _item: &str, _total_units: u64) -> ProgressHandle {
+            ProgressHandle::new(move |units| {
+                self.increments.fetch_add(units, Ordering::Relaxed);
+            })
         }
     }
 
@@ -228,7 +230,7 @@ mod tests {
         let writes = Arc::new(Mutex::new(Vec::new()));
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
-        let progress = ProgressHandle::new(progress, "ignored");
+        let progress = progress.register("ignored", 2);
 
         let sources = vec![
             TestSource {

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -406,7 +406,7 @@ impl Default for TpchGeneratorBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::progress::ProgressTracker;
+    use crate::progress::{ProgressHandle, ProgressTracker};
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -420,18 +420,15 @@ mod tests {
     }
 
     impl ProgressTracker for RecordingProgress {
-        fn register(&self, item: &str, total_units: u64) {
+        fn register(self: Arc<Self>, item: &str, total_units: u64) -> ProgressHandle {
+            let item = item.to_owned();
             self.registered
                 .lock()
                 .unwrap()
-                .push((item.to_owned(), total_units));
-        }
-
-        fn increment(&self, item: &str, units: u64) {
-            self.increments
-                .lock()
-                .unwrap()
-                .push((item.to_owned(), units));
+                .push((item.clone(), total_units));
+            ProgressHandle::new(move |units| {
+                self.increments.lock().unwrap().push((item.clone(), units));
+            })
         }
 
         fn finish(&self) {

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -97,10 +97,10 @@ impl PlanRunner {
         let mut worker_queue = WorkerQueue::new(num_threads);
         while let Some(plan) = plans.pop() {
             debug!("scheduling plan {plan}");
-            let progress = progress_handles[&plan.table()].clone();
+            let progress_handle = progress_handles[&plan.table()].clone();
             worker_queue
                 .schedule(plan.chunk_count(), move |num_plan_threads| {
-                    run_plan(plan, num_plan_threads, progress)
+                    run_plan(plan, num_plan_threads, progress_handle)
                 })
                 .await?;
         }

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -84,11 +84,11 @@ impl PlanRunner {
         for plan in &plans {
             *totals.entry(plan.table()).or_default() += plan.chunk_count() as u64;
         }
-        let progress_handles: BTreeMap<Table, ProgressHandle> = totals
+        let progress_by_table: BTreeMap<Table, ProgressHandle> = totals
             .into_iter()
             .map(|(table, total)| {
-                let handle = Arc::clone(&progress).register(table.name(), total);
-                (table, handle)
+                let progress = Arc::clone(&progress).register(table.name(), total);
+                (table, progress)
             })
             .collect();
         progress.start();
@@ -97,10 +97,10 @@ impl PlanRunner {
         let mut worker_queue = WorkerQueue::new(num_threads);
         while let Some(plan) = plans.pop() {
             debug!("scheduling plan {plan}");
-            let progress_handle = progress_handles[&plan.table()].clone();
+            let progress = progress_by_table[&plan.table()].clone();
             worker_queue
                 .schedule(plan.chunk_count(), move |num_plan_threads| {
-                    run_plan(plan, num_plan_threads, progress_handle)
+                    run_plan(plan, num_plan_threads, progress)
                 })
                 .await?;
         }

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -49,7 +49,7 @@ impl PlanRunner {
     /// Attach a [`ProgressTracker`].
     ///
     /// The runner pre-registers each table's output-unit total with the
-    /// tracker before scheduling, calls [`ProgressTracker::increment`]
+    /// tracker before scheduling, calls [`ProgressHandle::increment`]
     /// after output units are written, and calls [`ProgressTracker::finish`]
     /// once on the success path. Implementations needing cleanup on the
     /// error or panic path should use `Drop` as a fallback.
@@ -84,16 +84,20 @@ impl PlanRunner {
         for plan in &plans {
             *totals.entry(plan.table()).or_default() += plan.chunk_count() as u64;
         }
-        for (table, total) in totals {
-            progress.register(table.name(), total);
-        }
+        let progress_handles: BTreeMap<Table, ProgressHandle> = totals
+            .into_iter()
+            .map(|(table, total)| {
+                let handle = Arc::clone(&progress).register(table.name(), total);
+                (table, handle)
+            })
+            .collect();
         progress.start();
 
         // Do the actual work in parallel, using a worker queue
         let mut worker_queue = WorkerQueue::new(num_threads);
         while let Some(plan) = plans.pop() {
             debug!("scheduling plan {plan}");
-            let progress = Arc::clone(&progress);
+            let progress = progress_handles[&plan.table()].clone();
             worker_queue
                 .schedule(plan.chunk_count(), move |num_plan_threads| {
                     run_plan(plan, num_plan_threads, progress)
@@ -110,9 +114,8 @@ impl PlanRunner {
 async fn run_plan(
     plan: OutputPlan,
     num_threads: usize,
-    progress: Arc<dyn ProgressTracker>,
+    progress: ProgressHandle,
 ) -> io::Result<usize> {
-    let progress = ProgressHandle::new(progress, plan.table().name());
     match plan.table() {
         Table::Nation => run_nation_plan(plan, num_threads, progress).await,
         Table::Region => run_region_plan(plan, num_threads, progress).await,
@@ -393,8 +396,10 @@ mod tests {
     }
 
     impl ProgressTracker for CountingProgress {
-        fn increment(&self, _item: &str, units: u64) {
-            self.increments.fetch_add(units, Ordering::Relaxed);
+        fn register(self: Arc<Self>, _item: &str, _total_units: u64) -> ProgressHandle {
+            ProgressHandle::new(move |units| {
+                self.increments.fetch_add(units, Ordering::Relaxed);
+            })
         }
     }
 
@@ -427,7 +432,7 @@ mod tests {
 
         let tracker = Arc::new(CountingProgress::default());
         let progress: Arc<dyn ProgressTracker> = tracker.clone();
-        let progress = ProgressHandle::new(progress, plan.table().name());
+        let progress = progress.register(plan.table().name(), expected_units);
 
         assert!(maybe_skip_existing(&output_path, &plan, &progress));
         assert_eq!(tracker.increments.load(Ordering::Relaxed), expected_units);

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -86,10 +86,7 @@ impl PlanRunner {
         }
         let progress_by_table: BTreeMap<Table, ProgressHandle> = totals
             .into_iter()
-            .map(|(table, total)| {
-                let progress = Arc::clone(&progress).register(table.name(), total);
-                (table, progress)
-            })
+            .map(|(table, total)| (table, Arc::clone(&progress).register(table.name(), total)))
             .collect();
         progress.start();
 

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -86,7 +86,7 @@ impl PlanRunner {
         }
         let progress_by_table: BTreeMap<Table, ProgressHandle> = totals
             .into_iter()
-            .map(|(table, total)| (table, Arc::clone(&progress).register(table.name(), total)))
+            .map(|(table, total)| (table, progress.clone().register(table.name(), total)))
             .collect();
         progress.start();
 


### PR DESCRIPTION
Part of #355

## Summary

- `ProgressTracker::register` now returns an item-bound `ProgressHandle`.
- `ProgressHandle::increment` handles item-level progress updates.
