### PR TITLE
feat: list TPC-DS tables and descriptions in `--tables` help

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -4,6 +4,7 @@ use crate::logging::configure_logging;
 use crate::progress::IndicatifProgress;
 use crate::progress::{no_op_progress_tracker, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+use clap::builder::TypedValueParser;
 use clap::{ArgAction, Args, Subcommand};
 use std::io;
 #[cfg(feature = "indicatif-progress")]
@@ -131,8 +132,8 @@ pub struct CommonArgs {
     output_dir: PathBuf,
 
     /// Which tables to generate (default: all)
-    #[arg(short = 'T', long = "tables", value_delimiter = ',')]
-    tables: Option<Vec<String>>,
+    #[arg(short = 'T', long = "tables", value_delimiter = ',', value_parser = TableValueParser)]
+    tables: Option<Vec<Table>>,
 
     /// Reference implementation to match (default: trino)
     #[arg(long, default_value_t = CompatMode::Trino)]
@@ -293,10 +294,9 @@ impl CommonArgs {
 
     /// Return the tables that should be generated.
     fn tables(&self) -> Result<Vec<Table>> {
-        if let Some(tables) = &self.tables {
-            tables.iter().map(|table| parse_table(table)).collect()
-        } else {
-            Ok(Table::main_tables())
+        match &self.tables {
+            Some(tables) => Ok(tables.clone()),
+            None => Ok(Table::main_tables()),
         }
     }
 
@@ -356,6 +356,73 @@ fn parse_table(table: &str) -> Result<Table> {
     }
 }
 
+/// Parses a TPC-DS table name, and supplies the list of table names (with
+/// descriptions) shown in `--help`.
+#[derive(Debug, Clone)]
+struct TableValueParser;
+
+impl TypedValueParser for TableValueParser {
+    type Value = Table;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        _: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> std::result::Result<Self::Value, clap::Error> {
+        let to_err = |msg: String| {
+            clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{msg}\n")).with_cmd(cmd)
+        };
+
+        let value = value
+            .to_str()
+            .ok_or_else(|| to_err("table names must be valid UTF-8".to_string()))?;
+
+        parse_table(value).map_err(|e| to_err(e.to_string()))
+    }
+
+    fn possible_values(
+        &self,
+    ) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
+        Some(Box::new(Table::main_tables().into_iter().map(|table| {
+            clap::builder::PossibleValue::new(table.get_name()).help(table_help(table))
+        })))
+    }
+}
+
+/// One line description of each TPC-DS table, shown in `--help`.
+fn table_help(table: Table) -> &'static str {
+    match table {
+        Table::CallCenter => "Call center dimension",
+        Table::CatalogPage => "Catalog page dimension",
+        Table::CatalogReturns => "Catalog returns fact",
+        Table::CatalogSales => "Catalog sales fact",
+        Table::Customer => "Customer dimension",
+        Table::CustomerAddress => "Customer address dimension",
+        Table::CustomerDemographics => "Customer demographics dimension",
+        Table::DateDim => "Date dimension",
+        Table::HouseholdDemographics => "Household demographics dimension",
+        Table::IncomeBand => "Income band dimension",
+        Table::Inventory => "Inventory fact",
+        Table::Item => "Item dimension",
+        Table::Promotion => "Promotion dimension",
+        Table::Reason => "Reason dimension",
+        Table::ShipMode => "Ship mode dimension",
+        Table::Store => "Store dimension",
+        Table::StoreReturns => "Store returns fact",
+        Table::StoreSales => "Store sales fact",
+        Table::TimeDim => "Time dimension",
+        Table::Warehouse => "Warehouse dimension",
+        Table::WebPage => "Web page dimension",
+        Table::WebReturns => "Web returns fact",
+        Table::WebSales => "Web sales fact",
+        Table::WebSite => "Web site dimension",
+        Table::DbgenVersion => "Metadata about the generator run",
+        // source tables are not selectable on the command line
+        _ => "",
+    }
+}
+
 fn expected_table_names() -> String {
     Table::main_tables()
         .iter()
@@ -396,5 +463,20 @@ fn parse_row_group_bytes(s: &str) -> std::result::Result<usize, String> {
         Err("must be greater than zero".to_string())
     } else {
         Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_main_table_has_help_text() {
+        for table in Table::main_tables() {
+            assert!(
+                !table_help(table).is_empty(),
+                "{table} is missing a --help description"
+            );
+        }
     }
 }

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -832,3 +832,21 @@ fn test_tpcgen_cli_tpcds_parquet_preserves_arrow_schema() {
         .expect("dv_create_time field");
     assert_eq!(field.data_type(), &DataType::Time32(TimeUnit::Second));
 }
+
+/// Test that `--help` lists each selectable TPC-DS table.
+#[test]
+fn test_tpcgen_cli_tpcds_help_lists_tables() {
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("--help")
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    for table in Table::main_tables() {
+        assert!(
+            stdout.contains(&format!("- {}:", table.get_name())),
+            "Expected `tpcds --help` to list {table}, got stdout: {stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Which issue does this PR close?

- part of https://github.com/clflushopt/tpchgen-rs/issues/218

## Rationale for this change

`tpcgen-cli tpch --help` lists the possible values for `--tables`:

```
  -T, --tables <TABLES>
          Which tables to generate (default: all)

          Possible values:
          - region:   Region table (alias: r)
          - nation:   Nation table (alias: n)
          ...
```

but the TPC-DS equivalent showed nothing, leaving users to guess the table names:

```
  -T, --tables <TABLES>
          Which tables to generate (default: all)
```

## What changes are included in this PR?

Add a `TableValueParser` for TPC-DS mirroring the TPC-H one, so `tpcgen-cli tpcds --help` lists every selectable table with a one line description:

```
  -T, --tables <TABLES>
          Which tables to generate (default: all)

          Possible values:
          - call_center:            Call center dimension
          - catalog_page:           Catalog page dimension
          - catalog_returns:        Catalog returns fact
          - catalog_sales:          Catalog sales fact
          ...
          - web_site:               Web site dimension
          - dbgen_version:          Metadata about the generator run
```

The parser also gives `--tables` a typed `Vec<Table>` rather than `Vec<String>`, removing a parse/re-parse round trip. TPC-DS table names have no single letter aliases (unlike TPC-H), so no alias text is shown.

## Are these changes tested?

Yes:

## Are there any user-facing changes?

Yes, improved `--help` output. No change to accepted values or error messages