### PR TITLE
chore: update Rust toolchain to 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.89.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/tpchgen/src/dates.rs
+++ b/tpchgen/src/dates.rs
@@ -92,7 +92,7 @@ pub struct TPCHDate {
 impl Display for TPCHDate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // uses a pre-computed table to avoid recalculating the date
-        write!(f, "{}", &DATE_TO_STRING[self.date_index as usize])
+        write!(f, "{}", DATE_TO_STRING[self.date_index as usize])
     }
 }
 


### PR DESCRIPTION
Bumps the pinned toolchain in `rust-toolchain.toml` from 1.89.0 to 1.97.1 (current stable).

Also fixes the single new clippy lint that surfaces on the newer toolchain: